### PR TITLE
perf: bundle optimization, next/image, server prefetch, dashboard UX (#2)

### DIFF
--- a/src/app/(app)/batch/layout.tsx
+++ b/src/app/(app)/batch/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '배치 큐',
+}
+
+export default function BatchLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/(app)/billing/layout.tsx
+++ b/src/app/(app)/billing/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '결제',
+}
+
+export default function BillingLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '대시보드',
+}
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,58 @@
+import { Card } from '@/components/ui'
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-surface-200 dark:bg-surface-700 ${className ?? ''}`} />
+}
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="mt-2 h-5 w-64" />
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="mt-3 h-8 w-24" />
+            <Skeleton className="mt-2 h-3 w-32" />
+          </Card>
+        ))}
+      </div>
+
+      {/* Quick start */}
+      <Card>
+        <Skeleton className="h-6 w-28" />
+        <div className="mt-4 flex gap-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-32" />
+        </div>
+      </Card>
+
+      {/* Charts */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="mt-4 h-64" />
+        </Card>
+        <Card>
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="mt-4 h-64" />
+        </Card>
+      </div>
+
+      {/* Recent jobs */}
+      <Card>
+        <Skeleton className="h-6 w-28" />
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16" />
+          ))}
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,28 +1,36 @@
-'use client'
+import { cookies } from 'next/headers'
+import { getUserSummary, getUserDubbingJobs, getCreditUsageByMonth, getUserYouTubeUploads } from '@/lib/db/queries'
+import { DashboardContent } from '@/features/dashboard/components/DashboardContent'
+import { verifySessionCookie } from '@/lib/auth/session-cookie'
 
-import { DashboardSummary } from '@/features/dashboard/components/DashboardSummary'
-import { QuickStart } from '@/features/dashboard/components/QuickStart'
-import { RecentJobs } from '@/features/dashboard/components/RecentJobs'
-import { CreditChart } from '@/features/dashboard/components/CreditChart'
-import { LanguagePerformance } from '@/features/dashboard/components/LanguagePerformance'
+export default async function DashboardPage() {
+  const cookieStore = await cookies()
+  const raw = cookieStore.get('creatordub_session')?.value
+  const uid = raw ? verifySessionCookie(raw) : null
 
-export default function DashboardPage() {
+  if (!uid) {
+    return null
+  }
+
+  const [summary, jobs, creditUsage, ytUploads] = await Promise.all([
+    getUserSummary(uid),
+    getUserDubbingJobs(uid, 10),
+    getCreditUsageByMonth(uid),
+    getUserYouTubeUploads(uid),
+  ])
+
+  const ytVideoIds = ytUploads
+    .map((u) => u.youtube_video_id)
+    .filter(Boolean)
+
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">대시보드</h1>
-        <p className="text-surface-500 dark:text-surface-400">돌아오신 것을 환영합니다! 더빙 현황을 확인하세요.</p>
-      </div>
-
-      <DashboardSummary />
-      <QuickStart />
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        <CreditChart />
-        <LanguagePerformance />
-      </div>
-
-      <RecentJobs />
-    </div>
+    <DashboardContent
+      initial={{
+        summary,
+        jobs,
+        creditUsage,
+        ytVideoIds,
+      }}
+    />
   )
 }

--- a/src/app/(app)/dubbing/layout.tsx
+++ b/src/app/(app)/dubbing/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '새 더빙',
+}
+
+export default function DubbingLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/(app)/youtube/layout.tsx
+++ b/src/app/(app)/youtube/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'YouTube 설정',
+}
+
+export default function YouTubeLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { Moon, Sun, Bell, LogOut } from 'lucide-react'
 import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
@@ -12,9 +13,10 @@ export function Topbar() {
   const { user, clear } = useAuthStore()
   const router = useRouter()
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
     signOut()
     clear()
+    await fetch('/api/auth/signout', { method: 'POST' }).catch(() => {})
     router.push('/')
   }
 
@@ -39,10 +41,12 @@ export function Topbar() {
               <p className="text-xs text-surface-400 leading-tight">{user.email}</p>
             </div>
             {user.photoURL ? (
-              <img
+              <Image
                 src={user.photoURL}
                 alt={user.displayName || ''}
-                className="h-8 w-8 rounded-full object-cover"
+                width={32}
+                height={32}
+                className="rounded-full object-cover"
                 referrerPolicy="no-referrer"
               />
             ) : (

--- a/src/features/dashboard/components/CreditChart.tsx
+++ b/src/features/dashboard/components/CreditChart.tsx
@@ -3,6 +3,7 @@
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import { Card, CardTitle } from '@/components/ui'
 import { useCreditUsage } from '@/hooks/useDashboardData'
+import type { CreditUsageRow } from './types'
 
 // Fallback data when DB has no data yet
 const fallbackData = [
@@ -12,12 +13,16 @@ const fallbackData = [
   { month: '2026-04', used: 0 },
 ]
 
-export function CreditChart() {
-  const { data: rawData } = useCreditUsage()
+interface CreditChartProps {
+  initialData?: CreditUsageRow[]
+}
+
+export function CreditChart({ initialData }: CreditChartProps) {
+  const { data: rawData } = useCreditUsage(initialData)
 
   const chartData = rawData && rawData.length > 0
     ? rawData.map((r) => ({
-        month: (r.month as string).slice(5), // "2026-04" → "04"
+        month: r.month.slice(5),
         used: Number(r.minutes_used) || 0,
       })).reverse()
     : fallbackData.map((d) => ({ month: d.month.slice(5), used: d.used }))

--- a/src/features/dashboard/components/DashboardContent.tsx
+++ b/src/features/dashboard/components/DashboardContent.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { DashboardSummary } from './DashboardSummary'
+import { QuickStart } from './QuickStart'
+import { RecentJobs } from './RecentJobs'
+import { Card } from '@/components/ui'
+import type { DashboardInitialData } from './types'
+
+function ChartSkeleton() {
+  return (
+    <Card>
+      <div className="h-8 w-32 animate-pulse rounded bg-surface-200 dark:bg-surface-700" />
+      <div className="mt-2 h-4 w-48 animate-pulse rounded bg-surface-100 dark:bg-surface-800" />
+      <div className="mt-4 h-64 animate-pulse rounded bg-surface-100 dark:bg-surface-800" />
+    </Card>
+  )
+}
+
+const CreditChart = dynamic(
+  () => import('./CreditChart').then((m) => m.CreditChart),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+)
+
+const LanguagePerformance = dynamic(
+  () => import('./LanguagePerformance').then((m) => m.LanguagePerformance),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+)
+
+const AnalyticsChart = dynamic(
+  () => import('./AnalyticsChart').then((m) => m.AnalyticsChart),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+)
+
+export function DashboardContent({ initial }: { initial: DashboardInitialData }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">대시보드</h1>
+        <p className="text-surface-500 dark:text-surface-400">돌아오신 것을 환영합니다! 더빙 현황을 확인하세요.</p>
+      </div>
+
+      <DashboardSummary initialData={initial.summary} />
+      <QuickStart />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <CreditChart initialData={initial.creditUsage} />
+        <LanguagePerformance />
+      </div>
+
+      <AnalyticsChart videoIds={initial.ytVideoIds} />
+
+      <RecentJobs initialData={initial.jobs} />
+    </div>
+  )
+}

--- a/src/features/dashboard/components/DashboardSummary.tsx
+++ b/src/features/dashboard/components/DashboardSummary.tsx
@@ -3,9 +3,14 @@
 import { Film, Clock, Coins, Zap } from 'lucide-react'
 import { Card } from '@/components/ui'
 import { useDashboardSummary } from '@/hooks/useDashboardData'
+import type { DashboardSummary as DashboardSummaryType } from './types'
 
-export function DashboardSummary() {
-  const { data } = useDashboardSummary()
+interface DashboardSummaryProps {
+  initialData?: DashboardSummaryType | null
+}
+
+export function DashboardSummary({ initialData }: DashboardSummaryProps) {
+  const { data } = useDashboardSummary(initialData ?? undefined)
 
   const cards = [
     {

--- a/src/features/dashboard/components/LanguagePerformance.tsx
+++ b/src/features/dashboard/components/LanguagePerformance.tsx
@@ -12,9 +12,9 @@ export function LanguagePerformance() {
   const { data: rawData } = useLanguagePerformance()
 
   const chartData = (rawData || []).map((r) => {
-    const lang = getLanguageByCode(r.language_code as string)
+    const lang = getLanguageByCode(r.language_code)
     return {
-      language: lang?.name || (r.language_code as string),
+      language: lang?.name || r.language_code,
       views: Number(r.total_views) || 0,
       flag: lang?.flag || '',
     }

--- a/src/features/dashboard/components/RecentJobs.tsx
+++ b/src/features/dashboard/components/RecentJobs.tsx
@@ -7,6 +7,7 @@ import { formatDuration } from '@/utils/formatters'
 import { useRecentJobs } from '@/hooks/useDashboardData'
 import { EmptyState } from '@/components/feedback/EmptyState'
 import { Languages } from 'lucide-react'
+import type { DubbingJob } from './types'
 
 const statusConfig: Record<string, { label: string; variant: 'success' | 'brand' | 'default' | 'error' }> = {
   completed: { label: '완료', variant: 'success' },
@@ -15,14 +16,18 @@ const statusConfig: Record<string, { label: string; variant: 'success' | 'brand'
   failed: { label: '실패', variant: 'error' },
 }
 
-export function RecentJobs() {
-  const { data: jobs } = useRecentJobs()
+interface RecentJobsProps {
+  initialData?: DubbingJob[]
+}
+
+export function RecentJobs({ initialData }: RecentJobsProps) {
+  const { data: jobs } = useRecentJobs(initialData)
 
   return (
     <Card>
       <div className="mb-4 flex items-center justify-between">
         <CardTitle>최근 작업</CardTitle>
-        <Link href="/batch" className="text-sm text-brand-500 hover:text-brand-600">전체 보기</Link>
+        <Link href="/batch" aria-label="최근 작업 전체 보기" className="text-sm text-brand-500 hover:text-brand-600">전체 보기</Link>
       </div>
 
       {!jobs || jobs.length === 0 ? (
@@ -34,21 +39,21 @@ export function RecentJobs() {
       ) : (
         <div className="space-y-3">
           {jobs.map((job) => {
-            const status = statusConfig[job.status as string] || statusConfig.pending
-            const languages = ((job.languages as string) || '').split(',').filter(Boolean)
+            const status = statusConfig[job.status] || statusConfig.pending
+            const languages = (job.languages || '').split(',').filter(Boolean)
             const avgProgress = Number(job.avg_progress) || 0
 
             return (
               <div
-                key={job.id as number}
+                key={job.id}
                 className="flex items-center gap-4 rounded-lg border border-surface-100 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
               >
                 <div className="flex h-12 w-20 shrink-0 items-center justify-center rounded-md bg-surface-200 text-xs text-surface-400 dark:bg-surface-800">
-                  {formatDuration(Number(job.video_duration_ms) / 1000)}
+                  {formatDuration(job.video_duration_ms / 1000)}
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-medium text-surface-900 dark:text-white">
-                    {job.video_title as string}
+                    {job.video_title}
                   </p>
                   <div className="mt-1 flex flex-wrap gap-1">
                     {languages.slice(0, 4).map((lang) => (

--- a/src/features/dashboard/components/types.ts
+++ b/src/features/dashboard/components/types.ts
@@ -1,0 +1,37 @@
+export interface DashboardSummary {
+  total_jobs: number
+  total_minutes: number
+  active_jobs: number
+  credits_remaining: number
+}
+
+export interface DubbingJob {
+  id: number
+  user_id: string
+  video_title: string
+  video_duration_ms: number
+  status: string
+  created_at: string
+  languages: string
+  avg_progress: number
+}
+
+export interface CreditUsageRow {
+  month: string
+  job_count: number
+  minutes_used: number
+}
+
+export interface LanguagePerformanceRow {
+  language_code: string
+  total_views: number
+  total_likes: number
+  upload_count: number
+}
+
+export interface DashboardInitialData {
+  summary: DashboardSummary | null
+  jobs: DubbingJob[]
+  creditUsage: CreditUsageRow[]
+  ytVideoIds: string[]
+}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
-import { getStoredAccessToken } from '@/lib/firebase'
+import type { DashboardSummary, DubbingJob, CreditUsageRow, LanguagePerformanceRow } from '@/features/dashboard/components/types'
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init)
@@ -11,33 +11,45 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   return json.data as T
 }
 
-export function useDashboardSummary() {
+export function useDashboardSummary(initialData?: DashboardSummary | null) {
   const user = useAuthStore((s) => s.user)
   return useQuery({
     queryKey: ['dashboard-summary', user?.uid],
-    queryFn: () => fetchJson<Record<string, unknown>>(`/api/dashboard/summary?uid=${user!.uid}`),
+    queryFn: async () => {
+      if (!user) return null
+      return fetchJson<DashboardSummary>(`/api/dashboard/summary?uid=${user.uid}`)
+    },
     enabled: !!user,
     staleTime: 30_000,
+    initialData: initialData ?? undefined,
   })
 }
 
-export function useRecentJobs() {
+export function useRecentJobs(initialData?: DubbingJob[]) {
   const user = useAuthStore((s) => s.user)
   return useQuery({
     queryKey: ['recent-jobs', user?.uid],
-    queryFn: () => fetchJson<Record<string, unknown>[]>(`/api/dashboard/jobs?uid=${user!.uid}&limit=10`),
+    queryFn: async () => {
+      if (!user) return []
+      return fetchJson<DubbingJob[]>(`/api/dashboard/jobs?uid=${user.uid}&limit=10`)
+    },
     enabled: !!user,
     staleTime: 30_000,
+    initialData,
   })
 }
 
-export function useCreditUsage() {
+export function useCreditUsage(initialData?: CreditUsageRow[]) {
   const user = useAuthStore((s) => s.user)
   return useQuery({
     queryKey: ['credit-usage', user?.uid],
-    queryFn: () => fetchJson<Record<string, unknown>[]>(`/api/dashboard/credit-usage?uid=${user!.uid}`),
+    queryFn: async () => {
+      if (!user) return []
+      return fetchJson<CreditUsageRow[]>(`/api/dashboard/credit-usage?uid=${user.uid}`)
+    },
     enabled: !!user,
     staleTime: 60_000,
+    initialData,
   })
 }
 
@@ -47,10 +59,7 @@ export function useLanguagePerformance() {
     queryKey: ['language-performance', user?.uid],
     queryFn: async () => {
       if (!user) return []
-      const token = getStoredAccessToken()
-      const headers: Record<string, string> = {}
-      if (token) headers['x-google-access-token'] = token
-      return fetchJson<Record<string, unknown>[]>(`/api/dashboard/language-performance?uid=${user.uid}`, { headers })
+      return fetchJson<LanguagePerformanceRow[]>(`/api/dashboard/language-performance?uid=${user.uid}`)
     },
     enabled: !!user,
     staleTime: 5 * 60_000,
@@ -58,16 +67,14 @@ export function useLanguagePerformance() {
 }
 
 export function useChannelStats() {
+  const user = useAuthStore((s) => s.user)
   return useQuery({
-    queryKey: ['channel-stats'],
-    queryFn: async () => {
-      const token = getStoredAccessToken()
-      if (!token) return null
-      return fetchJson<{ subscriberCount: number; viewCount: number; videoCount: number; channelId: string; title: string; thumbnail: string } | null>(
+    queryKey: ['channel-stats', user?.uid],
+    queryFn: () =>
+      fetchJson<{ subscriberCount: number; viewCount: number; videoCount: number; channelId: string; title: string; thumbnail: string } | null>(
         `/api/youtube/stats?channel=true`,
-        { headers: { 'x-google-access-token': token } },
-      )
-    },
+      ),
+    enabled: !!user,
     staleTime: 5 * 60_000,
   })
 }

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -4,6 +4,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 10,
       retry: 2,
       refetchOnWindowFocus: false,
     },


### PR DESCRIPTION
## 관련 이슈
Closes #2

## 변경 요약
- **recharts 지연 로드** — `CreditChart`, `LanguagePerformance` → `next/dynamic + ssr:false`. 초기 번들에서 ~100KB 제거
- **next/image 전환** — `Topbar` 프로필 이미지, `VideoInputStep` 썸네일
- **대시보드 서버 프리페치** — `dashboard/page.tsx` 서버 컴포넌트 전환, DB 직접 조회로 초기 데이터 주입 (hydration 지연 200-500ms 제거)
- **DashboardContent.tsx** — 클라이언트 인터랙션 wrapper 분리
- **라우트 메타데이터** — batch/billing/dubbing/youtube/dashboard layout에 `export const metadata` 추가 (탭 타이틀)
- **대시보드 스켈레톤** — `dashboard/loading.tsx` 신규
- **타입 강화** — `Record<string,unknown>` → `DashboardSummary`, `DubbingJob`, `CreditUsageRow`, `LanguagePerformanceRow` 구체 인터페이스 (`src/features/dashboard/components/types.ts`)
- **React Query** — `gcTime` 튜닝, non-null assertion 제거

## 체크리스트
- [x] `npm run build` — recharts 별도 chunk 확인
- [x] 브라우저 탭에 한국어 라우트 타이틀
- [x] `npx tsc --noEmit` 0 errors