### PR TITLE
security: API authentication hardening & OAuth httpOnly cookie migration (#1)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,8 +5,50 @@ const withBundleAnalyzer = withBundleAnalyzerPkg({
   enabled: process.env.ANALYZE === "true",
 });
 
+const isDev = process.env.NODE_ENV === 'development';
+
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' blob: data: https://*.googleusercontent.com https://perso.ai https://*.perso.ai https://i.ytimg.com",
+  "font-src 'self'",
+  "connect-src 'self' https://*.blob.core.windows.net",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self' https://accounts.google.com",
+  "frame-ancestors 'none'",
+  "upgrade-insecure-requests",
+].join('; ');
+
+const securityHeaders = [
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Content-Security-Policy', value: cspDirectives },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  compress: true,
+  poweredByHeader: false,
+  images: {
+    remotePatterns: [
+      new URL('https://*.googleusercontent.com/**'),
+      new URL('https://perso.ai/**'),
+      new URL('https://*.perso.ai/**'),
+    ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,34 +1,11 @@
-'use client'
-
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { Sidebar } from '@/components/layout/Sidebar'
 import { Topbar } from '@/components/layout/Topbar'
-import { useAuthStore } from '@/stores/authStore'
-import { LoadingSpinner } from '@/components/feedback/LoadingSpinner'
 
 export default function AppLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const { isAuthenticated, isLoading } = useAuthStore()
-  const router = useRouter()
-
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      router.replace('/')
-    }
-  }, [isAuthenticated, isLoading, router])
-
-  if (isLoading) {
-    return <LoadingSpinner size="lg" className="min-h-screen" label="로딩 중..." />
-  }
-
-  if (!isAuthenticated) {
-    return null
-  }
-
   return (
     <div className="min-h-screen">
       <Sidebar />

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingSpinner } from '@/components/feedback/LoadingSpinner'
+
+export default function AppLoading() {
+  return <LoadingSpinner size="lg" className="min-h-[60vh]" label="로딩 중..." />
+}

--- a/src/app/api/auth/auth-callback.test.ts
+++ b/src/app/api/auth/auth-callback.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/db/queries', () => ({
+  upsertUser: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/session-cookie', () => ({
+  SESSION_COOKIE: 'creatordub_session',
+  signSessionCookie: vi.fn((uid: string) => `${uid}.fakesig`),
+}))
+
+vi.mock('@/lib/env', () => ({
+  getServerEnv: vi.fn(() => ({
+    GOOGLE_CLIENT_SECRET: 'test-secret',
+    PERSO_API_KEY: 'k',
+    PERSO_API_BASE_URL: 'https://api.perso.ai',
+    TURSO_URL: 'http://localhost',
+    TURSO_AUTH_TOKEN: 'tok',
+  })),
+  getClientEnv: vi.fn(() => ({
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: 'test-client-id',
+    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://perso.ai',
+  })),
+}))
+
+import { POST } from './callback/route'
+import { upsertUser } from '@/lib/db/queries'
+import { getServerEnv } from '@/lib/env'
+import { NextRequest } from 'next/server'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeReq(body: unknown) {
+  return new NextRequest('http://localhost/api/auth/callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/auth/callback', () => {
+  it('returns 400 for missing code', async () => {
+    const res = await POST(makeReq({ redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for missing redirectUri', async () => {
+    const res = await POST(makeReq({ code: 'abc' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid body', async () => {
+    const res = await POST(makeReq(null))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 when GOOGLE_CLIENT_SECRET is not configured', async () => {
+    vi.mocked(getServerEnv).mockReturnValueOnce({
+      GOOGLE_CLIENT_SECRET: undefined,
+      PERSO_API_KEY: 'k',
+      PERSO_API_BASE_URL: 'https://api.perso.ai',
+      TURSO_URL: 'http://localhost',
+      TURSO_AUTH_TOKEN: 'tok',
+    })
+    const res = await POST(makeReq({ code: 'abc', redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('CONFIG_ERROR')
+  })
+
+  it('returns 401 when Google token exchange fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      text: async () => 'invalid_grant',
+    })
+    const res = await POST(makeReq({ code: 'bad-code', redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error.code).toBe('TOKEN_EXCHANGE_FAILED')
+  })
+
+  it('returns 401 when userinfo fetch fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'at-123',
+          refresh_token: 'rt-456',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+    const res = await POST(makeReq({ code: 'good-code', redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error.code).toBe('USERINFO_FAILED')
+  })
+
+  it('exchanges code and returns user + sets cookies on success', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'at-123',
+          refresh_token: 'rt-456',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: 'user-1',
+          email: 'test@example.com',
+          name: 'Test User',
+          picture: 'https://example.com/photo.jpg',
+        }),
+      })
+
+    const res = await POST(makeReq({ code: 'good-code', redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.id).toBe('user-1')
+    expect(body.data.email).toBe('test@example.com')
+
+    expect(upsertUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'user-1',
+        email: 'test@example.com',
+        accessToken: 'at-123',
+        refreshToken: 'rt-456',
+      }),
+    )
+
+    const setCookies = res.headers.getSetCookie()
+    expect(setCookies.find((c: string) => c.startsWith('creatordub_session='))).toBeDefined()
+    expect(setCookies.find((c: string) => c.startsWith('google_access_token='))).toBeDefined()
+  })
+
+  it('handles missing refresh_token gracefully', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'at-789',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: 'user-2',
+          email: 'no-refresh@example.com',
+        }),
+      })
+
+    const res = await POST(makeReq({ code: 'code-no-refresh', redirectUri: 'http://localhost' }))
+    expect(res.status).toBe(200)
+
+    expect(upsertUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'user-2',
+        refreshToken: null,
+      }),
+    )
+  })
+})

--- a/src/app/api/auth/auth-signout.test.ts
+++ b/src/app/api/auth/auth-signout.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { POST } from './signout/route'
+
+describe('POST /api/auth/signout', () => {
+  it('returns 200 with ok true', async () => {
+    const res = await POST()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: null })
+  })
+
+  it('clears creatordub_session cookie', async () => {
+    const res = await POST()
+    const setCookies = res.headers.getSetCookie()
+    const sessionCookie = setCookies.find((c: string) =>
+      c.startsWith('creatordub_session='),
+    )
+    expect(sessionCookie).toBeDefined()
+    expect(sessionCookie).toContain('Max-Age=0')
+    expect(sessionCookie).toContain('HttpOnly')
+    expect(sessionCookie).toContain('Path=/')
+  })
+
+  it('clears google_access_token cookie', async () => {
+    const res = await POST()
+    const setCookies = res.headers.getSetCookie()
+    const tokenCookie = setCookies.find((c: string) =>
+      c.startsWith('google_access_token='),
+    )
+    expect(tokenCookie).toBeDefined()
+    expect(tokenCookie).toContain('Max-Age=0')
+    expect(tokenCookie).toContain('HttpOnly')
+  })
+
+  it('sets SameSite=Lax on cleared cookies', async () => {
+    const res = await POST()
+    const setCookies = res.headers.getSetCookie()
+    for (const cookie of setCookies) {
+      expect(cookie.toLowerCase()).toContain('samesite=lax')
+    }
+  })
+})

--- a/src/app/api/auth/auth-sync.test.ts
+++ b/src/app/api/auth/auth-sync.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/db/queries', () => ({
+  upsertUser: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/session-cookie', () => ({
+  SESSION_COOKIE: 'creatordub_session',
+  signSessionCookie: vi.fn((uid: string) => `${uid}.fakesig`),
+}))
+
+import { POST } from './sync/route'
+import { upsertUser } from '@/lib/db/queries'
+import { NextRequest } from 'next/server'
+
+function makeReq(body: unknown) {
+  return new NextRequest('http://localhost/api/auth/sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/auth/sync', () => {
+  it('returns 400 for missing uid', async () => {
+    const res = await POST(makeReq({ email: 'a@b.com' }))
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.ok).toBe(false)
+    expect(data.error.code).toBe('BAD_REQUEST')
+  })
+
+  it('returns 400 for missing email', async () => {
+    const res = await POST(makeReq({ uid: 'u1' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid email', async () => {
+    const res = await POST(makeReq({ uid: 'u1', email: 'not-an-email' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid body', async () => {
+    const req = new NextRequest('http://localhost/api/auth/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 with valid body and sets session cookie', async () => {
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', displayName: 'Test' }))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.ok).toBe(true)
+    expect(data.data.id).toBe('u1')
+    expect(upsertUser).toHaveBeenCalledWith({
+      id: 'u1',
+      email: 'a@b.com',
+      displayName: 'Test',
+      photoURL: null,
+      accessToken: null,
+    })
+
+    const setCookie = res.headers.getSetCookie()
+    expect(setCookie.some((c: string) => c.startsWith('creatordub_session=u1.fakesig'))).toBe(true)
+  })
+
+  it('sets google_access_token cookie when provided', async () => {
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', accessToken: 'tok123' }))
+    expect(res.status).toBe(200)
+    const setCookie = res.headers.getSetCookie()
+    expect(setCookie.some((c: string) => c.includes('google_access_token=tok123'))).toBe(true)
+  })
+
+  it('returns 500 on DB error', async () => {
+    vi.mocked(upsertUser).mockRejectedValueOnce(new Error('DB down'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }))
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.ok).toBe(false)
+  })
+})

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server'
+import { upsertUser } from '@/lib/db/queries'
+import { SESSION_COOKIE, signSessionCookie } from '@/lib/auth/session-cookie'
+import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
+import { callbackBodySchema } from '@/lib/validators/auth'
+import { getServerEnv } from '@/lib/env'
+import { getClientEnv } from '@/lib/env'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
+
+export async function POST(req: NextRequest) {
+  try {
+    const parsed = callbackBodySchema.safeParse(await req.json().catch(() => null))
+    if (!parsed.success) {
+      return apiFail('BAD_REQUEST', 'code and redirectUri required', 400)
+    }
+
+    const { code, redirectUri } = parsed.data
+    const serverEnv = getServerEnv()
+    const clientEnv = getClientEnv()
+
+    if (!serverEnv.GOOGLE_CLIENT_SECRET) {
+      return apiFail('CONFIG_ERROR', 'GOOGLE_CLIENT_SECRET not configured', 500)
+    }
+
+    const tokenRes = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: clientEnv.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+        client_secret: serverEnv.GOOGLE_CLIENT_SECRET,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+      }),
+    })
+
+    if (!tokenRes.ok) {
+      const err = await tokenRes.text()
+      return apiFail('TOKEN_EXCHANGE_FAILED', `Google token exchange failed: ${err}`, 401)
+    }
+
+    const tokens = (await tokenRes.json()) as {
+      access_token: string
+      refresh_token?: string
+      expires_in: number
+      token_type: string
+    }
+
+    const userRes = await fetch(GOOGLE_USERINFO_URL, {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    })
+    if (!userRes.ok) {
+      return apiFail('USERINFO_FAILED', 'Failed to fetch user info', 401)
+    }
+
+    const info = (await userRes.json()) as {
+      sub: string
+      email: string
+      name?: string
+      picture?: string
+    }
+
+    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+
+    await upsertUser({
+      id: info.sub,
+      email: info.email,
+      displayName: info.name ?? null,
+      photoURL: info.picture ?? null,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? null,
+      tokenExpiresAt: expiresAt,
+    })
+
+    const cookieOpts = {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax' as const,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24 * 7,
+    }
+
+    const res = apiOk({
+      id: info.sub,
+      email: info.email,
+      displayName: info.name ?? null,
+      photoURL: info.picture ?? null,
+    })
+    res.cookies.set(SESSION_COOKIE, signSessionCookie(info.sub), cookieOpts)
+    res.cookies.set('google_access_token', tokens.access_token, {
+      ...cookieOpts,
+      maxAge: tokens.expires_in,
+    })
+    return res
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,20 @@
+import { apiOk } from '@/lib/api/response'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const COOKIES_TO_CLEAR = ['creatordub_session', 'google_access_token']
+
+export async function POST() {
+  const res = apiOk(null)
+  for (const name of COOKIES_TO_CLEAR) {
+    res.cookies.set(name, '', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 0,
+    })
+  }
+  return res
+}

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -1,20 +1,42 @@
 import { NextRequest } from 'next/server'
 import { upsertUser } from '@/lib/db/queries'
+import { SESSION_COOKIE, signSessionCookie } from '@/lib/auth/session-cookie'
+import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
+import { syncBodySchema } from '@/lib/validators/auth'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json()
-    const { uid, email, displayName, photoURL, accessToken } = body
-    if (!uid || !email) {
-      return Response.json({ ok: false, error: { code: 'BAD_REQUEST', message: 'uid and email required' } }, { status: 400 })
+    const parsed = syncBodySchema.safeParse(await req.json().catch(() => null))
+    if (!parsed.success) {
+      return apiFail('BAD_REQUEST', 'uid and email required', 400)
     }
-    await upsertUser({ id: uid, email, displayName: displayName ?? null, photoURL: photoURL ?? null, accessToken: accessToken ?? null })
-    return Response.json({ ok: true, data: { id: uid } })
+
+    const { uid, email, displayName, photoURL, accessToken } = parsed.data
+    await upsertUser({
+      id: uid,
+      email,
+      displayName: displayName ?? null,
+      photoURL: photoURL ?? null,
+      accessToken: accessToken ?? null,
+    })
+
+    const cookieOpts = {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax' as const,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24 * 7,
+    }
+    const res = apiOk({ id: uid })
+    res.cookies.set(SESSION_COOKIE, signSessionCookie(uid), cookieOpts)
+    if (accessToken) {
+      res.cookies.set('google_access_token', accessToken, cookieOpts)
+    }
+    return res
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return Response.json({ ok: false, error: { code: 'DB_ERROR', message } }, { status: 500 })
+    return apiFailFromError(err)
   }
 }

--- a/src/app/api/dashboard/credit-usage/route.ts
+++ b/src/app/api/dashboard/credit-usage/route.ts
@@ -1,19 +1,30 @@
 import { NextRequest } from 'next/server'
 import { getCreditUsageByMonth } from '@/lib/db/queries'
+import { requireSession, forbiddenUidMismatch } from '@/lib/auth/session'
+import { creditUsageQuerySchema } from '@/lib/validators/dashboard'
+import { apiOk, apiFail } from '@/lib/api/response'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
-  const uid = req.nextUrl.searchParams.get('uid')
-  if (!uid) {
-    return Response.json({ ok: false, error: { code: 'BAD_REQUEST', message: 'uid required' } }, { status: 400 })
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = creditUsageQuerySchema.safeParse({
+    uid: req.nextUrl.searchParams.get('uid'),
+  })
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', 'uid required', 400)
   }
+
+  if (parsed.data.uid !== auth.session.uid) return forbiddenUidMismatch()
+
   try {
-    const data = await getCreditUsageByMonth(uid)
-    return Response.json({ ok: true, data })
+    const data = await getCreditUsageByMonth(auth.session.uid)
+    return apiOk(data)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return Response.json({ ok: false, error: { code: 'DB_ERROR', message } }, { status: 500 })
+    return apiFail('DB_ERROR', message, 500)
   }
 }

--- a/src/app/api/dashboard/dashboard-routes.test.ts
+++ b/src/app/api/dashboard/dashboard-routes.test.ts
@@ -1,0 +1,675 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+  forbiddenUidMismatch: vi.fn(
+    () =>
+      Response.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'UID mismatch' } },
+        { status: 403 },
+      ),
+  ),
+}))
+
+vi.mock('@/lib/db/queries', () => ({
+  getUserSummary: vi.fn(async () => ({ totalJobs: 5 })),
+  getUserDubbingJobs: vi.fn(async () => []),
+  getCreditUsageByMonth: vi.fn(async () => []),
+  getLanguagePerformance: vi.fn(async () => []),
+  getUserYouTubeUploads: vi.fn(async () => []),
+  updateYouTubeStats: vi.fn(),
+  createDubbingJob: vi.fn(async () => 1),
+  createJobLanguages: vi.fn(),
+  updateJobLanguageProgress: vi.fn(),
+  updateJobLanguageCompleted: vi.fn(),
+  updateJobStatus: vi.fn(),
+  createYouTubeUpload: vi.fn(async () => 10),
+  updateJobLanguageYouTube: vi.fn(),
+}))
+
+vi.mock('@/lib/youtube/server', () => ({
+  fetchVideoStatistics: vi.fn(async () => []),
+  YouTubeError: class YouTubeError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+      public code = 'YOUTUBE_ERROR',
+    ) {
+      super(message)
+    }
+  },
+}))
+
+import { requireSession } from '@/lib/auth/session'
+
+const mockSession = vi.mocked(requireSession)
+
+function mockAuth(uid: string) {
+  mockSession.mockResolvedValueOnce({
+    ok: true,
+    session: { uid, email: `${uid}@example.com` },
+  })
+}
+
+function mockNoAuth() {
+  mockSession.mockResolvedValueOnce({
+    ok: false,
+    response: Response.json(
+      { ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing token' } },
+      { status: 401 },
+    ),
+  })
+}
+
+// ── /api/dashboard/summary ────────────────────────────────
+
+describe('/api/dashboard/summary', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ GET } = await import('./summary/route'))
+  })
+
+  it('returns 200 with valid uid matching session', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/summary?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toEqual({ totalJobs: 5 })
+  })
+
+  it('returns 401 without session', async () => {
+    mockNoAuth()
+    const req = new NextRequest('http://localhost/api/dashboard/summary?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when uid differs from session', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/summary?uid=other')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body.error.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 400 when uid missing', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/summary')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 on DB error', async () => {
+    const { getUserSummary } = await import('@/lib/db/queries')
+    vi.mocked(getUserSummary).mockRejectedValueOnce(new Error('DB connection lost'))
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/summary?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('DB_ERROR')
+  })
+
+  it('returns generic message when non-Error is thrown', async () => {
+    const { getUserSummary } = await import('@/lib/db/queries')
+    vi.mocked(getUserSummary).mockRejectedValueOnce('string error')
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/summary?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe('Internal Server Error')
+  })
+})
+
+// ── /api/dashboard/jobs ───────────────────────────────────
+
+describe('/api/dashboard/jobs', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ GET } = await import('./jobs/route'))
+  })
+
+  it('returns 200 with matching uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/jobs?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 without session', async () => {
+    mockNoAuth()
+    const req = new NextRequest('http://localhost/api/dashboard/jobs?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for mismatched uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/jobs?uid=other')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when uid missing', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/jobs')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 on DB error', async () => {
+    const { getUserDubbingJobs } = await import('@/lib/db/queries')
+    vi.mocked(getUserDubbingJobs).mockRejectedValueOnce(new Error('DB timeout'))
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/jobs?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('DB_ERROR')
+  })
+
+  it('returns generic message when non-Error is thrown', async () => {
+    const { getUserDubbingJobs } = await import('@/lib/db/queries')
+    vi.mocked(getUserDubbingJobs).mockRejectedValueOnce(42)
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/jobs?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe('Internal Server Error')
+  })
+})
+
+// ── /api/dashboard/credit-usage ───────────────────────────
+
+describe('/api/dashboard/credit-usage', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ GET } = await import('./credit-usage/route'))
+  })
+
+  it('returns 200 with matching uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 without session', async () => {
+    mockNoAuth()
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for mismatched uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage?uid=other')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when uid missing', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 on DB error', async () => {
+    const { getCreditUsageByMonth } = await import('@/lib/db/queries')
+    vi.mocked(getCreditUsageByMonth).mockRejectedValueOnce(new Error('DB disk full'))
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('DB_ERROR')
+  })
+
+  it('returns generic message when non-Error is thrown', async () => {
+    const { getCreditUsageByMonth } = await import('@/lib/db/queries')
+    vi.mocked(getCreditUsageByMonth).mockRejectedValueOnce(null)
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/credit-usage?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe('Internal Server Error')
+  })
+})
+
+// ── /api/dashboard/language-performance ───────────────────
+
+import { getLanguagePerformance, getUserYouTubeUploads, updateYouTubeStats } from '@/lib/db/queries'
+import { fetchVideoStatistics } from '@/lib/youtube/server'
+
+const mockGetLanguagePerformance = vi.mocked(getLanguagePerformance)
+const mockGetUserYouTubeUploads = vi.mocked(getUserYouTubeUploads)
+const mockUpdateYouTubeStats = vi.mocked(updateYouTubeStats)
+const mockFetchVideoStatistics = vi.mocked(fetchVideoStatistics)
+
+describe('/api/dashboard/language-performance', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ GET } = await import('./language-performance/route'))
+  })
+
+  it('returns 200 with matching uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 401 without session', async () => {
+    mockNoAuth()
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for mismatched uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=other')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when uid missing', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('refreshes YouTube stats when accessToken and uploads exist', async () => {
+    mockAuth('user1')
+    mockGetUserYouTubeUploads.mockResolvedValueOnce([
+      { youtube_video_id: 'vid1' },
+      { youtube_video_id: 'vid2' },
+      { youtube_video_id: null },
+    ] as never)
+    mockFetchVideoStatistics.mockResolvedValueOnce([
+      { videoId: 'vid1', viewCount: 100, likeCount: 10, commentCount: 5 },
+      { videoId: 'vid2', viewCount: 200, likeCount: 20, commentCount: 8 },
+    ] as never)
+    const refreshedData = [{ lang: 'ko', views: 300 }]
+    mockGetLanguagePerformance.mockResolvedValueOnce([] as never) // initial call
+    mockGetLanguagePerformance.mockResolvedValueOnce(refreshedData as never) // after refresh
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1', {
+      headers: { cookie: 'google_access_token=fake_token' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual(refreshedData)
+    expect(mockUpdateYouTubeStats).toHaveBeenCalledTimes(2)
+    expect(mockFetchVideoStatistics).toHaveBeenCalledWith('fake_token', ['vid1', 'vid2'])
+  })
+
+  it('falls back to DB data when YouTube refresh fails', async () => {
+    mockAuth('user1')
+    const dbData = [{ lang: 'en', views: 50 }]
+    mockGetLanguagePerformance.mockResolvedValueOnce(dbData as never)
+    mockGetUserYouTubeUploads.mockRejectedValueOnce(new Error('YouTube down'))
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1', {
+      headers: { cookie: 'google_access_token=fake_token' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual(dbData)
+  })
+
+  it('skips YouTube refresh when no uploads have video IDs', async () => {
+    mockAuth('user1')
+    const dbData = [{ lang: 'ja', views: 10 }]
+    mockGetLanguagePerformance.mockResolvedValueOnce(dbData as never)
+    mockGetUserYouTubeUploads.mockResolvedValueOnce([
+      { youtube_video_id: null },
+      { youtube_video_id: '' },
+    ] as never)
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1', {
+      headers: { cookie: 'google_access_token=fake_token' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual(dbData)
+    expect(mockFetchVideoStatistics).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on DB error', async () => {
+    mockAuth('user1')
+    mockGetLanguagePerformance.mockRejectedValueOnce(new Error('DB connection lost'))
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('DB_ERROR')
+  })
+
+  it('returns generic message when non-Error is thrown from outer catch', async () => {
+    mockAuth('user1')
+    mockGetLanguagePerformance.mockRejectedValueOnce({ weird: 'object' })
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1')
+    const res = await GET(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe('Internal Server Error')
+  })
+
+  it('reads accessToken from x-google-access-token header', async () => {
+    mockAuth('user1')
+    mockGetUserYouTubeUploads.mockResolvedValueOnce([
+      { youtube_video_id: 'vid1' },
+    ] as never)
+    mockFetchVideoStatistics.mockResolvedValueOnce([
+      { videoId: 'vid1', viewCount: 50, likeCount: 5, commentCount: 1 },
+    ] as never)
+    mockGetLanguagePerformance.mockResolvedValueOnce([] as never)
+    mockGetLanguagePerformance.mockResolvedValueOnce([{ lang: 'ko' }] as never)
+
+    const req = new NextRequest('http://localhost/api/dashboard/language-performance?uid=user1', {
+      headers: { 'x-google-access-token': 'header_token' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(mockFetchVideoStatistics).toHaveBeenCalledWith('header_token', ['vid1'])
+  })
+})
+
+// ── /api/dashboard/mutations ──────────────────────────────
+
+describe('/api/dashboard/mutations', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./mutations/route'))
+  })
+
+  it('returns 401 without session', async () => {
+    mockNoAuth()
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createDubbingJob',
+        payload: {
+          userId: 'user1',
+          videoTitle: 'test',
+          videoDurationMs: 1000,
+          videoThumbnail: '',
+          sourceLanguage: 'en',
+          mediaSeq: 1,
+          spaceSeq: 1,
+          lipSyncEnabled: false,
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 for createDubbingJob with matching uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createDubbingJob',
+        payload: {
+          userId: 'user1',
+          videoTitle: 'test',
+          videoDurationMs: 1000,
+          videoThumbnail: '',
+          sourceLanguage: 'en',
+          mediaSeq: 1,
+          spaceSeq: 1,
+          lipSyncEnabled: false,
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.jobId).toBe(1)
+  })
+
+  it('returns 403 for createDubbingJob with mismatched uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createDubbingJob',
+        payload: {
+          userId: 'other',
+          videoTitle: 'test',
+          videoDurationMs: 1000,
+          videoThumbnail: '',
+          sourceLanguage: 'en',
+          mediaSeq: 1,
+          spaceSeq: 1,
+          lipSyncEnabled: false,
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 for invalid JSON', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: 'not json',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.code).toBe('BAD_REQUEST')
+  })
+
+  it('returns 400 for unknown action type', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'unknownAction', payload: {} }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 for createJobLanguages', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createJobLanguages',
+        payload: { jobId: 1, languages: [{ code: 'ko', projectSeq: 1 }] },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.jobId).toBe(1)
+  })
+
+  it('returns 200 for updateJobLanguageProgress', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'updateJobLanguageProgress',
+        payload: { jobId: 1, langCode: 'ko', status: 'processing', progress: 50, progressReason: 'Dubbing' },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual({ jobId: 1, langCode: 'ko' })
+  })
+
+  it('returns 200 for updateJobLanguageCompleted', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'updateJobLanguageCompleted',
+        payload: { jobId: 1, langCode: 'ko', urls: { dubbedVideoUrl: 'https://example.com/video.mp4' } },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual({ jobId: 1, langCode: 'ko' })
+  })
+
+  it('returns 200 for updateJobStatus', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'updateJobStatus',
+        payload: { jobId: 1, status: 'completed' },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.jobId).toBe(1)
+  })
+
+  it('returns 200 for createYouTubeUpload with matching uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createYouTubeUpload',
+        payload: {
+          userId: 'user1',
+          youtubeVideoId: 'abc123',
+          title: 'Test Video',
+          languageCode: 'ko',
+          privacyStatus: 'unlisted',
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.id).toBe(10)
+  })
+
+  it('returns 403 for createYouTubeUpload with mismatched uid', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createYouTubeUpload',
+        payload: {
+          userId: 'other',
+          youtubeVideoId: 'abc123',
+          title: 'Test',
+          languageCode: 'ko',
+          privacyStatus: 'unlisted',
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 for updateJobLanguageYouTube', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'updateJobLanguageYouTube',
+        payload: { jobId: 1, langCode: 'ko', youtubeVideoId: 'xyz789' },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual({ jobId: 1, langCode: 'ko' })
+  })
+
+  it('returns 500 on DB error', async () => {
+    const { createDubbingJob } = await import('@/lib/db/queries')
+    vi.mocked(createDubbingJob).mockRejectedValueOnce(new Error('DB write failed'))
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createDubbingJob',
+        payload: {
+          userId: 'user1',
+          videoTitle: 'test',
+          videoDurationMs: 1000,
+          videoThumbnail: '',
+          sourceLanguage: 'en',
+          mediaSeq: 1,
+          spaceSeq: 1,
+          lipSyncEnabled: false,
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.code).toBe('DB_ERROR')
+  })
+
+  it('returns generic message when non-Error is thrown from DB', async () => {
+    const { createDubbingJob } = await import('@/lib/db/queries')
+    vi.mocked(createDubbingJob).mockRejectedValueOnce('raw string')
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'createDubbingJob',
+        payload: {
+          userId: 'user1',
+          videoTitle: 'test',
+          videoDurationMs: 1000,
+          videoThumbnail: '',
+          sourceLanguage: 'en',
+          mediaSeq: 1,
+          spaceSeq: 1,
+          lipSyncEnabled: false,
+          isShort: false,
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error.message).toBe('Internal Server Error')
+  })
+})

--- a/src/app/api/dashboard/jobs/route.ts
+++ b/src/app/api/dashboard/jobs/route.ts
@@ -1,20 +1,31 @@
 import { NextRequest } from 'next/server'
 import { getUserDubbingJobs } from '@/lib/db/queries'
+import { requireSession, forbiddenUidMismatch } from '@/lib/auth/session'
+import { jobsQuerySchema } from '@/lib/validators/dashboard'
+import { apiOk, apiFail } from '@/lib/api/response'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
-  const uid = req.nextUrl.searchParams.get('uid')
-  const limit = Number(req.nextUrl.searchParams.get('limit') || '10')
-  if (!uid) {
-    return Response.json({ ok: false, error: { code: 'BAD_REQUEST', message: 'uid required' } }, { status: 400 })
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = jobsQuerySchema.safeParse({
+    uid: req.nextUrl.searchParams.get('uid'),
+    limit: req.nextUrl.searchParams.get('limit') ?? undefined,
+  })
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', 'uid required', 400)
   }
+
+  if (parsed.data.uid !== auth.session.uid) return forbiddenUidMismatch()
+
   try {
-    const data = await getUserDubbingJobs(uid, limit)
-    return Response.json({ ok: true, data })
+    const data = await getUserDubbingJobs(auth.session.uid, parsed.data.limit)
+    return apiOk(data)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return Response.json({ ok: false, error: { code: 'DB_ERROR', message } }, { status: 500 })
+    return apiFail('DB_ERROR', message, 500)
   }
 }

--- a/src/app/api/dashboard/language-performance/route.ts
+++ b/src/app/api/dashboard/language-performance/route.ts
@@ -1,16 +1,33 @@
 import { NextRequest } from 'next/server'
 import { getLanguagePerformance, getUserYouTubeUploads, updateYouTubeStats } from '@/lib/db/queries'
 import { fetchVideoStatistics } from '@/lib/youtube/server'
+import { requireSession, forbiddenUidMismatch } from '@/lib/auth/session'
+import { languagePerformanceQuerySchema } from '@/lib/validators/dashboard'
+import { apiOk, apiFail } from '@/lib/api/response'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+type YouTubeUploadRow = Record<string, unknown> & {
+  youtube_video_id?: string | null
+}
+
 export async function GET(req: NextRequest) {
-  const uid = req.nextUrl.searchParams.get('uid')
-  const accessToken = req.headers.get('x-google-access-token')
-  if (!uid) {
-    return Response.json({ ok: false, error: { code: 'BAD_REQUEST', message: 'uid required' } }, { status: 400 })
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = languagePerformanceQuerySchema.safeParse({
+    uid: req.nextUrl.searchParams.get('uid'),
+  })
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', 'uid required', 400)
   }
+
+  if (parsed.data.uid !== auth.session.uid) return forbiddenUidMismatch()
+
+  const uid = auth.session.uid
+  const accessToken = req.cookies.get('google_access_token')?.value || req.headers.get('x-google-access-token')
+
   try {
     const dbData = await getLanguagePerformance(uid)
 
@@ -18,8 +35,8 @@ export async function GET(req: NextRequest) {
       try {
         const uploads = await getUserYouTubeUploads(uid)
         const videoIds = uploads
-          .map((u) => (u as Record<string, unknown>).youtube_video_id as string)
-          .filter(Boolean)
+          .map((u) => (u as YouTubeUploadRow).youtube_video_id)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
 
         if (videoIds.length > 0) {
           const stats = await fetchVideoStatistics(accessToken, videoIds)
@@ -31,16 +48,16 @@ export async function GET(req: NextRequest) {
             })
           }
           const refreshed = await getLanguagePerformance(uid)
-          return Response.json({ ok: true, data: refreshed })
+          return apiOk(refreshed)
         }
       } catch {
         // YouTube refresh failed — return DB data
       }
     }
 
-    return Response.json({ ok: true, data: dbData })
+    return apiOk(dbData)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return Response.json({ ok: false, error: { code: 'DB_ERROR', message } }, { status: 500 })
+    return apiFail('DB_ERROR', message, 500)
   }
 }

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -8,124 +8,75 @@ import {
   createYouTubeUpload,
   updateJobLanguageYouTube,
 } from '@/lib/db/queries'
+import { requireSession } from '@/lib/auth/session'
+import { mutationActionSchema, getUserIdFromAction } from '@/lib/validators/dashboard'
+import { apiOk, apiFail } from '@/lib/api/response'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-type Action =
-  | {
-      type: 'createDubbingJob'
-      payload: {
-        userId: string
-        videoTitle: string
-        videoDurationMs: number
-        videoThumbnail: string
-        sourceLanguage: string
-        mediaSeq: number
-        spaceSeq: number
-        lipSyncEnabled: boolean
-        isShort: boolean
-      }
-    }
-  | {
-      type: 'createJobLanguages'
-      payload: { jobId: number; languages: { code: string; projectSeq: number }[] }
-    }
-  | {
-      type: 'updateJobLanguageProgress'
-      payload: {
-        jobId: number
-        langCode: string
-        status: string
-        progress: number
-        progressReason: string
-      }
-    }
-  | {
-      type: 'updateJobLanguageCompleted'
-      payload: {
-        jobId: number
-        langCode: string
-        urls: { dubbedVideoUrl?: string; audioUrl?: string; srtUrl?: string }
-      }
-    }
-  | { type: 'updateJobStatus'; payload: { jobId: number; status: string } }
-  | {
-      type: 'createYouTubeUpload'
-      payload: {
-        userId: string
-        jobLanguageId?: number
-        youtubeVideoId: string
-        title: string
-        languageCode: string
-        privacyStatus: string
-        isShort: boolean
-      }
-    }
-  | {
-      type: 'updateJobLanguageYouTube'
-      payload: { jobId: number; langCode: string; youtubeVideoId: string }
-    }
-
-function ok<T>(data: T) {
-  return Response.json({ ok: true, data })
-}
-
-function fail(code: string, message: string, status = 400) {
-  return Response.json({ ok: false, error: { code, message } }, { status })
-}
-
 export async function POST(req: NextRequest) {
-  let action: Action
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  let body: unknown
   try {
-    action = (await req.json()) as Action
+    body = await req.json()
   } catch {
-    return fail('BAD_REQUEST', 'Invalid JSON body', 400)
+    return apiFail('BAD_REQUEST', 'Invalid JSON body', 400)
   }
-  if (!action || typeof action !== 'object' || !('type' in action)) {
-    return fail('BAD_REQUEST', 'Missing action.type', 400)
+
+  const parsed = mutationActionSchema.safeParse(body)
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', parsed.error.issues.map((i) => i.message).join('; '), 400)
+  }
+
+  const action = parsed.data
+  const actionUserId = getUserIdFromAction(action)
+  if (actionUserId && actionUserId !== auth.session.uid) {
+    return apiFail('FORBIDDEN', 'UID mismatch: you can only mutate your own data', 403)
   }
 
   try {
     switch (action.type) {
       case 'createDubbingJob': {
         const jobId = await createDubbingJob(action.payload)
-        return ok({ jobId })
+        return apiOk({ jobId })
       }
       case 'createJobLanguages': {
         await createJobLanguages(action.payload.jobId, action.payload.languages)
-        return ok({ jobId: action.payload.jobId })
+        return apiOk({ jobId: action.payload.jobId })
       }
       case 'updateJobLanguageProgress': {
         const { jobId, langCode, status, progress, progressReason } = action.payload
         await updateJobLanguageProgress(jobId, langCode, status, progress, progressReason)
-        return ok({ jobId, langCode })
+        return apiOk({ jobId, langCode })
       }
       case 'updateJobLanguageCompleted': {
         const { jobId, langCode, urls } = action.payload
         await updateJobLanguageCompleted(jobId, langCode, urls)
-        return ok({ jobId, langCode })
+        return apiOk({ jobId, langCode })
       }
       case 'updateJobStatus': {
         const { jobId, status } = action.payload
         await updateJobStatus(jobId, status)
-        return ok({ jobId })
+        return apiOk({ jobId })
       }
       case 'createYouTubeUpload': {
         const id = await createYouTubeUpload(action.payload)
-        return ok({ id })
+        return apiOk({ id })
       }
       case 'updateJobLanguageYouTube': {
         const { jobId, langCode, youtubeVideoId } = action.payload
         await updateJobLanguageYouTube(jobId, langCode, youtubeVideoId)
-        return ok({ jobId, langCode })
+        return apiOk({ jobId, langCode })
       }
       default: {
-        return fail('BAD_REQUEST', `Unknown action: ${(action as { type: string }).type}`, 400)
+        return apiFail('BAD_REQUEST', 'Unknown action type', 400)
       }
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return fail('DB_ERROR', message, 500)
+    return apiFail('DB_ERROR', message, 500)
   }
 }

--- a/src/app/api/dashboard/summary/route.ts
+++ b/src/app/api/dashboard/summary/route.ts
@@ -1,19 +1,30 @@
 import { NextRequest } from 'next/server'
 import { getUserSummary } from '@/lib/db/queries'
+import { requireSession, forbiddenUidMismatch } from '@/lib/auth/session'
+import { summaryQuerySchema } from '@/lib/validators/dashboard'
+import { apiOk, apiFail } from '@/lib/api/response'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
-  const uid = req.nextUrl.searchParams.get('uid')
-  if (!uid) {
-    return Response.json({ ok: false, error: { code: 'BAD_REQUEST', message: 'uid required' } }, { status: 400 })
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = summaryQuerySchema.safeParse({
+    uid: req.nextUrl.searchParams.get('uid'),
+  })
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', 'uid required', 400)
   }
+
+  if (parsed.data.uid !== auth.session.uid) return forbiddenUidMismatch()
+
   try {
-    const data = await getUserSummary(uid)
-    return Response.json({ ok: true, data })
+    const data = await getUserSummary(auth.session.uid)
+    return apiOk(data)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return Response.json({ ok: false, error: { code: 'DB_ERROR', message } }, { status: 500 })
+    return apiFail('DB_ERROR', message, 500)
   }
 }

--- a/src/app/api/perso/download/route.ts
+++ b/src/app/api/perso/download/route.ts
@@ -1,23 +1,31 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
-import type { DownloadResponse, DownloadTarget } from '@/lib/perso/types'
+import { downloadTargetSchema } from '@/lib/validators/perso'
+import type { DownloadResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/download?projectSeq={p}&spaceSeq={s}&target={t}
- *   → GET /video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/download?target={t}
- *
- * Valid targets: video | dubbingVideo | lipSyncVideo | originalSubtitle
- *               | translatedSubtitle | voiceAudio | backgroundAudio | all
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
-    const target = (url.searchParams.get('target') || 'all') as DownloadTarget
+    const rawTarget = url.searchParams.get('target') || 'all'
+    const parsed = downloadTargetSchema.safeParse(rawTarget)
+    if (!parsed.success) {
+      throw Object.assign(new Error(`Invalid target: ${rawTarget}`), {
+        name: 'PersoError',
+        code: 'INVALID_PARAM',
+        status: 400,
+      })
+    }
+    const target = parsed.data
 
     return persoFetch<DownloadResponse>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`,

--- a/src/app/api/perso/external/metadata/route.ts
+++ b/src/app/api/perso/external/metadata/route.ts
@@ -1,25 +1,19 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, readJson } from '@/lib/perso/route-helpers'
+import { handle, parseBody } from '@/lib/perso/route-helpers'
+import { externalMetadataBodySchema } from '@/lib/validators/perso'
 import type { ExternalMetadataResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-interface Body {
-  spaceSeq: number
-  url: string
-  lang?: string
-}
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-/**
- * POST /api/perso/external/metadata
- *  → POST /file/api/v1/video-translator/external/metadata
- *
- * NOTE: Perso expects snake_case body: { space_seq, url, lang }
- */
-export async function POST(req: Request) {
   return handle(async () => {
-    const { spaceSeq, url, lang = 'ko' } = await readJson<Body>(req)
+    const { spaceSeq, url, lang = 'ko' } = await parseBody(req, externalMetadataBodySchema)
     return persoFetch<ExternalMetadataResponse>(
       '/file/api/v1/video-translator/external/metadata',
       {

--- a/src/app/api/perso/external/upload/route.ts
+++ b/src/app/api/perso/external/upload/route.ts
@@ -1,29 +1,20 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, readJson } from '@/lib/perso/route-helpers'
+import { handle, parseBody } from '@/lib/perso/route-helpers'
+import { externalUploadBodySchema } from '@/lib/validators/perso'
 import type { UploadVideoResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-// External upload may take up to 10 minutes; extend Vercel function timeout.
 export const maxDuration = 600
 
-interface Body {
-  spaceSeq: number
-  url: string
-  lang?: string
-}
+export async function PUT(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-/**
- * PUT /api/perso/external/upload
- *   → PUT /file/api/upload/video/external
- *
- * NOTE: Perso expects snake_case body: { space_seq, url, lang }.
- * This call is SYNCHRONOUS on the Perso side and may take up to 10 minutes
- * while Perso downloads the YouTube video. We set a 10-minute timeout.
- */
-export async function PUT(req: Request) {
   return handle(async () => {
-    const { spaceSeq, url, lang = 'ko' } = await readJson<Body>(req)
+    const { spaceSeq, url, lang = 'ko' } = await parseBody(req, externalUploadBodySchema)
     return persoFetch<UploadVideoResponse>(
       '/file/api/upload/video/external',
       {

--- a/src/app/api/perso/languages/route.ts
+++ b/src/app/api/perso/languages/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle } from '@/lib/perso/route-helpers'
 import type { PersoLanguage } from '@/lib/perso/types'
@@ -5,13 +7,14 @@ import type { PersoLanguage } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/** GET /api/perso/languages → GET /video-translator/api/v1/languages */
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const data = await persoFetch<
       { languages: PersoLanguage[] } | PersoLanguage[]
     >('/video-translator/api/v1/languages', { baseURL: 'api' })
-    // Normalize: API may return either { languages: [...] } or the array directly
     if (Array.isArray(data)) return data
     return data.languages ?? []
   })

--- a/src/app/api/perso/lipsync/route.ts
+++ b/src/app/api/perso/lipsync/route.ts
@@ -1,17 +1,15 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * POST /api/perso/lipsync?projectSeq={p}&spaceSeq={s}
- *   → POST /video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/lip-sync
- *
- * Post-processing step that aligns dubbed audio to the original speaker's
- * mouth movements. Only available on plans that support lip sync.
- */
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')

--- a/src/app/api/perso/perso-routes-auth.test.ts
+++ b/src/app/api/perso/perso-routes-auth.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+  forbiddenUidMismatch: vi.fn(
+    () =>
+      Response.json(
+        { ok: false, error: { code: 'FORBIDDEN', message: 'UID mismatch' } },
+        { status: 403 },
+      ),
+  ),
+}))
+
+vi.mock('@/lib/perso/client', () => ({
+  persoFetch: vi.fn(async () => ({ ok: true })),
+}))
+
+import { requireSession } from '@/lib/auth/session'
+
+const mockSession = vi.mocked(requireSession)
+
+function mockNoAuth() {
+  mockSession.mockResolvedValueOnce({
+    ok: false,
+    response: Response.json(
+      { ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing token' } },
+      { status: 401 },
+    ),
+  })
+}
+
+function mockAuth(uid = 'user1') {
+  mockSession.mockResolvedValueOnce({
+    ok: true,
+    session: { uid, email: `${uid}@example.com` },
+  })
+}
+
+describe('Perso API routes — session auth guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const cases: {
+    name: string
+    path: string
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH'
+    importPath: string
+    body?: Record<string, unknown>
+    query?: string
+  }[] = [
+    { name: 'spaces', path: '/api/perso/spaces', method: 'GET', importPath: './spaces/route' },
+    { name: 'languages', path: '/api/perso/languages', method: 'GET', importPath: './languages/route' },
+    {
+      name: 'external/metadata',
+      path: '/api/perso/external/metadata',
+      method: 'POST',
+      importPath: './external/metadata/route',
+      body: { spaceSeq: 1, url: 'https://youtube.com/watch?v=abc' },
+    },
+    {
+      name: 'external/upload',
+      path: '/api/perso/external/upload',
+      method: 'PUT',
+      importPath: './external/upload/route',
+      body: { spaceSeq: 1, url: 'https://youtube.com/watch?v=abc' },
+    },
+    {
+      name: 'upload/sas-token',
+      path: '/api/perso/upload/sas-token',
+      method: 'GET',
+      importPath: './upload/sas-token/route',
+      query: 'fileName=test.mp4',
+    },
+    {
+      name: 'upload/register',
+      path: '/api/perso/upload/register',
+      method: 'PUT',
+      importPath: './upload/register/route',
+      body: { spaceSeq: 1, fileUrl: 'https://example.com/f.mp4', fileName: 'f.mp4' },
+    },
+    {
+      name: 'validate',
+      path: '/api/perso/validate',
+      method: 'POST',
+      importPath: './validate/route',
+      body: { spaceSeq: 1, durationMs: 5000, originalName: 'test.mp4', mediaType: 'video', extension: 'mp4', size: 1000, width: 1920, height: 1080 },
+    },
+    {
+      name: 'queue',
+      path: '/api/perso/queue',
+      method: 'PUT',
+      importPath: './queue/route',
+      query: 'spaceSeq=1',
+    },
+    {
+      name: 'translate',
+      path: '/api/perso/translate',
+      method: 'POST',
+      importPath: './translate/route',
+      query: 'spaceSeq=1',
+      body: { targetLanguages: ['en'] },
+    },
+    {
+      name: 'projects',
+      path: '/api/perso/projects',
+      method: 'GET',
+      importPath: './projects/route',
+      query: 'spaceSeq=1',
+    },
+    {
+      name: 'script GET',
+      path: '/api/perso/script',
+      method: 'GET',
+      importPath: './script/route',
+      query: 'projectSeq=1&spaceSeq=1',
+    },
+    {
+      name: 'script PATCH',
+      path: '/api/perso/script',
+      method: 'PATCH',
+      importPath: './script/route',
+      query: 'projectSeq=1&sentenceSeq=1',
+      body: { translatedText: 'hello' },
+    },
+    {
+      name: 'script/regenerate',
+      path: '/api/perso/script/regenerate',
+      method: 'PATCH',
+      importPath: './script/regenerate/route',
+      query: 'projectSeq=1&audioSentenceSeq=1',
+    },
+    {
+      name: 'download',
+      path: '/api/perso/download',
+      method: 'GET',
+      importPath: './download/route',
+      query: 'projectSeq=1&spaceSeq=1',
+    },
+    {
+      name: 'lipsync',
+      path: '/api/perso/lipsync',
+      method: 'POST',
+      importPath: './lipsync/route',
+      query: 'projectSeq=1&spaceSeq=1',
+    },
+    {
+      name: 'project',
+      path: '/api/perso/project',
+      method: 'GET',
+      importPath: './project/route',
+      query: 'projectSeq=1&spaceSeq=1',
+    },
+    {
+      name: 'progress',
+      path: '/api/perso/progress',
+      method: 'GET',
+      importPath: './progress/route',
+      query: 'projectSeq=1&spaceSeq=1',
+    },
+  ]
+
+  for (const tc of cases) {
+    it(`${tc.name} (${tc.method}) → 401 without auth`, async () => {
+      mockNoAuth()
+      const url = `http://localhost${tc.path}${tc.query ? `?${tc.query}` : ''}`
+      const init: { method: string; body?: string } = { method: tc.method }
+      if (tc.body) init.body = JSON.stringify(tc.body)
+
+      const req = new NextRequest(url, init)
+      const mod = await import(tc.importPath)
+      const handler = mod[tc.method]
+      const res = await handler(req)
+      expect(res.status).toBe(401)
+    })
+
+    it(`${tc.name} (${tc.method}) → calls handler with valid auth`, async () => {
+      mockAuth()
+      const url = `http://localhost${tc.path}${tc.query ? `?${tc.query}` : ''}`
+      const init: { method: string; body?: string } = { method: tc.method }
+      if (tc.body) init.body = JSON.stringify(tc.body)
+
+      const req = new NextRequest(url, init)
+      const mod = await import(tc.importPath)
+      const handler = mod[tc.method]
+      const res = await handler(req)
+      expect(res.status).not.toBe(401)
+    })
+  }
+})

--- a/src/app/api/perso/perso-zod-validation.test.ts
+++ b/src/app/api/perso/perso-zod-validation.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(async () => ({
+    ok: true,
+    session: { uid: 'user1', email: 'user1@example.com' },
+  })),
+}))
+
+vi.mock('@/lib/perso/client', () => ({
+  persoFetch: vi.fn(async () => ({ ok: true })),
+}))
+
+describe('Perso routes — zod body validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('external/metadata rejects invalid body (bad url)', async () => {
+    const { POST } = await import('./external/metadata/route')
+    const req = new NextRequest('http://localhost/api/perso/external/metadata', {
+      method: 'POST',
+      body: JSON.stringify({ spaceSeq: 1, url: 'not-a-url' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.code).toBe('INVALID_BODY')
+  })
+
+  it('external/metadata rejects missing spaceSeq', async () => {
+    const { POST } = await import('./external/metadata/route')
+    const req = new NextRequest('http://localhost/api/perso/external/metadata', {
+      method: 'POST',
+      body: JSON.stringify({ url: 'https://youtube.com/watch?v=abc' }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('external/upload rejects missing url', async () => {
+    const { PUT } = await import('./external/upload/route')
+    const req = new NextRequest('http://localhost/api/perso/external/upload', {
+      method: 'PUT',
+      body: JSON.stringify({ spaceSeq: 1 }),
+    })
+    const res = await PUT(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('upload/register rejects empty fileName', async () => {
+    const { PUT } = await import('./upload/register/route')
+    const req = new NextRequest('http://localhost/api/perso/upload/register', {
+      method: 'PUT',
+      body: JSON.stringify({ spaceSeq: 1, fileUrl: 'https://example.com/f.mp4', fileName: '' }),
+    })
+    const res = await PUT(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('validate rejects missing fields', async () => {
+    const { POST } = await import('./validate/route')
+    const req = new NextRequest('http://localhost/api/perso/validate', {
+      method: 'POST',
+      body: JSON.stringify({ spaceSeq: 1 }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('translate rejects invalid preferredSpeedType', async () => {
+    const { POST } = await import('./translate/route')
+    const req = new NextRequest('http://localhost/api/perso/translate?spaceSeq=1', {
+      method: 'POST',
+      body: JSON.stringify({
+        mediaSeq: 1, isVideoProject: true, sourceLanguageCode: 'ko',
+        targetLanguageCodes: ['en'], numberOfSpeakers: 1, preferredSpeedType: 'BLUE',
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('script PATCH rejects empty translatedText', async () => {
+    const { PATCH } = await import('./script/route')
+    const req = new NextRequest('http://localhost/api/perso/script?projectSeq=1&sentenceSeq=1', {
+      method: 'PATCH',
+      body: JSON.stringify({ translatedText: '' }),
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('download rejects invalid target', async () => {
+    const { GET } = await import('./download/route')
+    const req = new NextRequest('http://localhost/api/perso/download?projectSeq=1&spaceSeq=1&target=invalid')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.code).toBe('INVALID_PARAM')
+  })
+
+  it('download accepts valid target', async () => {
+    const { GET } = await import('./download/route')
+    const req = new NextRequest('http://localhost/api/perso/download?projectSeq=1&spaceSeq=1&target=video')
+    const res = await GET(req)
+    expect(res.status).not.toBe(400)
+  })
+})

--- a/src/app/api/perso/progress/route.ts
+++ b/src/app/api/perso/progress/route.ts
@@ -1,20 +1,20 @@
-import { NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { mapPersoError } from '@/lib/perso/errors'
-import { requireIntParam } from '@/lib/perso/route-helpers'
+import { ok, fail, requireIntParam } from '@/lib/perso/route-helpers'
 import type { ProgressResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/progress?projectSeq={p}&spaceSeq={s}
- *   → GET /video-translator/api/v1/projects/{projectSeq}/space/{spaceSeq}/progress
- *
- * Cache-Control: no-store to prevent Next.js/CDN caching of polling responses.
- * Client polling interval: minimum 5 seconds (enforce in consumer).
- */
-export async function GET(req: Request) {
+const NO_CACHE_HEADERS = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate',
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   try {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
@@ -25,22 +25,8 @@ export async function GET(req: Request) {
       { baseURL: 'api' },
     )
 
-    return NextResponse.json(
-      { ok: true as const, data },
-      {
-        headers: {
-          'Cache-Control': 'no-store, no-cache, must-revalidate',
-        },
-      },
-    )
+    return ok(data, { headers: NO_CACHE_HEADERS })
   } catch (err) {
-    const { status, code, message, details } = mapPersoError(err)
-    return NextResponse.json(
-      { ok: false as const, error: { code, message, details } },
-      {
-        status,
-        headers: { 'Cache-Control': 'no-store' },
-      },
-    )
+    return fail(err)
   }
 }

--- a/src/app/api/perso/project/route.ts
+++ b/src/app/api/perso/project/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 import type { ProjectDetail } from '@/lib/perso/types'
@@ -5,13 +7,10 @@ import type { ProjectDetail } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/project?projectSeq={p}&spaceSeq={s}
- *   → GET /video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}
- *
- * Single project detail lookup. Complements /api/perso/projects (list).
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')

--- a/src/app/api/perso/projects/route.ts
+++ b/src/app/api/perso/projects/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 import type { ProjectDetail } from '@/lib/perso/types'
@@ -5,11 +7,10 @@ import type { ProjectDetail } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/projects?spaceSeq={n}
- *   → GET /video-translator/api/v1/projects/spaces/{spaceSeq}
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const spaceSeq = requireIntParam(url, 'spaceSeq')

--- a/src/app/api/perso/queue/route.ts
+++ b/src/app/api/perso/queue/route.ts
@@ -1,16 +1,15 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * PUT /api/perso/queue?spaceSeq={n}
- *   → PUT /video-translator/api/v1/projects/spaces/{spaceSeq}/queue
- *
- * Idempotent: re-calling on an already-initialized queue is safe.
- */
-export async function PUT(req: Request) {
+export async function PUT(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const spaceSeq = requireIntParam(url, 'spaceSeq')

--- a/src/app/api/perso/script/regenerate/route.ts
+++ b/src/app/api/perso/script/regenerate/route.ts
@@ -1,16 +1,15 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * PATCH /api/perso/script/regenerate?projectSeq={p}&audioSentenceSeq={s}
- *   → PATCH /video-translator/api/v1/project/{projectSeq}/audio-sentence/{seq}/generate-audio
- *
- * Triggers TTS re-synthesis for a single sentence after translation edit.
- */
-export async function PATCH(req: Request) {
+export async function PATCH(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')

--- a/src/app/api/perso/script/route.ts
+++ b/src/app/api/perso/script/route.ts
@@ -1,15 +1,17 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, readJson, requireIntParam } from '@/lib/perso/route-helpers'
+import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
+import { scriptPatchBodySchema } from '@/lib/validators/perso'
 import type { ScriptSentence } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/script?projectSeq={p}&spaceSeq={s}
- *   → GET /video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/script
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
@@ -21,19 +23,15 @@ export async function GET(req: Request) {
   })
 }
 
-/**
- * PATCH /api/perso/script?projectSeq={p}&sentenceSeq={s}
- *   → PATCH /video-translator/api/v1/project/{projectSeq}/audio-sentence/{sentenceSeq}
- *
- * Body: { translatedText: string }
- * Used for inline script editing in the review UI.
- */
-export async function PATCH(req: Request) {
+export async function PATCH(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const sentenceSeq = requireIntParam(url, 'sentenceSeq')
-    const body = await readJson<{ translatedText: string }>(req)
+    const body = await parseBody(req, scriptPatchBodySchema)
     return persoFetch<unknown>(
       `/video-translator/api/v1/project/${projectSeq}/audio-sentence/${sentenceSeq}`,
       { method: 'PATCH', baseURL: 'api', body },

--- a/src/app/api/perso/spaces/route.ts
+++ b/src/app/api/perso/spaces/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle } from '@/lib/perso/route-helpers'
 import type { PersoSpace } from '@/lib/perso/types'
@@ -5,8 +7,10 @@ import type { PersoSpace } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/** GET /api/perso/spaces → GET /portal/api/v1/spaces */
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(() =>
     persoFetch<PersoSpace[]>('/portal/api/v1/spaces', { baseURL: 'api' }),
   )

--- a/src/app/api/perso/translate/route.ts
+++ b/src/app/api/perso/translate/route.ts
@@ -1,41 +1,34 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { PersoError } from '@/lib/perso/errors'
-import { handle, readJson, requireIntParam } from '@/lib/perso/route-helpers'
-import type { TranslateRequest, TranslateResponse } from '@/lib/perso/types'
+import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
+import { translateBodySchema } from '@/lib/validators/perso'
+import type { TranslateResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * POST /api/perso/translate?spaceSeq={n}
- *   1. Auto-initializes queue (idempotent) — fixes "space queue not found" bug
- *   2. POST /video-translator/api/v1/projects/spaces/{spaceSeq}/translate
- *
- * Known failure codes: VT4043/VT4044 (language), VT5034 (queue full),
- * VT4021 (insufficient credits).
- */
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const spaceSeq = requireIntParam(url, 'spaceSeq')
-    const body = await readJson<TranslateRequest>(req)
+    const body = await parseBody(req, translateBodySchema)
 
-    // Step 1 — auto-initialize queue (idempotent). Swallow "already initialized"
-    // style errors so translate can proceed. Hard failures surface normally.
     try {
       await persoFetch<unknown>(
         `/video-translator/api/v1/projects/spaces/${spaceSeq}/queue`,
         { method: 'PUT', baseURL: 'api' },
       )
     } catch (err) {
-      // Only swallow benign errors; re-throw real failures.
       if (err instanceof PersoError && err.status >= 500) {
         throw err
       }
-      // 4xx from queue init is typically "already initialized" — safe to ignore.
     }
 
-    // Step 2 — actual translate call
     return persoFetch<TranslateResponse>(
       `/video-translator/api/v1/projects/spaces/${spaceSeq}/translate`,
       {

--- a/src/app/api/perso/upload/register/route.ts
+++ b/src/app/api/perso/upload/register/route.ts
@@ -1,24 +1,19 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, readJson } from '@/lib/perso/route-helpers'
+import { handle, parseBody } from '@/lib/perso/route-helpers'
+import { uploadRegisterBodySchema } from '@/lib/validators/perso'
 import type { UploadVideoResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-interface Body {
-  spaceSeq: number
-  fileUrl: string
-  fileName: string
-}
+export async function PUT(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-/**
- * PUT /api/perso/upload/register → PUT /file/api/upload/video
- *
- * camelCase body: { spaceSeq, fileUrl, fileName }
- */
-export async function PUT(req: Request) {
   return handle(async () => {
-    const body = await readJson<Body>(req)
+    const body = await parseBody(req, uploadRegisterBodySchema)
     return persoFetch<UploadVideoResponse>('/file/api/upload/video', {
       method: 'PUT',
       baseURL: 'file',

--- a/src/app/api/perso/upload/sas-token/route.ts
+++ b/src/app/api/perso/upload/sas-token/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireStringParam } from '@/lib/perso/route-helpers'
 import type { SasTokenResponse } from '@/lib/perso/types'
@@ -5,11 +7,10 @@ import type { SasTokenResponse } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/perso/upload/sas-token?fileName=...
- *   → GET /file/api/upload/sas-token?fileName=...
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
     const url = new URL(req.url)
     const fileName = requireStringParam(url, 'fileName')

--- a/src/app/api/perso/validate/route.ts
+++ b/src/app/api/perso/validate/route.ts
@@ -1,22 +1,18 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, readJson } from '@/lib/perso/route-helpers'
-import type { MediaValidateRequest } from '@/lib/perso/types'
+import { handle, parseBody } from '@/lib/perso/route-helpers'
+import { mediaValidateBodySchema } from '@/lib/validators/perso'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * POST /api/perso/validate → POST /file/api/v1/media/validate
- *
- * Body (camelCase):
- *   { spaceSeq, durationMs, originalName, mediaType, extension, size, width, height }
- *
- * Known failure codes mapped via errors.ts:
- *   F4004 (size), F4008 (length), F4009 (too short), F40010 (resolution), F4005 (plan).
- */
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return handle(async () => {
-    const body = await readJson<MediaValidateRequest>(req)
+    const body = await parseBody(req, mediaValidateBodySchema)
     return persoFetch<{ valid?: boolean } | null>(
       '/file/api/v1/media/validate',
       {

--- a/src/app/api/youtube/analytics/analytics-route.test.ts
+++ b/src/app/api/youtube/analytics/analytics-route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import type { VideoAnalytics } from '@/lib/youtube/types'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(async () => ({
+    ok: true,
+    session: { uid: 'u1', email: 'u1@example.com' },
+  })),
+}))
+
+const mockAnalytics: VideoAnalytics = {
+  videoId: 'vid1',
+  daily: [{ date: '2026-01-01', views: 50, estimatedMinutesWatched: 20, averageViewDuration: 60 }],
+  countries: [{ country: 'US', views: 50, estimatedMinutesWatched: 20 }],
+  totals: { views: 50, estimatedMinutesWatched: 20, averageViewDuration: 60 },
+}
+
+vi.mock('@/lib/youtube/route-helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/youtube/route-helpers')>()
+  return {
+    ...actual,
+    requireAccessToken: vi.fn(async () => 'mock-token'),
+    ytHandle: vi.fn(async (fn: () => Promise<unknown>) => {
+      try {
+        const data = await fn()
+        return Response.json({ ok: true, data })
+      } catch (err) {
+        const code = (err as { code?: string }).code || 'UNKNOWN'
+        const status = (err as { status?: number }).status || 500
+        const message = err instanceof Error ? err.message : 'Unknown'
+        return Response.json({ ok: false, error: { code, message } }, { status })
+      }
+    }),
+  }
+})
+
+const mockFetchVideoAnalytics = vi.fn<
+  (accessToken: string, videoId: string, startDate: string, endDate: string) => Promise<VideoAnalytics>
+>().mockResolvedValue(mockAnalytics)
+vi.mock('@/lib/youtube/server', () => ({
+  fetchVideoAnalytics: (...args: [string, string, string, string]) => mockFetchVideoAnalytics(...args),
+}))
+
+const mockExecute = vi.fn()
+vi.mock('@/lib/db/client', () => ({
+  getDb: () => ({ execute: mockExecute }),
+}))
+
+describe('GET /api/youtube/analytics', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockExecute.mockResolvedValue({ rows: [] })
+    ;({ GET } = await import('./route'))
+  })
+
+  it('returns empty array when no videoIds provided', async () => {
+    const req = new NextRequest('http://localhost/api/youtube/analytics')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toEqual([])
+  })
+
+  it('fetches analytics for provided videoIds', async () => {
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=vid1&userId=u1')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].videoId).toBe('vid1')
+    expect(mockFetchVideoAnalytics).toHaveBeenCalledWith('mock-token', 'vid1', expect.any(String), expect.any(String))
+  })
+
+  it('uses cache when available and fresh', async () => {
+    const now = new Date().toISOString()
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ data: JSON.stringify(mockAnalytics), fetched_at: now }],
+    })
+
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=vid1&userId=u1')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(mockFetchVideoAnalytics).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale cache and fetches fresh data', async () => {
+    const staleDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+    mockExecute
+      .mockResolvedValueOnce({
+        rows: [{ data: JSON.stringify(mockAnalytics), fetched_at: staleDate }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=vid1&userId=u1')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(mockFetchVideoAnalytics).toHaveBeenCalled()
+  })
+
+  it('handles multiple videoIds', async () => {
+    mockFetchVideoAnalytics
+      .mockResolvedValueOnce({ ...mockAnalytics, videoId: 'v1' })
+      .mockResolvedValueOnce({ ...mockAnalytics, videoId: 'v2' })
+    mockExecute.mockResolvedValue({ rows: [] })
+
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=v1,v2&userId=u1')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0].videoId).toBe('v1')
+    expect(body.data[1].videoId).toBe('v2')
+  })
+
+  it('accepts custom date range', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/youtube/analytics?videoIds=vid1&userId=u1&startDate=2026-01-01&endDate=2026-01-31',
+    )
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    expect(mockFetchVideoAnalytics).toHaveBeenCalledWith('mock-token', 'vid1', '2026-01-01', '2026-01-31')
+  })
+
+  it('uses session uid for cache key instead of query param', async () => {
+    mockExecute.mockResolvedValue({ rows: [] })
+
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=vid1')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toHaveLength(1)
+    const cacheSelectCall = mockExecute.mock.calls.find(
+      (call) => typeof call[0]?.sql === 'string' && call[0].sql.includes('SELECT'),
+    )
+    expect(cacheSelectCall?.[0].args).toContain('u1:vid1')
+  })
+
+  it('writes cache after fetching fresh data', async () => {
+    mockExecute.mockResolvedValue({ rows: [] })
+
+    const req = new NextRequest('http://localhost/api/youtube/analytics?videoIds=vid1&userId=u1')
+    await GET(req)
+
+    const setCacheCalls = mockExecute.mock.calls.filter(
+      (call) => typeof call[0]?.sql === 'string' && call[0].sql.includes('INSERT OR REPLACE'),
+    )
+    expect(setCacheCalls.length).toBe(1)
+  })
+})

--- a/src/app/api/youtube/analytics/route.ts
+++ b/src/app/api/youtube/analytics/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { getDb } from '@/lib/db/client'
+import {
+  fetchVideoAnalytics,
+} from '@/lib/youtube/server'
+import {
+  requireAccessToken,
+  parseQuery,
+  ytHandle,
+} from '@/lib/youtube/route-helpers'
+import { analyticsQuerySchema } from '@/lib/validators/youtube'
+import type { VideoAnalytics } from '@/lib/youtube/types'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+function defaultDateRange() {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(start.getDate() - 28)
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  }
+}
+
+async function getCached(
+  userId: string,
+  videoId: string,
+): Promise<VideoAnalytics | null> {
+  const db = getDb()
+  const row = await db.execute({
+    sql: 'SELECT data, fetched_at FROM analytics_cache WHERE id = ? AND user_id = ?',
+    args: [`${userId}:${videoId}`, userId],
+  })
+  if (!row.rows[0]) return null
+  const fetchedAt = new Date(row.rows[0].fetched_at as string).getTime()
+  if (Date.now() - fetchedAt > CACHE_TTL_MS) return null
+  return JSON.parse(row.rows[0].data as string) as VideoAnalytics
+}
+
+async function setCache(
+  userId: string,
+  videoId: string,
+  data: VideoAnalytics,
+): Promise<void> {
+  const db = getDb()
+  await db.execute({
+    sql: `INSERT OR REPLACE INTO analytics_cache (id, user_id, video_id, data, fetched_at)
+          VALUES (?, ?, ?, ?, datetime('now'))`,
+    args: [`${userId}:${videoId}`, userId, videoId, JSON.stringify(data)],
+  })
+}
+
+/**
+ * GET /api/youtube/analytics?videoIds=a,b,c[&startDate=YYYY-MM-DD&endDate=YYYY-MM-DD]
+ */
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return ytHandle(async () => {
+    const accessToken = await requireAccessToken(req)
+    const url = new URL(req.url)
+
+    const raw = url.searchParams.get('videoIds')
+    if (!raw || raw.trim() === '') return []
+
+    const query = parseQuery(url, analyticsQuerySchema)
+    const { videoIds } = query
+    if (videoIds.length === 0) return []
+
+    const { startDate: defaultStart, endDate: defaultEnd } = defaultDateRange()
+    const startDate = query.startDate || defaultStart
+    const endDate = query.endDate || defaultEnd
+
+    const userId = auth.session.uid
+
+    const results: VideoAnalytics[] = []
+    for (const videoId of videoIds) {
+      const cached = await getCached(userId, videoId)
+      if (cached) {
+        results.push(cached)
+        continue
+      }
+      const fresh = await fetchVideoAnalytics(
+        accessToken,
+        videoId,
+        startDate,
+        endDate,
+      )
+      await setCache(userId, videoId, fresh)
+      results.push(fresh)
+    }
+
+    return results
+  })
+}

--- a/src/app/api/youtube/caption/route.ts
+++ b/src/app/api/youtube/caption/route.ts
@@ -1,24 +1,23 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { uploadCaptionToYouTube } from '@/lib/youtube/server'
 import {
   requireAccessToken,
+  parseYtBody,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
+import { captionBodySchema } from '@/lib/validators/youtube'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-interface Body {
-  videoId: string
-  language: string
-  name: string
-  srtContent: string
-}
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-/** POST /api/youtube/caption — upload SRT to existing video */
-export async function POST(req: Request) {
   return ytHandle(async () => {
-    const accessToken = requireAccessToken(req)
-    const body = (await req.json()) as Body
+    const accessToken = await requireAccessToken(req)
+    const body = await parseYtBody(req, captionBodySchema)
     await uploadCaptionToYouTube({ accessToken, ...body })
     return { uploaded: true }
   })

--- a/src/app/api/youtube/stats/route.ts
+++ b/src/app/api/youtube/stats/route.ts
@@ -1,32 +1,32 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import {
   fetchChannelStatistics,
   fetchVideoStatistics,
 } from '@/lib/youtube/server'
 import {
   requireAccessToken,
+  parseQuery,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
+import { statsQuerySchema } from '@/lib/validators/youtube'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/youtube/stats?videoIds=a,b,c    → video statistics
- * GET /api/youtube/stats?channel=true      → authenticated user's channel stats
- */
-export async function GET(req: Request) {
-  return ytHandle(async () => {
-    const accessToken = requireAccessToken(req)
-    const url = new URL(req.url)
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-    if (url.searchParams.get('channel') === 'true') {
+  return ytHandle(async () => {
+    const accessToken = await requireAccessToken(req)
+    const url = new URL(req.url)
+    const query = parseQuery(url, statsQuerySchema)
+
+    if (query.channel === 'true') {
       return fetchChannelStatistics(accessToken)
     }
 
-    const videoIds = (url.searchParams.get('videoIds') || '')
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
-    return fetchVideoStatistics(accessToken, videoIds)
+    return fetchVideoStatistics(accessToken, query.videoIds)
   })
 }

--- a/src/app/api/youtube/upload/route.ts
+++ b/src/app/api/youtube/upload/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import {
   uploadVideoToYouTube,
   YouTubeError,
@@ -6,28 +8,18 @@ import {
   requireAccessToken,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
+import { uploadFormSchema } from '@/lib/validators/youtube'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-export const maxDuration = 600 // long uploads
+export const maxDuration = 600
 
-/**
- * POST /api/youtube/upload
- *
- * Accepts multipart/form-data with:
- *   - video: File (required)
- *   - title: string
- *   - description: string
- *   - tags: string (comma-separated)
- *   - categoryId?: string
- *   - privacyStatus?: 'public' | 'unlisted' | 'private'
- *   - language?: string
- *
- * Auth: `Authorization: Bearer <google_access_token>` header required.
- */
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return ytHandle(async () => {
-    const accessToken = requireAccessToken(req)
+    const accessToken = await requireAccessToken(req)
     const form = await req.formData()
 
     const video = form.get('video')
@@ -35,30 +27,26 @@ export async function POST(req: Request) {
       throw new YouTubeError(400, 'Missing video file', 'MISSING_VIDEO')
     }
 
-    const title = String(form.get('title') || '')
-    const description = String(form.get('description') || '')
-    const tagsRaw = String(form.get('tags') || '')
-    const tags = tagsRaw
-      ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean)
-      : []
+    const rawFields = {
+      title: String(form.get('title') || ''),
+      description: String(form.get('description') || ''),
+      tags: String(form.get('tags') || ''),
+      categoryId: (form.get('categoryId') as string) || undefined,
+      privacyStatus: (form.get('privacyStatus') as string) || undefined,
+      language: (form.get('language') as string) || undefined,
+    }
 
-    const categoryId = (form.get('categoryId') as string) || undefined
-    const privacyStatus = (form.get('privacyStatus') as
-      | 'public'
-      | 'unlisted'
-      | 'private'
-      | null) || undefined
-    const language = (form.get('language') as string) || undefined
+    const fields = uploadFormSchema.parse(rawFields)
 
     return uploadVideoToYouTube({
       accessToken,
       videoBlob: video,
-      title,
-      description,
-      tags,
-      categoryId,
-      privacyStatus: privacyStatus ?? undefined,
-      language,
+      title: fields.title,
+      description: fields.description,
+      tags: fields.tags,
+      categoryId: fields.categoryId,
+      privacyStatus: fields.privacyStatus,
+      language: fields.language,
     })
   })
 }

--- a/src/app/api/youtube/videos/route.ts
+++ b/src/app/api/youtube/videos/route.ts
@@ -1,21 +1,24 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
 import { fetchMyVideos } from '@/lib/youtube/server'
 import {
   requireAccessToken,
+  parseQuery,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
+import { videosQuerySchema } from '@/lib/validators/youtube'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-/**
- * GET /api/youtube/videos?maxResults=10
- * Returns the authenticated user's most recent uploads.
- */
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
   return ytHandle(async () => {
-    const accessToken = requireAccessToken(req)
+    const accessToken = await requireAccessToken(req)
     const url = new URL(req.url)
-    const maxResults = Number(url.searchParams.get('maxResults') || '10')
+    const { maxResults } = parseQuery(url, videosQuerySchema)
     return fetchMyVideos(accessToken, maxResults)
   })
 }

--- a/src/app/api/youtube/youtube-routes-auth.test.ts
+++ b/src/app/api/youtube/youtube-routes-auth.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+}))
+
+vi.mock('@/lib/youtube/route-helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/youtube/route-helpers')>()
+  return {
+    ...actual,
+    requireAccessToken: vi.fn(async () => 'mock-token'),
+    ytHandle: vi.fn(async (fn: () => Promise<unknown>) => {
+      try {
+        const data = await fn()
+        return Response.json({ ok: true, data })
+      } catch {
+        return Response.json({ ok: false, error: { code: 'ERR', message: 'fail' } }, { status: 500 })
+      }
+    }),
+  }
+})
+
+vi.mock('@/lib/youtube/server', () => ({
+  uploadVideoToYouTube: vi.fn(async () => ({ videoId: 'yt-1' })),
+  uploadCaptionToYouTube: vi.fn(async () => undefined),
+  fetchVideoStatistics: vi.fn(async () => []),
+  fetchChannelStatistics: vi.fn(async () => ({})),
+  fetchMyVideos: vi.fn(async () => []),
+  fetchVideoAnalytics: vi.fn(async () => ({ videoId: 'v1', daily: [], countries: [], totals: {} })),
+  YouTubeError: class extends Error {
+    constructor(public status: number, msg: string, public code = 'ERR') { super(msg) }
+  },
+}))
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: () => ({ execute: vi.fn(async () => ({ rows: [] })) }),
+}))
+
+import { requireSession } from '@/lib/auth/session'
+
+const mockSession = vi.mocked(requireSession)
+
+function mockNoAuth() {
+  mockSession.mockResolvedValueOnce({
+    ok: false,
+    response: Response.json(
+      { ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing token' } },
+      { status: 401 },
+    ),
+  })
+}
+
+function mockAuth(uid = 'user1') {
+  mockSession.mockResolvedValueOnce({
+    ok: true,
+    session: { uid, email: `${uid}@example.com` },
+  })
+}
+
+describe('YouTube API routes — session auth guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const cases: {
+    name: string
+    path: string
+    method: 'GET' | 'POST'
+    importPath: string
+    body?: BodyInit
+    contentType?: string
+  }[] = [
+    { name: 'stats', path: '/api/youtube/stats', method: 'GET', importPath: './stats/route' },
+    { name: 'videos', path: '/api/youtube/videos', method: 'GET', importPath: './videos/route' },
+    {
+      name: 'caption',
+      path: '/api/youtube/caption',
+      method: 'POST',
+      importPath: './caption/route',
+      body: JSON.stringify({ videoId: 'v1', language: 'ko', name: 'Korean', srtContent: 'x' }),
+      contentType: 'application/json',
+    },
+    {
+      name: 'upload',
+      path: '/api/youtube/upload',
+      method: 'POST',
+      importPath: './upload/route',
+    },
+    {
+      name: 'analytics',
+      path: '/api/youtube/analytics',
+      method: 'GET',
+      importPath: './analytics/route',
+    },
+  ]
+
+  for (const tc of cases) {
+    it(`${tc.name} (${tc.method}) → 401 without auth`, async () => {
+      mockNoAuth()
+      const headers: Record<string, string> = {}
+      if (tc.contentType) headers['Content-Type'] = tc.contentType
+      const req = new NextRequest(`http://localhost${tc.path}`, {
+        method: tc.method,
+        ...(tc.body ? { body: tc.body } : {}),
+        headers,
+      })
+      const mod = await import(tc.importPath)
+      const handler = mod[tc.method]
+      const res = await handler(req)
+      expect(res.status).toBe(401)
+    })
+
+    it(`${tc.name} (${tc.method}) → calls handler with valid auth`, async () => {
+      mockAuth()
+      const headers: Record<string, string> = {}
+      if (tc.contentType) headers['Content-Type'] = tc.contentType
+      const req = new NextRequest(`http://localhost${tc.path}`, {
+        method: tc.method,
+        ...(tc.body ? { body: tc.body } : {}),
+        headers,
+      })
+      const mod = await import(tc.importPath)
+      const handler = mod[tc.method]
+      const res = await handler(req)
+      expect(res.status).not.toBe(401)
+    })
+  }
+})

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(async () => ({
+    ok: true,
+    session: { uid: 'user1', email: 'user1@example.com' },
+  })),
+}))
+
+vi.mock('@/lib/youtube/route-helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/youtube/route-helpers')>()
+  return {
+    ...actual,
+    requireAccessToken: vi.fn(async () => 'mock-token'),
+    ytHandle: vi.fn(async (fn: () => Promise<unknown>) => {
+      try {
+        const data = await fn()
+        return Response.json({ ok: true, data })
+      } catch (err) {
+        const code = (err as { code?: string }).code || 'UNKNOWN'
+        const status = (err as { status?: number }).status || 500
+        const message = err instanceof Error ? err.message : 'Unknown'
+        return Response.json(
+          { ok: false, error: { code, message } },
+          { status },
+        )
+      }
+    }),
+    ytOk: vi.fn(),
+    ytFail: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/youtube/server', () => ({
+  uploadVideoToYouTube: vi.fn(async () => ({
+    videoId: 'yt-123',
+    title: 'Test Video',
+    status: 'uploaded',
+  })),
+  uploadCaptionToYouTube: vi.fn(async () => undefined),
+  fetchVideoStatistics: vi.fn(async () => [
+    { videoId: 'v1', viewCount: 100, likeCount: 10, commentCount: 5 },
+  ]),
+  fetchChannelStatistics: vi.fn(async () => ({
+    subscriberCount: 500,
+    viewCount: 10000,
+    videoCount: 20,
+    channelId: 'ch-1',
+    title: 'My Channel',
+    thumbnail: '',
+  })),
+  YouTubeError: class YouTubeError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+      public code = 'YOUTUBE_ERROR',
+    ) {
+      super(message)
+      this.name = 'YouTubeError'
+    }
+  },
+}))
+
+import { requireAccessToken } from '@/lib/youtube/route-helpers'
+import { uploadVideoToYouTube } from '@/lib/youtube/server'
+
+describe('POST /api/youtube/upload', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./upload/route'))
+  })
+
+  it('uploads video and returns videoId', async () => {
+    const videoBlob = new Blob(['fake'], { type: 'video/mp4' })
+    const mockFormData = new Map<string, unknown>([
+      ['video', videoBlob],
+      ['title', 'Test'],
+      ['description', 'Desc'],
+      ['tags', 'a,b'],
+      ['language', 'ko'],
+    ])
+    const req = {
+      url: 'http://localhost/api/youtube/upload',
+      headers: new Headers(),
+      formData: async () => ({ get: (key: string) => mockFormData.get(key) ?? null }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.videoId).toBe('yt-123')
+    expect(uploadVideoToYouTube).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: 'mock-token',
+        title: 'Test',
+        tags: ['a', 'b'],
+      }),
+    )
+  })
+
+  it('handles missing optional fields (no tags, no categoryId, no language)', async () => {
+    const videoBlob = new Blob(['fake'], { type: 'video/mp4' })
+    const mockFormData = new Map<string, unknown>([['video', videoBlob]])
+    const req = {
+      url: 'http://localhost/api/youtube/upload',
+      headers: new Headers(),
+      formData: async () => ({ get: (key: string) => mockFormData.get(key) ?? null }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(uploadVideoToYouTube).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: '',
+        description: '',
+        tags: [],
+        categoryId: undefined,
+        privacyStatus: undefined,
+        language: undefined,
+      }),
+    )
+  })
+
+  it('handles empty tags string', async () => {
+    const videoBlob = new Blob(['fake'], { type: 'video/mp4' })
+    const mockFormData = new Map<string, unknown>([
+      ['video', videoBlob],
+      ['tags', ''],
+    ])
+    const req = {
+      url: 'http://localhost/api/youtube/upload',
+      headers: new Headers(),
+      formData: async () => ({ get: (key: string) => mockFormData.get(key) ?? null }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(uploadVideoToYouTube).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: [] }),
+    )
+  })
+
+  it('returns error when video field missing', async () => {
+    const mockFormData = new Map<string, unknown>([['title', 'No video']])
+    const req = {
+      url: 'http://localhost/api/youtube/upload',
+      headers: new Headers(),
+      formData: async () => ({ get: (key: string) => mockFormData.get(key) ?? null }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('MISSING_VIDEO')
+  })
+})
+
+describe('POST /api/youtube/caption', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./caption/route'))
+  })
+
+  it('uploads caption and returns uploaded: true', async () => {
+    const req = new NextRequest('http://localhost/api/youtube/caption', {
+      method: 'POST',
+      body: JSON.stringify({
+        videoId: 'yt-123',
+        language: 'ko',
+        name: 'Korean',
+        srtContent: '1\n00:00:00,000 --> 00:00:01,000\n안녕\n',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toEqual({ uploaded: true })
+  })
+})
+
+describe('GET /api/youtube/stats', () => {
+  let GET: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ GET } = await import('./stats/route'))
+  })
+
+  it('returns video statistics by videoIds', async () => {
+    const req = new NextRequest('http://localhost/api/youtube/stats?videoIds=v1,v2')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].videoId).toBe('v1')
+  })
+
+  it('returns channel statistics when channel=true', async () => {
+    const req = new NextRequest('http://localhost/api/youtube/stats?channel=true')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.data.channelId).toBe('ch-1')
+  })
+
+  it('returns video statistics with empty videoIds (no channel param)', async () => {
+    const { fetchVideoStatistics } = await import('@/lib/youtube/server')
+    vi.mocked(fetchVideoStatistics).mockResolvedValueOnce([] as never)
+    const req = new NextRequest('http://localhost/api/youtube/stats')
+    const res = await GET(req)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(vi.mocked(fetchVideoStatistics)).toHaveBeenCalledWith('mock-token', [])
+  })
+})
+
+describe('requireAccessToken integration', () => {
+  it('is called by routes to extract token', () => {
+    expect(requireAccessToken).toBeDefined()
+    expect(vi.isMockFunction(requireAccessToken)).toBe(true)
+  })
+})

--- a/src/components/layout/LandingNavBar.tsx
+++ b/src/components/layout/LandingNavBar.tsx
@@ -20,9 +20,8 @@ export function LandingNavBar() {
   const handleGoogleLogin = async () => {
     setLoading(true)
     try {
-      const { user, accessToken } = await signInWithGoogle()
+      const { user } = await signInWithGoogle()
       useAuthStore.getState().setUser(user)
-      useAuthStore.getState().setAccessToken(accessToken)
       router.push('/dashboard')
     } catch (err) {
       addToast({ type: 'error', title: '로그인 실패', message: err instanceof Error ? err.message : '' })

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -11,22 +11,16 @@ import { restoreSession } from '@/lib/firebase'
 function ThemeHydrator() {
   useEffect(() => {
     useThemeStore.persist.rehydrate()
-    const mode = useThemeStore.getState().mode
-    const root = document.documentElement
-    if (mode === 'dark') root.classList.add('dark')
-    else root.classList.remove('dark')
   }, [])
   return null
 }
 
 function AuthHydrator() {
   useEffect(() => {
-    const { user, accessToken } = restoreSession()
+    const { user } = restoreSession()
     const auth = useAuthStore.getState()
     if (user) {
       auth.setUser(user)
-      if (accessToken) auth.setAccessToken(accessToken)
-      // Sync to DB (best-effort)
       fetch('/api/auth/sync', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -35,7 +29,6 @@ function AuthHydrator() {
           email: user.email,
           displayName: user.displayName,
           photoURL: user.photoURL,
-          accessToken,
         }),
       }).catch(() => {})
     } else {

--- a/src/lib/auth/session-cookie.test.ts
+++ b/src/lib/auth/session-cookie.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { signSessionCookie, verifySessionCookie, SESSION_COOKIE } from './session-cookie'
+
+describe('session-cookie', () => {
+  it('exports SESSION_COOKIE constant', () => {
+    expect(SESSION_COOKIE).toBe('creatordub_session')
+  })
+
+  describe('signSessionCookie', () => {
+    it('produces uid.signature format', () => {
+      const signed = signSessionCookie('user123')
+      expect(signed).toMatch(/^user123\.[a-f0-9]{64}$/)
+    })
+
+    it('produces different signatures for different uids', () => {
+      const a = signSessionCookie('alice')
+      const b = signSessionCookie('bob')
+      expect(a.split('.')[1]).not.toBe(b.split('.')[1])
+    })
+
+    it('produces deterministic output', () => {
+      expect(signSessionCookie('uid1')).toBe(signSessionCookie('uid1'))
+    })
+  })
+
+  describe('verifySessionCookie', () => {
+    it('returns uid for valid signed cookie', () => {
+      const signed = signSessionCookie('user123')
+      expect(verifySessionCookie(signed)).toBe('user123')
+    })
+
+    it('returns null for tampered uid', () => {
+      const signed = signSessionCookie('user123')
+      const tampered = 'hacker' + signed.slice(signed.indexOf('.'))
+      expect(verifySessionCookie(tampered)).toBeNull()
+    })
+
+    it('returns null for tampered signature', () => {
+      const signed = signSessionCookie('user123')
+      const tampered = signed.slice(0, -4) + 'dead'
+      expect(verifySessionCookie(tampered)).toBeNull()
+    })
+
+    it('returns null for plain uid (unsigned)', () => {
+      expect(verifySessionCookie('user123')).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(verifySessionCookie('')).toBeNull()
+    })
+
+    it('returns null for just a dot', () => {
+      expect(verifySessionCookie('.')).toBeNull()
+    })
+
+    it('returns null when signature length differs from expected', () => {
+      const signed = signSessionCookie('user123')
+      const truncated = signed.slice(0, -10)
+      expect(verifySessionCookie(truncated)).toBeNull()
+    })
+
+    it('handles uid containing dots', () => {
+      const signed = signSessionCookie('user.with.dots')
+      expect(verifySessionCookie(signed)).toBe('user.with.dots')
+    })
+  })
+
+  describe('SESSION_SECRET env var', () => {
+    const originalEnv = process.env.SESSION_SECRET
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.SESSION_SECRET
+      } else {
+        process.env.SESSION_SECRET = originalEnv
+      }
+    })
+
+    it('uses custom secret when SESSION_SECRET is set', async () => {
+      const defaultSigned = signSessionCookie('uid1')
+
+      process.env.SESSION_SECRET = 'custom-test-secret-32chars-long!!'
+
+      vi.resetModules()
+      const freshMod = await vi.importActual<typeof import('./session-cookie')>('./session-cookie')
+      const customSigned = freshMod.signSessionCookie('uid1')
+
+      expect(customSigned).not.toBe(defaultSigned)
+    })
+
+    it('throws in production when SESSION_SECRET is not set', async () => {
+      delete process.env.SESSION_SECRET
+      vi.stubEnv('NODE_ENV', 'production')
+
+      vi.resetModules()
+      const freshMod = await vi.importActual<typeof import('./session-cookie')>('./session-cookie')
+
+      expect(() => freshMod.signSessionCookie('uid1')).toThrow(
+        'SESSION_SECRET env var is required in production',
+      )
+
+      vi.unstubAllEnvs()
+    })
+  })
+})

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,0 +1,40 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+const SESSION_COOKIE = 'creatordub_session'
+const SEPARATOR = '.'
+
+function getSecret(): string {
+  const secret = process.env.SESSION_SECRET
+  if (secret) return secret
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('SESSION_SECRET env var is required in production')
+  }
+  return 'creatordub-dev-secret-do-not-use-in-prod'
+}
+
+function hmac(data: string): string {
+  return createHmac('sha256', getSecret()).update(data).digest('hex')
+}
+
+export { SESSION_COOKIE }
+
+export function signSessionCookie(uid: string): string {
+  return `${uid}${SEPARATOR}${hmac(uid)}`
+}
+
+export function verifySessionCookie(cookie: string): string | null {
+  const idx = cookie.lastIndexOf(SEPARATOR)
+  if (idx < 1) return null
+
+  const uid = cookie.slice(0, idx)
+  const sig = cookie.slice(idx + 1)
+  const expected = hmac(uid)
+
+  if (sig.length !== expected.length) return null
+
+  const sigBuf = Buffer.from(sig, 'utf8')
+  const expectedBuf = Buffer.from(expected, 'utf8')
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return null
+
+  return uid
+}

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { requireSession, forbiddenUidMismatch } from './session'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeReq(opts?: { cookie?: string; header?: string }): NextRequest {
+  const req = new NextRequest('http://localhost/api/test')
+  if (opts?.cookie) {
+    req.cookies.set('google_access_token', opts.cookie)
+  }
+  if (opts?.header) {
+    return new NextRequest('http://localhost/api/test', {
+      headers: { 'x-google-access-token': opts.header },
+    })
+  }
+  return req
+}
+
+describe('requireSession', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('returns 401 when no access token present', async () => {
+    const req = makeReq()
+    const result = await requireSession(req)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const body = await result.response.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns session on valid Google tokeninfo', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sub: 'uid123',
+        email: 'test@example.com',
+        email_verified: 'true',
+        expires_in: '3600',
+      }),
+    })
+
+    const req = makeReq({ cookie: 'valid-token' })
+    const result = await requireSession(req)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.session).toEqual({ uid: 'uid123', email: 'test@example.com' })
+    }
+  })
+
+  it('returns 401 when Google tokeninfo rejects token', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
+
+    const req = makeReq({ cookie: 'expired-token' })
+    const result = await requireSession(req)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const body = await result.response.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+      expect(body.error.message).toContain('Invalid or expired')
+    }
+  })
+
+  it('returns 401 when tokeninfo lacks sub or email', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sub: '', email: '' }),
+    })
+
+    const req = makeReq({ cookie: 'incomplete-token' })
+    const result = await requireSession(req)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const body = await result.response.json()
+      expect(body.error.code).toBe('UNAUTHORIZED')
+      expect(body.error.message).toContain('missing required claims')
+    }
+  })
+
+  it('returns 500 when fetch throws', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'))
+
+    const req = makeReq({ cookie: 'some-token' })
+    const result = await requireSession(req)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.response.status).toBe(500)
+      const body = await result.response.json()
+      expect(body.error.code).toBe('AUTH_ERROR')
+    }
+  })
+
+  it('reads token from x-google-access-token header', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sub: 'uid456',
+        email: 'header@example.com',
+        email_verified: 'true',
+        expires_in: '3600',
+      }),
+    })
+
+    const req = makeReq({ header: 'header-token' })
+    const result = await requireSession(req)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.session.uid).toBe('uid456')
+    }
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('header-token'),
+    )
+  })
+})
+
+describe('forbiddenUidMismatch', () => {
+  it('returns 403 with FORBIDDEN code', async () => {
+    const res = forbiddenUidMismatch()
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('FORBIDDEN')
+  })
+})

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,70 @@
+import 'server-only'
+
+import { NextRequest } from 'next/server'
+import { apiFail } from '@/lib/api/response'
+
+export interface Session {
+  uid: string
+  email: string
+}
+
+interface GoogleTokenInfo {
+  sub: string
+  email: string
+  email_verified: string
+  expires_in: string
+}
+
+const GOOGLE_TOKENINFO_URL = 'https://www.googleapis.com/oauth2/v3/tokeninfo'
+
+function getAccessToken(req: NextRequest): string | null {
+  return (
+    req.cookies.get('google_access_token')?.value ||
+    req.headers.get('x-google-access-token') ||
+    null
+  )
+}
+
+export async function requireSession(
+  req: NextRequest,
+): Promise<
+  | { ok: true; session: Session }
+  | { ok: false; response: Response }
+> {
+  const token = getAccessToken(req)
+  if (!token) {
+    return {
+      ok: false,
+      response: apiFail('UNAUTHORIZED', 'Missing access token', 401),
+    }
+  }
+
+  try {
+    const res = await fetch(`${GOOGLE_TOKENINFO_URL}?access_token=${encodeURIComponent(token)}`)
+    if (!res.ok) {
+      return {
+        ok: false,
+        response: apiFail('UNAUTHORIZED', 'Invalid or expired access token', 401),
+      }
+    }
+
+    const info = (await res.json()) as GoogleTokenInfo
+    if (!info.sub || !info.email) {
+      return {
+        ok: false,
+        response: apiFail('UNAUTHORIZED', 'Token missing required claims', 401),
+      }
+    }
+
+    return { ok: true, session: { uid: info.sub, email: info.email } }
+  } catch {
+    return {
+      ok: false,
+      response: apiFail('AUTH_ERROR', 'Failed to verify access token', 500),
+    }
+  }
+}
+
+export function forbiddenUidMismatch(): Response {
+  return apiFail('FORBIDDEN', 'UID mismatch: you can only access your own data', 403)
+}

--- a/src/lib/auth/token-refresh.test.ts
+++ b/src/lib/auth/token-refresh.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/db/queries', () => ({
+  getUserTokens: vi.fn(),
+  updateUserTokens: vi.fn(),
+}))
+
+vi.mock('@/lib/env', () => ({
+  getServerEnv: vi.fn(() => ({
+    GOOGLE_CLIENT_SECRET: 'secret',
+    PERSO_API_KEY: 'k',
+    PERSO_API_BASE_URL: 'https://api.perso.ai',
+    TURSO_URL: 'http://localhost',
+    TURSO_AUTH_TOKEN: 'tok',
+  })),
+  getClientEnv: vi.fn(() => ({
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: 'client-id',
+    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://perso.ai',
+  })),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import {
+  isTokenExpired,
+  refreshGoogleToken,
+  getOrRefreshAccessToken,
+} from './token-refresh'
+import { getUserTokens, updateUserTokens } from '@/lib/db/queries'
+import { getServerEnv } from '@/lib/env'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('isTokenExpired', () => {
+  it('returns true for null expiresAt', () => {
+    expect(isTokenExpired(null)).toBe(true)
+  })
+
+  it('returns true for past date', () => {
+    expect(isTokenExpired('2020-01-01T00:00:00.000Z')).toBe(true)
+  })
+
+  it('returns false for future date beyond buffer', () => {
+    const future = new Date(Date.now() + 30 * 60 * 1000).toISOString()
+    expect(isTokenExpired(future)).toBe(false)
+  })
+
+  it('returns true for date within 5-minute buffer', () => {
+    const nearFuture = new Date(Date.now() + 3 * 60 * 1000).toISOString()
+    expect(isTokenExpired(nearFuture)).toBe(true)
+  })
+})
+
+describe('refreshGoogleToken', () => {
+  it('returns null when GOOGLE_CLIENT_SECRET is not set', async () => {
+    vi.mocked(getServerEnv).mockReturnValueOnce({
+      GOOGLE_CLIENT_SECRET: undefined,
+      PERSO_API_KEY: 'k',
+      PERSO_API_BASE_URL: 'https://api.perso.ai',
+      TURSO_URL: 'http://localhost',
+      TURSO_AUTH_TOKEN: 'tok',
+    })
+    const result = await refreshGoogleToken('rt-123')
+    expect(result).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null when Google returns error', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 400 })
+    const result = await refreshGoogleToken('bad-token')
+    expect(result).toBeNull()
+  })
+
+  it('returns new tokens on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'new-at', expires_in: 3600 }),
+    })
+    const result = await refreshGoogleToken('rt-123')
+    expect(result).toEqual({ accessToken: 'new-at', expiresIn: 3600 })
+  })
+})
+
+describe('getOrRefreshAccessToken', () => {
+  it('returns null when user has no tokens', async () => {
+    vi.mocked(getUserTokens).mockResolvedValueOnce(null)
+    const result = await getOrRefreshAccessToken('user-1')
+    expect(result).toBeNull()
+  })
+
+  it('returns existing token when not expired', async () => {
+    const future = new Date(Date.now() + 30 * 60 * 1000).toISOString()
+    vi.mocked(getUserTokens).mockResolvedValueOnce({
+      accessToken: 'valid-at',
+      refreshToken: 'rt',
+      tokenExpiresAt: future,
+    })
+    const result = await getOrRefreshAccessToken('user-1')
+    expect(result).toBe('valid-at')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns existing token when expired but no refresh token', async () => {
+    vi.mocked(getUserTokens).mockResolvedValueOnce({
+      accessToken: 'old-at',
+      refreshToken: null,
+      tokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    const result = await getOrRefreshAccessToken('user-1')
+    expect(result).toBe('old-at')
+  })
+
+  it('refreshes and updates DB when token is expired', async () => {
+    vi.mocked(getUserTokens).mockResolvedValueOnce({
+      accessToken: 'old-at',
+      refreshToken: 'rt-123',
+      tokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'fresh-at', expires_in: 3600 }),
+    })
+
+    const result = await getOrRefreshAccessToken('user-1')
+    expect(result).toBe('fresh-at')
+    expect(updateUserTokens).toHaveBeenCalledWith(
+      'user-1',
+      'fresh-at',
+      expect.stringContaining('T'),
+    )
+  })
+
+  it('falls back to old token when refresh fails', async () => {
+    vi.mocked(getUserTokens).mockResolvedValueOnce({
+      accessToken: 'old-at',
+      refreshToken: 'rt-bad',
+      tokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    })
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
+
+    const result = await getOrRefreshAccessToken('user-1')
+    expect(result).toBe('old-at')
+  })
+})

--- a/src/lib/auth/token-refresh.ts
+++ b/src/lib/auth/token-refresh.ts
@@ -1,0 +1,67 @@
+import 'server-only'
+
+import { getUserTokens, updateUserTokens } from '@/lib/db/queries'
+import { getServerEnv, getClientEnv } from '@/lib/env'
+import { logger } from '@/lib/logger'
+
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+export function isTokenExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return true
+  return Date.now() >= new Date(expiresAt).getTime() - REFRESH_BUFFER_MS
+}
+
+export async function refreshGoogleToken(
+  refreshToken: string,
+): Promise<{ accessToken: string; expiresIn: number } | null> {
+  const serverEnv = getServerEnv()
+  const clientEnv = getClientEnv()
+
+  if (!serverEnv.GOOGLE_CLIENT_SECRET) return null
+
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientEnv.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+      client_secret: serverEnv.GOOGLE_CLIENT_SECRET,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  })
+
+  if (!res.ok) {
+    logger.warn('google token refresh failed', { status: res.status })
+    return null
+  }
+
+  const data = (await res.json()) as {
+    access_token: string
+    expires_in: number
+  }
+  return { accessToken: data.access_token, expiresIn: data.expires_in }
+}
+
+export async function getOrRefreshAccessToken(
+  userId: string,
+): Promise<string | null> {
+  const tokens = await getUserTokens(userId)
+  if (!tokens) return null
+
+  if (tokens.accessToken && !isTokenExpired(tokens.tokenExpiresAt)) {
+    return tokens.accessToken
+  }
+
+  if (!tokens.refreshToken) return tokens.accessToken
+
+  const refreshed = await refreshGoogleToken(tokens.refreshToken)
+  if (!refreshed) return tokens.accessToken
+
+  const expiresAt = new Date(
+    Date.now() + refreshed.expiresIn * 1000,
+  ).toISOString()
+  await updateUserTokens(userId, refreshed.accessToken, expiresAt)
+
+  return refreshed.accessToken
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -11,7 +11,6 @@ export interface GoogleUser {
   photoURL: string | null
 }
 
-const STORAGE_KEY_TOKEN = 'google_access_token'
 const STORAGE_KEY_USER = 'google_user'
 
 export function getStoredUser(): GoogleUser | null {
@@ -24,18 +23,12 @@ export function getStoredUser(): GoogleUser | null {
   }
 }
 
-export function getStoredAccessToken(): string | null {
-  if (typeof window === 'undefined') return null
-  return localStorage.getItem(STORAGE_KEY_TOKEN)
-}
-
 function storeUser(user: GoogleUser) {
   localStorage.setItem(STORAGE_KEY_USER, JSON.stringify(user))
 }
 
 export async function signInWithGoogle(): Promise<{
   user: GoogleUser
-  accessToken: string
 }> {
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
   if (!clientId) throw new Error('NEXT_PUBLIC_GOOGLE_CLIENT_ID를 .env.local에 설정해주세요')
@@ -49,14 +42,16 @@ export async function signInWithGoogle(): Promise<{
       'https://www.googleapis.com/auth/youtube.upload',
       'https://www.googleapis.com/auth/youtube.readonly',
       'https://www.googleapis.com/auth/youtube.force-ssl',
+      'https://www.googleapis.com/auth/yt-analytics.readonly',
     ].join(' ')
 
     const authUrl =
       `https://accounts.google.com/o/oauth2/v2/auth?` +
       `client_id=${encodeURIComponent(clientId)}` +
       `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&response_type=token` +
+      `&response_type=code` +
       `&scope=${encodeURIComponent(scope)}` +
+      `&access_type=offline` +
       `&include_granted_scopes=true` +
       `&prompt=consent`
 
@@ -79,35 +74,50 @@ export async function signInWithGoogle(): Promise<{
           clearInterval(timer)
           popup.close()
 
-          const hash = new URL(url).hash.substring(1)
-          const params = new URLSearchParams(hash)
-          const accessToken = params.get('access_token')
+          const parsedUrl = new URL(url)
+          const code = parsedUrl.searchParams.get('code')
+          const error = parsedUrl.searchParams.get('error')
 
-          if (!accessToken) {
-            reject(new Error('인증 토큰을 받지 못했습니다.'))
+          if (error) {
+            reject(new Error(`Google 인증 오류: ${error}`))
             return
           }
 
-          const res = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
-            headers: { Authorization: `Bearer ${accessToken}` },
-          })
-          if (!res.ok) throw new Error('유저 정보를 가져올 수 없습니다.')
-          const info = await res.json()
-
-          const user: GoogleUser = {
-            uid: info.sub,
-            email: info.email,
-            displayName: info.name || null,
-            photoURL: info.picture || null,
+          if (!code) {
+            reject(new Error('인증 코드를 받지 못했습니다.'))
+            return
           }
 
-          localStorage.setItem(STORAGE_KEY_TOKEN, accessToken)
+          const res = await fetch('/api/auth/callback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code, redirectUri }),
+          })
+
+          if (!res.ok) {
+            const body = await res.json().catch(() => null)
+            throw new Error(body?.error?.message || '인증에 실패했습니다.')
+          }
+
+          const body = await res.json()
+          const data = body.data
+
+          const user: GoogleUser = {
+            uid: data.id,
+            email: data.email,
+            displayName: data.displayName || null,
+            photoURL: data.photoURL || null,
+          }
+
           storeUser(user)
 
-          resolve({ user, accessToken })
+          resolve({ user })
         }
-      } catch {
-        // Cross-origin — popup still on Google's domain, keep waiting
+      } catch (err) {
+        if (err instanceof Error && err.message !== '로그인이 취소되었습니다.') {
+          clearInterval(timer)
+          reject(err)
+        }
       }
     }, 500)
   })
@@ -115,14 +125,11 @@ export async function signInWithGoogle(): Promise<{
 
 export function signOut(): void {
   if (typeof window === 'undefined') return
-  localStorage.removeItem(STORAGE_KEY_TOKEN)
   localStorage.removeItem(STORAGE_KEY_USER)
 }
 
-export function restoreSession(): { user: GoogleUser | null; accessToken: string | null } {
-  const user = getStoredUser()
-  const accessToken = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY_TOKEN) : null
-  return { user, accessToken }
+export function restoreSession(): { user: GoogleUser | null } {
+  return { user: getStoredUser() }
 }
 
 export type User = GoogleUser

--- a/src/lib/perso/route-helpers.test.ts
+++ b/src/lib/perso/route-helpers.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { ok, fail, handle, readJson, parseBody, requireIntParam, requireStringParam } from './route-helpers'
+import { PersoError } from './errors'
+
+describe('ok', () => {
+  it('returns JSON with ok: true envelope', async () => {
+    const res = ok({ count: 5 })
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: { count: 5 } })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('fail', () => {
+  it('maps known PersoError code', async () => {
+    const err = new PersoError('F4004', 'file too big', 400)
+    const res = fail(err)
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('F4004')
+    expect(body.error.details).toBeNull()
+  })
+
+  it('handles unknown PersoError code', async () => {
+    const err = new PersoError('XUNKNOWN', 'something', 422)
+    const res = fail(err)
+    const body = await res.json()
+    expect(res.status).toBe(422)
+    expect(body.error.code).toBe('XUNKNOWN')
+  })
+
+  it('preserves PersoError details', async () => {
+    const err = new PersoError('F4004', 'file too big', 400, { maxSize: 100 })
+    const res = fail(err)
+    const body = await res.json()
+    expect(body.error.details).toEqual({ maxSize: 100 })
+  })
+
+  it('logs and returns 500 for server PersoError', async () => {
+    const err = new PersoError('INTERNAL', 'server broke', 500)
+    const res = fail(err)
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL')
+  })
+
+  it('handles generic Error', async () => {
+    const res = fail(new Error('oops'))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+    expect(body.error.details).toBeNull()
+  })
+
+  it('handles non-Error', async () => {
+    const res = fail('string error')
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('UNKNOWN')
+  })
+})
+
+describe('handle', () => {
+  it('wraps successful return in ok envelope', async () => {
+    const res = await handle(async () => ({ result: 42 }))
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: { result: 42 } })
+  })
+
+  it('wraps thrown error in fail envelope', async () => {
+    const res = await handle(async () => {
+      throw new PersoError('F4008', 'too long', 400)
+    })
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('readJson', () => {
+  it('parses valid JSON body', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ key: 'value' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const result = await readJson<{ key: string }>(req)
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('throws PersoError-like on invalid JSON', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: 'not json',
+    })
+    await expect(readJson(req)).rejects.toThrow('Invalid JSON body')
+  })
+})
+
+describe('parseBody', () => {
+  const schema = z.object({ name: z.string().min(1), age: z.number().int().positive() })
+
+  it('parses valid body and returns typed data', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Alice', age: 30 }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const result = await parseBody(req, schema)
+    expect(result).toEqual({ name: 'Alice', age: 30 })
+  })
+
+  it('throws with INVALID_BODY on schema mismatch', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ name: '', age: -1 }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    try {
+      await parseBody(req, schema)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect((err as Error & { code: string }).code).toBe('INVALID_BODY')
+      expect((err as Error & { status: number }).status).toBe(400)
+      expect((err as Error).message).toContain('name')
+    }
+  })
+
+  it('throws on invalid JSON before schema check', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: 'not json',
+    })
+    await expect(parseBody(req, schema)).rejects.toThrow('Invalid JSON body')
+  })
+
+  it('strips extra fields', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Bob', age: 25, extra: true }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const result = await parseBody(req, schema)
+    expect(result).toEqual({ name: 'Bob', age: 25 })
+  })
+})
+
+describe('requireIntParam', () => {
+  it('returns numeric value', () => {
+    const url = new URL('http://localhost?id=42')
+    expect(requireIntParam(url, 'id')).toBe(42)
+  })
+
+  it('throws on missing param', () => {
+    const url = new URL('http://localhost')
+    expect(() => requireIntParam(url, 'id')).toThrow('Missing required query param: id')
+  })
+
+  it('throws on non-numeric param', () => {
+    const url = new URL('http://localhost?id=abc')
+    expect(() => requireIntParam(url, 'id')).toThrow('Invalid numeric query param: id')
+  })
+})
+
+describe('requireStringParam', () => {
+  it('returns string value', () => {
+    const url = new URL('http://localhost?name=test')
+    expect(requireStringParam(url, 'name')).toBe('test')
+  })
+
+  it('throws on missing param', () => {
+    const url = new URL('http://localhost')
+    expect(() => requireStringParam(url, 'name')).toThrow('Missing required query param: name')
+  })
+
+  it('throws on empty param', () => {
+    const url = new URL('http://localhost?name=')
+    expect(() => requireStringParam(url, 'name')).toThrow('Missing required query param: name')
+  })
+})

--- a/src/lib/perso/route-helpers.ts
+++ b/src/lib/perso/route-helpers.ts
@@ -1,39 +1,33 @@
 import 'server-only'
 
-import { NextResponse } from 'next/server'
-import { mapPersoError } from '@/lib/perso/errors'
+import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
+import { mapPersoError, PersoError } from '@/lib/perso/errors'
+import { logger } from '@/lib/logger'
 
-/** Success response envelope. */
-export function ok<T>(data: T, init?: ResponseInit) {
-  return NextResponse.json({ ok: true as const, data }, init)
-}
+export { apiOk as ok }
 
-/** Error response envelope with mapped HTTP status. */
 export function fail(err: unknown) {
-  const { status, code, message, details } = mapPersoError(err)
-  return NextResponse.json(
-    { ok: false as const, error: { code, message, details } },
-    { status },
-  )
+  if (err instanceof PersoError) {
+    const mapped = mapPersoError(err)
+    if (mapped.status >= 500) {
+      logger.error('perso api error', { status: mapped.status, code: mapped.code, message: mapped.message })
+    }
+    return apiFail(mapped.code, mapped.message, mapped.status, mapped.details)
+  }
+  return apiFailFromError(err)
 }
 
-/** Wraps a route handler body, funneling thrown errors through `fail`. */
 export async function handle<T>(
   fn: () => Promise<T>,
   init?: ResponseInit,
 ): Promise<Response> {
   try {
-    const data = await fn()
-    return ok(data, init)
+    return apiOk(await fn(), init)
   } catch (err) {
     return fail(err)
   }
 }
 
-/**
- * Read and parse JSON body. Throws a 400 PersoError-like error when the
- * body is malformed or missing required fields.
- */
 export async function readJson<T = unknown>(req: Request): Promise<T> {
   try {
     return (await req.json()) as T
@@ -46,11 +40,24 @@ export async function readJson<T = unknown>(req: Request): Promise<T> {
   }
 }
 
-/** Require a numeric query param, throw 400 if missing. */
-export function requireIntParam(
-  url: URL,
-  name: string,
-): number {
+import type { ZodSchema, ZodError } from 'zod'
+
+export async function parseBody<T>(req: Request, schema: ZodSchema<T>): Promise<T> {
+  const raw = await readJson(req)
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    const zodErr = result.error as ZodError
+    const details = zodErr.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    throw Object.assign(new Error(`Invalid body: ${details}`), {
+      name: 'PersoError',
+      code: 'INVALID_BODY',
+      status: 400,
+    })
+  }
+  return result.data
+}
+
+export function requireIntParam(url: URL, name: string): number {
   const raw = url.searchParams.get(name)
   if (raw === null || raw === '') {
     const err = new Error(`Missing required query param: ${name}`)
@@ -68,7 +75,6 @@ export function requireIntParam(
   return n
 }
 
-/** Require a string query param, throw 400 if missing. */
 export function requireStringParam(url: URL, name: string): string {
   const raw = url.searchParams.get(name)
   if (raw === null || raw === '') {

--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const syncBodySchema = z.object({
+  uid: z.string().min(1),
+  email: z.string().email(),
+  displayName: z.string().nullable().optional(),
+  photoURL: z.string().url().nullable().optional(),
+  accessToken: z.string().nullable().optional(),
+})
+
+export const callbackBodySchema = z.object({
+  code: z.string().min(1),
+  redirectUri: z.string().url(),
+})

--- a/src/lib/validators/dashboard.test.ts
+++ b/src/lib/validators/dashboard.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  summaryQuerySchema,
+  jobsQuerySchema,
+  mutationActionSchema,
+} from './dashboard'
+
+describe('summaryQuerySchema', () => {
+  it('accepts valid uid', () => {
+    expect(summaryQuerySchema.parse({ uid: 'user123' })).toEqual({ uid: 'user123' })
+  })
+
+  it('rejects empty uid', () => {
+    expect(() => summaryQuerySchema.parse({ uid: '' })).toThrow()
+  })
+
+  it('rejects missing uid', () => {
+    expect(() => summaryQuerySchema.parse({})).toThrow()
+  })
+})
+
+describe('jobsQuerySchema', () => {
+  it('accepts valid params with default limit', () => {
+    const result = jobsQuerySchema.parse({ uid: 'user123' })
+    expect(result.uid).toBe('user123')
+    expect(result.limit).toBe(10)
+  })
+
+  it('accepts custom limit', () => {
+    const result = jobsQuerySchema.parse({ uid: 'user123', limit: '50' })
+    expect(result.limit).toBe(50)
+  })
+
+  it('rejects limit over 100', () => {
+    expect(() => jobsQuerySchema.parse({ uid: 'u', limit: '200' })).toThrow()
+  })
+})
+
+describe('mutationActionSchema', () => {
+  it('accepts createDubbingJob', () => {
+    const action = {
+      type: 'createDubbingJob',
+      payload: {
+        userId: 'u1',
+        videoTitle: 'Test',
+        videoDurationMs: 60000,
+        videoThumbnail: 'https://img.jpg',
+        sourceLanguage: 'ko',
+        mediaSeq: 1,
+        spaceSeq: 1,
+        lipSyncEnabled: false,
+        isShort: false,
+      },
+    }
+    expect(() => mutationActionSchema.parse(action)).not.toThrow()
+  })
+
+  it('accepts updateJobStatus', () => {
+    const action = {
+      type: 'updateJobStatus',
+      payload: { jobId: 1, status: 'completed' },
+    }
+    expect(() => mutationActionSchema.parse(action)).not.toThrow()
+  })
+
+  it('rejects unknown type', () => {
+    const action = { type: 'unknownAction', payload: {} }
+    expect(() => mutationActionSchema.parse(action)).toThrow()
+  })
+})

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod'
+
+export const summaryQuerySchema = z.object({
+  uid: z.string().min(1),
+})
+
+export const jobsQuerySchema = z.object({
+  uid: z.string().min(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+})
+
+export const creditUsageQuerySchema = z.object({
+  uid: z.string().min(1),
+})
+
+export const languagePerformanceQuerySchema = z.object({
+  uid: z.string().min(1),
+})
+
+const createDubbingJobSchema = z.object({
+  type: z.literal('createDubbingJob'),
+  payload: z.object({
+    userId: z.string().min(1),
+    videoTitle: z.string().min(1),
+    videoDurationMs: z.number().int().nonnegative(),
+    videoThumbnail: z.string(),
+    sourceLanguage: z.string().min(1),
+    mediaSeq: z.number().int(),
+    spaceSeq: z.number().int(),
+    lipSyncEnabled: z.boolean(),
+    isShort: z.boolean(),
+  }),
+})
+
+const createJobLanguagesSchema = z.object({
+  type: z.literal('createJobLanguages'),
+  payload: z.object({
+    jobId: z.number().int(),
+    languages: z.array(z.object({ code: z.string().min(1), projectSeq: z.number().int() })).min(1),
+  }),
+})
+
+const updateJobLanguageProgressSchema = z.object({
+  type: z.literal('updateJobLanguageProgress'),
+  payload: z.object({
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+    status: z.string().min(1),
+    progress: z.number().min(0).max(100),
+    progressReason: z.string(),
+  }),
+})
+
+const updateJobLanguageCompletedSchema = z.object({
+  type: z.literal('updateJobLanguageCompleted'),
+  payload: z.object({
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+    urls: z.object({
+      dubbedVideoUrl: z.string().optional(),
+      audioUrl: z.string().optional(),
+      srtUrl: z.string().optional(),
+    }),
+  }),
+})
+
+const updateJobStatusSchema = z.object({
+  type: z.literal('updateJobStatus'),
+  payload: z.object({
+    jobId: z.number().int(),
+    status: z.string().min(1),
+  }),
+})
+
+const createYouTubeUploadSchema = z.object({
+  type: z.literal('createYouTubeUpload'),
+  payload: z.object({
+    userId: z.string().min(1),
+    jobLanguageId: z.number().int().optional(),
+    youtubeVideoId: z.string().min(1),
+    title: z.string().min(1),
+    languageCode: z.string().min(1),
+    privacyStatus: z.string().min(1),
+    isShort: z.boolean(),
+  }),
+})
+
+const updateJobLanguageYouTubeSchema = z.object({
+  type: z.literal('updateJobLanguageYouTube'),
+  payload: z.object({
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+    youtubeVideoId: z.string().min(1),
+  }),
+})
+
+export const mutationActionSchema = z.discriminatedUnion('type', [
+  createDubbingJobSchema,
+  createJobLanguagesSchema,
+  updateJobLanguageProgressSchema,
+  updateJobLanguageCompletedSchema,
+  updateJobStatusSchema,
+  createYouTubeUploadSchema,
+  updateJobLanguageYouTubeSchema,
+])
+
+export type MutationAction = z.infer<typeof mutationActionSchema>
+
+export function getUserIdFromAction(action: MutationAction): string | null {
+  switch (action.type) {
+    case 'createDubbingJob':
+      return action.payload.userId
+    case 'createYouTubeUpload':
+      return action.payload.userId
+    default:
+      return null
+  }
+}

--- a/src/lib/validators/dubbing.test.ts
+++ b/src/lib/validators/dubbing.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { videoUrlSchema, videoUrlInputSchema } from './dubbing'
+
+describe('videoUrlSchema', () => {
+  it('accepts YouTube URL', () => {
+    expect(() => videoUrlSchema.parse('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).not.toThrow()
+  })
+
+  it('accepts direct mp4 URL', () => {
+    expect(() => videoUrlSchema.parse('https://cdn.example.com/video.mp4')).not.toThrow()
+  })
+
+  it('accepts mp4 URL with query params', () => {
+    expect(() => videoUrlSchema.parse('https://cdn.example.com/video.mp4?token=abc')).not.toThrow()
+  })
+
+  it('rejects empty string', () => {
+    expect(() => videoUrlSchema.parse('')).toThrow()
+  })
+
+  it('rejects non-video URL', () => {
+    expect(() => videoUrlSchema.parse('https://example.com/page.html')).toThrow()
+  })
+
+  it('rejects random text', () => {
+    expect(() => videoUrlSchema.parse('not a url')).toThrow()
+  })
+})
+
+describe('videoUrlInputSchema', () => {
+  it('accepts valid input', () => {
+    const input = {
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      spaceSeq: 1,
+    }
+    const result = videoUrlInputSchema.parse(input)
+    expect(result.lang).toBe('ko')
+  })
+
+  it('rejects invalid spaceSeq', () => {
+    expect(() =>
+      videoUrlInputSchema.parse({
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        spaceSeq: 0,
+      }),
+    ).toThrow()
+  })
+})

--- a/src/lib/validators/dubbing.ts
+++ b/src/lib/validators/dubbing.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+const YOUTUBE_URL_REGEX =
+  /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+
+const DIRECT_VIDEO_URL_REGEX =
+  /^https?:\/\/.+\.(mp4|mov|webm)(\?.*)?$/i
+
+export const videoUrlSchema = z
+  .string()
+  .min(1, '영상 URL을 입력하세요')
+  .refine(
+    (url) => YOUTUBE_URL_REGEX.test(url) || DIRECT_VIDEO_URL_REGEX.test(url),
+    'YouTube URL 또는 .mp4/.mov/.webm 직접 링크를 입력하세요',
+  )
+
+export const videoUrlInputSchema = z.object({
+  url: videoUrlSchema,
+  spaceSeq: z.number().int().positive(),
+  lang: z.string().min(2).default('ko'),
+})

--- a/src/lib/validators/perso.test.ts
+++ b/src/lib/validators/perso.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  externalMetadataBodySchema,
+  externalUploadBodySchema,
+  uploadRegisterBodySchema,
+  mediaValidateBodySchema,
+  translateBodySchema,
+  scriptPatchBodySchema,
+  downloadTargetSchema,
+} from './perso'
+
+describe('externalMetadataBodySchema', () => {
+  it('accepts valid body', () => {
+    const r = externalMetadataBodySchema.safeParse({ spaceSeq: 1, url: 'https://youtube.com/watch?v=abc' })
+    expect(r.success).toBe(true)
+  })
+  it('accepts optional lang', () => {
+    const r = externalMetadataBodySchema.safeParse({ spaceSeq: 1, url: 'https://youtube.com/watch?v=abc', lang: 'en' })
+    expect(r.success).toBe(true)
+  })
+  it('rejects missing spaceSeq', () => {
+    const r = externalMetadataBodySchema.safeParse({ url: 'https://example.com' })
+    expect(r.success).toBe(false)
+  })
+  it('rejects invalid url', () => {
+    const r = externalMetadataBodySchema.safeParse({ spaceSeq: 1, url: 'not-a-url' })
+    expect(r.success).toBe(false)
+  })
+  it('rejects non-positive spaceSeq', () => {
+    const r = externalMetadataBodySchema.safeParse({ spaceSeq: 0, url: 'https://example.com' })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe('externalUploadBodySchema', () => {
+  it('accepts valid body', () => {
+    const r = externalUploadBodySchema.safeParse({ spaceSeq: 1, url: 'https://example.com/v.mp4' })
+    expect(r.success).toBe(true)
+  })
+  it('rejects missing url', () => {
+    const r = externalUploadBodySchema.safeParse({ spaceSeq: 1 })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe('uploadRegisterBodySchema', () => {
+  it('accepts valid body', () => {
+    const r = uploadRegisterBodySchema.safeParse({ spaceSeq: 1, fileUrl: 'https://example.com/f.mp4', fileName: 'f.mp4' })
+    expect(r.success).toBe(true)
+  })
+  it('rejects empty fileName', () => {
+    const r = uploadRegisterBodySchema.safeParse({ spaceSeq: 1, fileUrl: 'https://example.com/f.mp4', fileName: '' })
+    expect(r.success).toBe(false)
+  })
+  it('rejects invalid fileUrl', () => {
+    const r = uploadRegisterBodySchema.safeParse({ spaceSeq: 1, fileUrl: 'bad', fileName: 'f.mp4' })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe('mediaValidateBodySchema', () => {
+  const valid = {
+    spaceSeq: 1, durationMs: 5000, originalName: 'test.mp4',
+    mediaType: 'video', extension: 'mp4', size: 1000, width: 1920, height: 1080,
+  }
+  it('accepts valid body', () => {
+    expect(mediaValidateBodySchema.safeParse(valid).success).toBe(true)
+  })
+  it('rejects missing field', () => {
+    const { width: _w, ...missing } = valid
+    void _w
+    expect(mediaValidateBodySchema.safeParse(missing).success).toBe(false)
+  })
+  it('rejects negative size', () => {
+    expect(mediaValidateBodySchema.safeParse({ ...valid, size: -1 }).success).toBe(false)
+  })
+})
+
+describe('translateBodySchema', () => {
+  const valid = {
+    mediaSeq: 1, isVideoProject: true, sourceLanguageCode: 'ko',
+    targetLanguageCodes: ['en'], numberOfSpeakers: 1, preferredSpeedType: 'GREEN' as const,
+  }
+  it('accepts valid body', () => {
+    expect(translateBodySchema.safeParse(valid).success).toBe(true)
+  })
+  it('accepts optional fields', () => {
+    expect(translateBodySchema.safeParse({ ...valid, withLipSync: true, srtBlobPath: '/p' }).success).toBe(true)
+  })
+  it('rejects empty targetLanguageCodes', () => {
+    expect(translateBodySchema.safeParse({ ...valid, targetLanguageCodes: [] }).success).toBe(false)
+  })
+  it('rejects invalid preferredSpeedType', () => {
+    expect(translateBodySchema.safeParse({ ...valid, preferredSpeedType: 'BLUE' }).success).toBe(false)
+  })
+})
+
+describe('scriptPatchBodySchema', () => {
+  it('accepts valid body', () => {
+    expect(scriptPatchBodySchema.safeParse({ translatedText: 'hello' }).success).toBe(true)
+  })
+  it('rejects empty translatedText', () => {
+    expect(scriptPatchBodySchema.safeParse({ translatedText: '' }).success).toBe(false)
+  })
+  it('rejects missing field', () => {
+    expect(scriptPatchBodySchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('downloadTargetSchema', () => {
+  it.each([
+    'video', 'dubbingVideo', 'lipSyncVideo', 'originalSubtitle',
+    'translatedSubtitle', 'voiceAudio', 'backgroundAudio', 'all',
+  ])('accepts "%s"', (target) => {
+    expect(downloadTargetSchema.safeParse(target).success).toBe(true)
+  })
+  it('rejects invalid target', () => {
+    expect(downloadTargetSchema.safeParse('invalid').success).toBe(false)
+  })
+})

--- a/src/lib/validators/perso.ts
+++ b/src/lib/validators/perso.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+
+export const externalMetadataBodySchema = z.object({
+  spaceSeq: z.number().int().positive(),
+  url: z.string().url(),
+  lang: z.string().min(1).optional(),
+})
+
+export const externalUploadBodySchema = z.object({
+  spaceSeq: z.number().int().positive(),
+  url: z.string().url(),
+  lang: z.string().min(1).optional(),
+})
+
+export const uploadRegisterBodySchema = z.object({
+  spaceSeq: z.number().int().positive(),
+  fileUrl: z.string().url(),
+  fileName: z.string().min(1),
+})
+
+export const mediaValidateBodySchema = z.object({
+  spaceSeq: z.number().int().positive(),
+  durationMs: z.number().nonnegative(),
+  originalName: z.string().min(1),
+  mediaType: z.string().min(1),
+  extension: z.string().min(1),
+  size: z.number().nonnegative(),
+  width: z.number().nonnegative(),
+  height: z.number().nonnegative(),
+})
+
+export const translateBodySchema = z.object({
+  mediaSeq: z.number().int().positive(),
+  isVideoProject: z.boolean(),
+  sourceLanguageCode: z.string().min(1),
+  targetLanguageCodes: z.array(z.string().min(1)).min(1),
+  numberOfSpeakers: z.number().int().positive(),
+  withLipSync: z.boolean().optional(),
+  preferredSpeedType: z.enum(['GREEN', 'RED']),
+  customDictionaryBlobPath: z.string().optional(),
+  srtBlobPath: z.string().optional(),
+})
+
+export const scriptPatchBodySchema = z.object({
+  translatedText: z.string().min(1),
+})
+
+export const downloadTargetSchema = z.enum([
+  'video',
+  'dubbingVideo',
+  'lipSyncVideo',
+  'originalSubtitle',
+  'translatedSubtitle',
+  'voiceAudio',
+  'backgroundAudio',
+  'all',
+])

--- a/src/lib/validators/youtube.test.ts
+++ b/src/lib/validators/youtube.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  captionBodySchema,
+  analyticsQuerySchema,
+  statsQuerySchema,
+  videosQuerySchema,
+  uploadFormSchema,
+} from './youtube'
+
+describe('captionBodySchema', () => {
+  it('accepts valid body', () => {
+    const result = captionBodySchema.safeParse({
+      videoId: 'yt-123',
+      language: 'ko',
+      name: 'Korean',
+      srtContent: '1\n00:00:00,000 --> 00:00:01,000\nHello\n',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing videoId', () => {
+    const result = captionBodySchema.safeParse({
+      language: 'ko',
+      name: 'Korean',
+      srtContent: 'content',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty srtContent', () => {
+    const result = captionBodySchema.safeParse({
+      videoId: 'yt-123',
+      language: 'ko',
+      name: 'Korean',
+      srtContent: '',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('analyticsQuerySchema', () => {
+  it('parses videoIds and transforms to array', () => {
+    const result = analyticsQuerySchema.parse({ videoIds: 'v1,v2,v3' })
+    expect(result.videoIds).toEqual(['v1', 'v2', 'v3'])
+  })
+
+  it('accepts optional date range', () => {
+    const result = analyticsQuerySchema.parse({
+      videoIds: 'v1',
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+    })
+    expect(result.startDate).toBe('2026-01-01')
+    expect(result.endDate).toBe('2026-01-31')
+  })
+
+  it('rejects invalid date format', () => {
+    const result = analyticsQuerySchema.safeParse({
+      videoIds: 'v1',
+      startDate: 'January 1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('filters empty strings from videoIds', () => {
+    const result = analyticsQuerySchema.parse({ videoIds: 'v1,,v2,' })
+    expect(result.videoIds).toEqual(['v1', 'v2'])
+  })
+})
+
+describe('statsQuerySchema', () => {
+  it('parses channel=true', () => {
+    const result = statsQuerySchema.parse({ channel: 'true' })
+    expect(result.channel).toBe('true')
+  })
+
+  it('parses videoIds string', () => {
+    const result = statsQuerySchema.parse({ videoIds: 'v1,v2' })
+    expect(result.videoIds).toEqual(['v1', 'v2'])
+  })
+
+  it('defaults to empty videoIds', () => {
+    const result = statsQuerySchema.parse({})
+    expect(result.videoIds).toEqual([])
+  })
+})
+
+describe('videosQuerySchema', () => {
+  it('defaults maxResults to 10', () => {
+    const result = videosQuerySchema.parse({})
+    expect(result.maxResults).toBe(10)
+  })
+
+  it('parses string maxResults to number', () => {
+    const result = videosQuerySchema.parse({ maxResults: '25' })
+    expect(result.maxResults).toBe(25)
+  })
+
+  it('rejects maxResults > 50', () => {
+    const result = videosQuerySchema.safeParse({ maxResults: '100' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects maxResults < 1', () => {
+    const result = videosQuerySchema.safeParse({ maxResults: '0' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-integer maxResults', () => {
+    const result = videosQuerySchema.safeParse({ maxResults: '2.5' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('uploadFormSchema', () => {
+  it('accepts all fields', () => {
+    const result = uploadFormSchema.parse({
+      title: 'My Video',
+      description: 'A test',
+      tags: 'a,b,c',
+      categoryId: '22',
+      privacyStatus: 'unlisted',
+      language: 'ko',
+    })
+    expect(result.title).toBe('My Video')
+    expect(result.tags).toEqual(['a', 'b', 'c'])
+    expect(result.privacyStatus).toBe('unlisted')
+  })
+
+  it('defaults title and description to empty', () => {
+    const result = uploadFormSchema.parse({})
+    expect(result.title).toBe('')
+    expect(result.description).toBe('')
+    expect(result.tags).toEqual([])
+  })
+
+  it('rejects invalid privacyStatus', () => {
+    const result = uploadFormSchema.safeParse({ privacyStatus: 'secret' })
+    expect(result.success).toBe(false)
+  })
+
+  it('handles empty tags string', () => {
+    const result = uploadFormSchema.parse({ tags: '' })
+    expect(result.tags).toEqual([])
+  })
+})

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+export const captionBodySchema = z.object({
+  videoId: z.string().min(1),
+  language: z.string().min(1),
+  name: z.string().min(1),
+  srtContent: z.string().min(1),
+})
+
+export const analyticsQuerySchema = z.object({
+  videoIds: z
+    .string()
+    .min(1)
+    .transform((v) => v.split(',').map((s) => s.trim()).filter(Boolean)),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+})
+
+export const statsQuerySchema = z.object({
+  channel: z.string().optional(),
+  videoIds: z
+    .string()
+    .default('')
+    .transform((v) => v.split(',').map((s) => s.trim()).filter(Boolean)),
+})
+
+export const videosQuerySchema = z.object({
+  maxResults: z
+    .string()
+    .default('10')
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(50)),
+})
+
+export const uploadFormSchema = z.object({
+  title: z.string().default(''),
+  description: z.string().default(''),
+  tags: z
+    .string()
+    .default('')
+    .transform((v) => (v ? v.split(',').map((t) => t.trim()).filter(Boolean) : [])),
+  categoryId: z.string().optional(),
+  privacyStatus: z.enum(['public', 'unlisted', 'private']).optional(),
+  language: z.string().optional(),
+})

--- a/src/lib/youtube/route-helpers.test.ts
+++ b/src/lib/youtube/route-helpers.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { cookies } from 'next/headers'
+import { ytOk, ytFail, ytHandle, requireAccessToken, parseQuery, parseYtBody } from './route-helpers'
+import { YouTubeError } from './server'
+
+describe('ytOk', () => {
+  it('returns JSON with ok: true envelope', async () => {
+    const res = ytOk({ videoId: 'abc' })
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: { videoId: 'abc' } })
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts custom ResponseInit', async () => {
+    const res = ytOk('created', { status: 201 })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: 'created' })
+  })
+})
+
+describe('ytFail', () => {
+  it('maps YouTubeError with code and status', async () => {
+    const err = new YouTubeError(403, 'Quota exceeded', 'QUOTA_EXCEEDED')
+    const res = ytFail(err)
+    const body = await res.json()
+    expect(res.status).toBe(403)
+    expect(body).toEqual({
+      ok: false,
+      error: { code: 'QUOTA_EXCEEDED', message: 'Quota exceeded', details: null },
+    })
+  })
+
+  it('defaults YouTubeError status to 500 when falsy', async () => {
+    const err = new YouTubeError(0, 'No status', 'NO_STATUS')
+    const res = ytFail(err)
+    expect(res.status).toBe(500)
+  })
+
+  it('handles generic Error', async () => {
+    const res = ytFail(new Error('something broke'))
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toEqual({ code: 'INTERNAL_ERROR', message: 'something broke', details: null })
+  })
+
+  it('handles non-Error values', async () => {
+    const res = ytFail('string error')
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error).toEqual({ code: 'UNKNOWN', message: 'Internal Server Error', details: null })
+  })
+})
+
+describe('ytHandle', () => {
+  it('wraps successful return in ytOk envelope', async () => {
+    const res = await ytHandle(async () => ({ count: 5 }))
+    const body = await res.json()
+    expect(body).toEqual({ ok: true, data: { count: 5 } })
+  })
+
+  it('wraps thrown YouTubeError in ytFail envelope', async () => {
+    const res = await ytHandle(async () => {
+      throw new YouTubeError(404, 'Not found', 'NOT_FOUND')
+    })
+    const body = await res.json()
+    expect(res.status).toBe(404)
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('NOT_FOUND')
+  })
+
+  it('wraps thrown generic Error in ytFail envelope', async () => {
+    const res = await ytHandle(async () => {
+      throw new Error('unexpected')
+    })
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+  })
+})
+
+describe('parseQuery', () => {
+  const schema = z.object({
+    id: z.string().min(1),
+    count: z.string().default('5').transform(Number).pipe(z.number().int()),
+  })
+
+  it('parses valid query params', () => {
+    const url = new URL('http://localhost?id=abc&count=10')
+    const result = parseQuery(url, schema)
+    expect(result).toEqual({ id: 'abc', count: 10 })
+  })
+
+  it('applies defaults for missing optional params', () => {
+    const url = new URL('http://localhost?id=abc')
+    const result = parseQuery(url, schema)
+    expect(result).toEqual({ id: 'abc', count: 5 })
+  })
+
+  it('throws YouTubeError(400) for invalid params', () => {
+    const url = new URL('http://localhost')
+    expect(() => parseQuery(url, schema)).toThrow(YouTubeError)
+    try {
+      parseQuery(url, schema)
+    } catch (e) {
+      expect((e as YouTubeError).status).toBe(400)
+      expect((e as YouTubeError).code).toBe('INVALID_QUERY')
+    }
+  })
+})
+
+describe('parseYtBody', () => {
+  const schema = z.object({ name: z.string().min(1) })
+
+  it('parses valid JSON body', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'test' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const result = await parseYtBody(req, schema)
+    expect(result).toEqual({ name: 'test' })
+  })
+
+  it('throws YouTubeError(400) for invalid JSON', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: 'not json',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    await expect(parseYtBody(req, schema)).rejects.toThrow(YouTubeError)
+    const req2 = new Request('http://localhost', {
+      method: 'POST',
+      body: 'not json',
+    })
+    try {
+      await parseYtBody(req2, schema)
+    } catch (e) {
+      expect((e as YouTubeError).status).toBe(400)
+      expect((e as YouTubeError).code).toBe('INVALID_BODY')
+    }
+  })
+
+  it('throws YouTubeError(400) for schema violation', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ name: '' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    try {
+      await parseYtBody(req, schema)
+    } catch (e) {
+      expect((e as YouTubeError).status).toBe(400)
+      expect((e as YouTubeError).code).toBe('INVALID_BODY')
+      expect((e as YouTubeError).message).toContain('Invalid body')
+    }
+  })
+})
+
+describe('requireAccessToken', () => {
+  it('returns token from httpOnly cookie', async () => {
+    vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn((name: string) =>
+        name === 'google_access_token' ? { name, value: 'cookie-token' } : undefined,
+      ),
+    } as never)
+
+    const req = new Request('http://localhost')
+    const token = await requireAccessToken(req)
+    expect(token).toBe('cookie-token')
+  })
+
+  it('returns token from Authorization bearer header', async () => {
+    vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn(() => undefined),
+    } as never)
+
+    const req = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer header-token' },
+    })
+    const token = await requireAccessToken(req)
+    expect(token).toBe('header-token')
+  })
+
+  it('returns token from x-google-access-token header', async () => {
+    vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn(() => undefined),
+    } as never)
+
+    const req = new Request('http://localhost', {
+      headers: { 'x-google-access-token': 'custom-token' },
+    })
+    const token = await requireAccessToken(req)
+    expect(token).toBe('custom-token')
+  })
+
+  it('throws YouTubeError(401) when no token found', async () => {
+    vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn(() => undefined),
+    } as never)
+
+    const req = new Request('http://localhost')
+    await expect(requireAccessToken(req)).rejects.toThrow(YouTubeError)
+    await vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn(() => undefined),
+    } as never)
+    try {
+      await requireAccessToken(req)
+    } catch (e) {
+      expect(e).toBeInstanceOf(YouTubeError)
+      expect((e as YouTubeError).status).toBe(401)
+      expect((e as YouTubeError).code).toBe('MISSING_ACCESS_TOKEN')
+    }
+  })
+})

--- a/src/lib/youtube/route-helpers.ts
+++ b/src/lib/youtube/route-helpers.ts
@@ -1,39 +1,80 @@
 import 'server-only'
 
-import { NextResponse } from 'next/server'
+import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
 import { YouTubeError } from '@/lib/youtube/server'
+import { logger } from '@/lib/logger'
 
-export function ytOk<T>(data: T, init?: ResponseInit) {
-  return NextResponse.json({ ok: true as const, data }, init)
-}
+export { apiOk as ytOk }
 
 export function ytFail(err: unknown) {
   if (err instanceof YouTubeError) {
-    return NextResponse.json(
-      { ok: false as const, error: { code: err.code, message: err.message } },
-      { status: err.status || 500 },
-    )
+    const status = err.status || 500
+    if (status >= 500) {
+      logger.error('youtube api error', { status, code: err.code, message: err.message })
+    }
+    return apiFail(err.code, err.message, status)
   }
-  const message = err instanceof Error ? err.message : 'Unknown YouTube error'
-  return NextResponse.json(
-    { ok: false as const, error: { code: 'UNKNOWN', message } },
-    { status: 500 },
-  )
+  return apiFailFromError(err)
 }
 
 export async function ytHandle<T>(fn: () => Promise<T>): Promise<Response> {
   try {
-    return ytOk(await fn())
+    return apiOk(await fn())
   } catch (err) {
     return ytFail(err)
   }
 }
 
-/**
- * Extract access token from either the Authorization header or a custom
- * `x-google-access-token` header. Throws YouTubeError(401) if missing.
- */
-export function requireAccessToken(req: Request): string {
+import type { ZodSchema, ZodError } from 'zod'
+
+export function parseQuery<T>(url: URL, schema: ZodSchema<T>): T {
+  const raw = Object.fromEntries(url.searchParams.entries())
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    const zodErr = result.error as ZodError
+    const details = zodErr.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    throw new YouTubeError(400, `Invalid query: ${details}`, 'INVALID_QUERY')
+  }
+  return result.data
+}
+
+export async function parseYtBody<T>(req: Request, schema: ZodSchema<T>): Promise<T> {
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    throw new YouTubeError(400, 'Invalid JSON body', 'INVALID_BODY')
+  }
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    const zodErr = result.error as ZodError
+    const details = zodErr.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    throw new YouTubeError(400, `Invalid body: ${details}`, 'INVALID_BODY')
+  }
+  return result.data
+}
+
+import { cookies } from 'next/headers'
+import { verifySessionCookie } from '@/lib/auth/session-cookie'
+import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
+
+export async function requireAccessToken(req: Request): Promise<string> {
+  const cookieStore = await cookies()
+  const cookieToken = cookieStore.get('google_access_token')?.value
+
+  if (!cookieToken) {
+    const sessionCookie = cookieStore.get('creatordub_session')?.value
+    if (sessionCookie) {
+      const uid = verifySessionCookie(sessionCookie)
+      if (uid) {
+        const refreshed = await getOrRefreshAccessToken(uid)
+        if (refreshed) return refreshed
+      }
+    }
+  }
+
+  if (cookieToken) return cookieToken
+
   const auth = req.headers.get('authorization') || ''
   if (auth.toLowerCase().startsWith('bearer ')) {
     return auth.slice(7).trim()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { SESSION_COOKIE, verifySessionCookie } from '@/lib/auth/session-cookie'
+
+export function proxy(request: NextRequest) {
+  const raw = request.cookies.get(SESSION_COOKIE)?.value
+  if (!raw || !verifySessionCookie(raw)) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    '/dashboard/:path*',
+    '/dubbing/:path*',
+    '/batch/:path*',
+    '/youtube/:path*',
+    '/billing/:path*',
+    '/settings/:path*',
+  ],
+}

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAuthStore } from './authStore'
+
+describe('authStore', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      isLoading: true,
+      isAuthenticated: false,
+    })
+  })
+
+  it('starts with null user and loading state', () => {
+    const state = useAuthStore.getState()
+    expect(state.user).toBeNull()
+    expect(state.isLoading).toBe(true)
+    expect(state.isAuthenticated).toBe(false)
+  })
+
+  it('setUser marks authenticated and stops loading', () => {
+    const mockUser = { uid: 'u1', displayName: 'Test', email: 'test@test.com', photoURL: null } as never
+    useAuthStore.getState().setUser(mockUser)
+
+    const state = useAuthStore.getState()
+    expect(state.user).toBe(mockUser)
+    expect(state.isAuthenticated).toBe(true)
+    expect(state.isLoading).toBe(false)
+  })
+
+  it('setUser(null) clears authentication', () => {
+    useAuthStore.getState().setUser({ uid: 'u1' } as never)
+    useAuthStore.getState().setUser(null)
+
+    const state = useAuthStore.getState()
+    expect(state.user).toBeNull()
+    expect(state.isAuthenticated).toBe(false)
+  })
+
+  it('clear resets all state', () => {
+    useAuthStore.getState().setUser({ uid: 'u1' } as never)
+    useAuthStore.getState().clear()
+
+    const state = useAuthStore.getState()
+    expect(state.user).toBeNull()
+    expect(state.isAuthenticated).toBe(false)
+    expect(state.isLoading).toBe(false)
+  })
+
+  it('setLoading updates loading state', () => {
+    useAuthStore.getState().setLoading(false)
+    expect(useAuthStore.getState().isLoading).toBe(false)
+  })
+})

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,18 +5,15 @@ import type { GoogleUser } from '@/lib/firebase'
 
 interface AuthState {
   user: GoogleUser | null
-  accessToken: string | null
   isLoading: boolean
   isAuthenticated: boolean
   setUser: (user: GoogleUser | null) => void
-  setAccessToken: (token: string | null) => void
   setLoading: (loading: boolean) => void
   clear: () => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
-  accessToken: null,
   isLoading: true,
   isAuthenticated: false,
 
@@ -27,19 +24,11 @@ export const useAuthStore = create<AuthState>((set) => ({
       isLoading: false,
     }),
 
-  setAccessToken: (token) => {
-    if (typeof window !== 'undefined' && token) {
-      localStorage.setItem('google_access_token', token)
-    }
-    set({ accessToken: token })
-  },
-
   setLoading: (loading) => set({ isLoading: loading }),
 
   clear: () => {
     set({
       user: null,
-      accessToken: null,
       isAuthenticated: false,
       isLoading: false,
     })

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => Promise.resolve({ get: vi.fn() })),
+  headers: vi.fn(() => new Map()),
+}))

--- a/tests/helpers/signed-cookie.ts
+++ b/tests/helpers/signed-cookie.ts
@@ -1,0 +1,9 @@
+import { createHmac } from 'node:crypto'
+
+const DEV_SECRET = 'creatordub-dev-secret-do-not-use-in-prod'
+
+export function signTestSessionCookie(uid: string): string {
+  const secret = process.env.SESSION_SECRET || DEV_SECRET
+  const sig = createHmac('sha256', secret).update(uid).digest('hex')
+  return `${uid}.${sig}`
+}


### PR DESCRIPTION
## 관련 이슈
Closes #1

## 변경 요약
- **`requireSession()`** — HMAC-SHA256 서명 쿠키 기반 세션 검증 미들웨어
- **`proxy.ts`** — Next 16 middleware로 `(app)` 경로 서버사이드 auth guard
- **`(app)/layout.tsx`** — `'use client'` 플리커 방지 → 서버 컴포넌트 전환
- **Auth Code Flow** — `/api/auth/callback` 신설, code exchange → DB 저장 → httpOnly 쿠키 발급
- **토큰 갱신** — `token-refresh.ts`: 만료 확인 + refresh_token 자동 재발급
- **localStorage 제거** — `authStore.accessToken` 및 `setAccessToken` localStorage 호출 삭제
- **전 API 라우트 인가** — `/api/dashboard/*` (uid 세션 대조), `/api/perso/*` (16개), `/api/youtube/*` (5개)
- **zod 검증** — dashboard/perso/youtube/auth 모든 라우트 입력값 검증
- **보안 헤더** — `next.config.ts`에 HSTS, X-Frame-Options, CSP, Referrer-Policy 추가
- **의존성** — `axios`, `firebase` 미사용 패키지 제거

## 테스트
- 신규 테스트: auth-callback (8), auth-signout (4), auth-sync (7), dashboard-routes (18), perso-routes-auth (34), perso-zod-validation (9), youtube-routes (6), youtube-routes-auth (10), youtube-zod-validation (17), session (6), session-cookie (12), token-refresh (12), authStore (4)

## 체크리스트
- [x] 세션 없이 API 호출 → 401
- [x] 다른 uid로 dashboard 조회 → 403
- [x] localStorage에 토큰 없음
- [x] `npm run lint` 0 errors
- [x] `npx tsc --noEmit` 0 errors