### PR TITLE
feat: video URL upload tab & YouTube Analytics dashboard chart (#3)

### DIFF
--- a/docs/research/youtube-multi-audio.md
+++ b/docs/research/youtube-multi-audio.md
@@ -1,0 +1,79 @@
+# YouTube 다중 오디오 트랙 기술 조사
+
+> 작성일: 2026-04-10 | BACKLOG P2-1
+
+## 질문
+
+단일 YouTube 영상에 여러 언어의 오디오 트랙을 API로 첨부할 수 있는가?
+
+## 결론 (TL;DR)
+
+**YouTube Data API v3는 다중 오디오 트랙 업로드를 지원하지 않는다.**
+
+YouTube는 2024년부터 크리에이터 스튜디오 UI에서 "대체 오디오 트랙(Alternative Audio Tracks)" 기능을 제공하지만, 이에 대응하는 공개 REST API 엔드포인트는 존재하지 않는다. 따라서 현재 프로젝트에서 API만으로 다중 오디오 트랙을 자동 삽입하는 것은 불가능하다.
+
+## 상세 조사
+
+### 1. YouTube Studio의 다중 오디오 트랙 기능
+
+- 2023년 9월 YouTube가 "Multi-language audio" 기능을 발표.
+- 2024년 2월 전체 크리에이터에게 확대 적용.
+- YouTube Studio → 영상 편집 → "오디오" 탭에서 언어별 오디오 파일(.mp3, .aac, .wav 등)을 수동 업로드.
+- 시청자는 재생 중 기어 아이콘 → "오디오 트랙"에서 언어 전환 가능.
+- 제한사항: 원본 영상의 오디오를 대체하는 것이 아니라 추가 트랙으로 삽입됨.
+
+### 2. YouTube Data API v3 지원 현황
+
+| API Resource | 다중 오디오 관련 필드 | 지원 여부 |
+|---|---|---|
+| `videos.insert` | `snippet.defaultAudioLanguage` | 단일 값만 — 기본 오디오 언어 메타데이터 |
+| `videos.update` | `snippet.defaultAudioLanguage` | 변경 가능하지만 오디오 파일과 무관 |
+| `captions.insert` | `snippet.language`, `snippet.audioTrackType` | **자막(텍스트) 전용** — 오디오 파일 아님 |
+| `captions.list` | `audioTrackType` enum | `commentary`, `descriptive`, `primary`, `unknown` — 자막 종류 구분용 |
+| 오디오 트랙 전용 리소스 | — | **존재하지 않음** |
+
+- `captions` 리소스의 `audioTrackType`은 "이 자막이 어떤 오디오 트랙에 대응하는지" 메타데이터일 뿐, 오디오 파일 업로드와 무관.
+- YouTube Data API v3 공식 참조문서에 오디오 트랙(audio track) 업로드/관리 엔드포인트는 없음.
+- YouTube Content ID API (Partner API)에는 `audioTracks` 관련 기능이 있으나 MCN/파트너 계정 전용이며 일반 OAuth 접근 불가.
+
+### 3. 대안 평가
+
+| 대안 | 실현 가능성 | 장점 | 단점 |
+|---|---|---|---|
+| **A. 언어별 별도 영상 업로드 (현재 방식)** | ✅ 즉시 가능 | API 완전 지원, 구현 완료 | 영상 중복, 시청자 분산, SEO 분리 |
+| **B. 자막(Caption) 트랙만 추가** | ✅ 즉시 가능 | API 지원, 이미 구현됨 | 음성이 아닌 텍스트만 — 더빙 취지와 불일치 |
+| **C. YouTube Studio 수동 업로드 안내** | ✅ 가능 | 진정한 다중 오디오 | 자동화 불가, UX 마찰 |
+| **D. Selenium/Puppeteer로 Studio UI 자동화** | ⚠️ 기술적 가능 | 자동화 달성 | Google ToS 위반 위험, 깨지기 쉬움, 유지보수 불가 |
+| **E. YouTube Content ID API** | ❌ 불가 | 공식 API | MCN/파트너 전용, 일반 계정 접근 불가 |
+| **F. API 지원 대기** | — | 장기적 최선 | 시기 불명 |
+
+### 4. 권장 방향
+
+**단기 (현재 iteration에서 적용):**
+
+1. **현재 방식 유지** — 언어별 별도 영상 업로드 (A).
+2. 업로드 완료 후 **Studio 다중 오디오 업로드 안내 메시지** 표시 (C 보조).
+   - "YouTube Studio에서 이 영상에 더빙 오디오를 추가 트랙으로 등록할 수 있습니다."
+   - 영상 편집 직링크: `https://studio.youtube.com/video/{videoId}/edit`
+
+**중기 (API 변경 감시):**
+
+3. YouTube Data API 변경 로그를 주기적으로 확인.
+   - 감시 대상: `videos` 리소스에 `audioTracks` part 추가 여부.
+   - 감시 URL: YouTube API revision history.
+4. API 지원이 추가되면:
+   - 더빙 완료 → 원본 영상에 오디오 트랙 첨부 (별도 영상 업로드 불필요).
+   - OAuth 스코프에 해당 권한 추가 필요할 수 있음.
+
+## 현재 프로젝트 영향
+
+- `src/lib/youtube/server.ts`: 변경 불필요. `uploadVideoToYouTube`는 현재 방식(영상별 업로드) 유지.
+- `src/features/dubbing/components/steps/UploadStep.tsx`: Studio 안내 메시지 추가 가능 (선택).
+- OAuth 스코프(`src/lib/firebase.ts`): 변경 불필요.
+- DB 스키마: 변경 불필요 — 현재 `youtube_uploads` 테이블이 영상별 레코드를 이미 관리.
+
+## 참고
+
+- YouTube Help: "Add audio in another language to your video" (YouTube Studio 기능 설명)
+- YouTube Data API v3 Reference: Videos, Captions 리소스
+- YouTube Blog (2023-09): "Multi-language audio on YouTube"

--- a/src/features/dashboard/components/AnalyticsChart.tsx
+++ b/src/features/dashboard/components/AnalyticsChart.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { Card, CardTitle } from '@/components/ui'
+import { useQuery } from '@tanstack/react-query'
+import { ytFetchAnalytics } from '@/lib/api-client'
+import { useAuthStore } from '@/stores/authStore'
+import { useState } from 'react'
+
+export function AnalyticsChart({ videoIds }: { videoIds?: string[] }) {
+  const user = useAuthStore((s) => s.user)
+  const [tab, setTab] = useState<'daily' | 'country'>('daily')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['youtube-analytics', videoIds],
+    queryFn: () => ytFetchAnalytics(videoIds ?? [], user?.uid ?? ''),
+    enabled: !!user && !!videoIds && videoIds.length > 0,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60,
+  })
+
+  if (!videoIds || videoIds.length === 0) {
+    return (
+      <Card>
+        <CardTitle>시청 분석</CardTitle>
+        <p className="text-sm text-surface-500 dark:text-surface-400">
+          YouTube에 업로드된 영상이 없습니다.
+        </p>
+      </Card>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardTitle>시청 분석</CardTitle>
+        <div className="mt-4 h-64 animate-pulse rounded bg-surface-100 dark:bg-surface-800" />
+      </Card>
+    )
+  }
+
+  const allDaily = (data || []).flatMap((v) => v.daily)
+  const mergedDaily = Object.values(
+    allDaily.reduce<Record<string, { date: string; views: number; minutes: number }>>(
+      (acc, row) => {
+        const existing = acc[row.date] || { date: row.date, views: 0, minutes: 0 }
+        existing.views += row.views
+        existing.minutes += row.estimatedMinutesWatched
+        acc[row.date] = existing
+        return acc
+      },
+      {},
+    ),
+  ).sort((a, b) => a.date.localeCompare(b.date))
+
+  const mergedCountries = Object.values(
+    (data || [])
+      .flatMap((v) => v.countries)
+      .reduce<Record<string, { country: string; views: number; minutes: number }>>(
+        (acc, row) => {
+          const existing = acc[row.country] || { country: row.country, views: 0, minutes: 0 }
+          existing.views += row.views
+          existing.minutes += row.estimatedMinutesWatched
+          acc[row.country] = existing
+          return acc
+        },
+        {},
+      ),
+  )
+    .sort((a, b) => b.views - a.views)
+    .slice(0, 10)
+
+  return (
+    <Card>
+      <div className="mb-4 flex items-center justify-between">
+        <CardTitle>시청 분석</CardTitle>
+        <div className="flex gap-1 rounded-lg bg-surface-100 p-1 dark:bg-surface-800" role="tablist">
+          <button
+            role="tab"
+            aria-selected={tab === 'daily'}
+            onClick={() => setTab('daily')}
+            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors focus-ring ${
+              tab === 'daily'
+                ? 'bg-white text-surface-900 shadow-sm dark:bg-surface-700 dark:text-white'
+                : 'text-surface-500 hover:text-surface-700 dark:text-surface-400'
+            }`}
+          >
+            일별
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === 'country'}
+            onClick={() => setTab('country')}
+            className={`rounded-md px-3 py-1 text-xs font-medium transition-colors focus-ring ${
+              tab === 'country'
+                ? 'bg-white text-surface-900 shadow-sm dark:bg-surface-700 dark:text-white'
+                : 'text-surface-500 hover:text-surface-700 dark:text-surface-400'
+            }`}
+          >
+            국가별
+          </button>
+        </div>
+      </div>
+
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          {tab === 'daily' ? (
+            <BarChart data={mergedDaily} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
+              <XAxis
+                dataKey="date"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 11, fill: '#a1a1aa' }}
+                tickFormatter={(v: string) => v.slice(5)}
+              />
+              <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#a1a1aa' }} />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#18181b',
+                  border: '1px solid #3f3f46',
+                  borderRadius: '8px',
+                  color: '#fff',
+                  fontSize: '13px',
+                }}
+                formatter={(value, name) => [
+                  Number(value).toLocaleString(),
+                  name === 'views' ? '조회수' : '시청 시간(분)',
+                ]}
+                labelFormatter={(label) => String(label)}
+              />
+              <Bar dataKey="views" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          ) : (
+            <BarChart
+              data={mergedCountries}
+              layout="vertical"
+              margin={{ top: 5, right: 5, left: 10, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
+              <XAxis type="number" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: '#a1a1aa' }} />
+              <YAxis
+                type="category"
+                dataKey="country"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: '#a1a1aa' }}
+                width={40}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#18181b',
+                  border: '1px solid #3f3f46',
+                  borderRadius: '8px',
+                  color: '#fff',
+                  fontSize: '13px',
+                }}
+                formatter={(value, name) => [
+                  Number(value).toLocaleString(),
+                  name === 'views' ? '조회수' : '시청 시간(분)',
+                ]}
+              />
+              <Bar dataKey="views" fill="#8b5cf6" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  )
+}

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
+import Image from 'next/image'
 import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap } from 'lucide-react'
 import { Card, Button, Input, Badge, Tabs, TabsList, TabsTrigger, TabsContent, Progress } from '@/components/ui'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
-import { isValidYouTubeUrl } from '@/utils/validators'
+import { isValidVideoUrl, isValidYouTubeUrl } from '@/utils/validators'
 import { formatDuration } from '@/utils/formatters'
 import { getPersoFileUrl } from '@/lib/api-client'
 
 export function VideoInputStep() {
-  const { videoMeta, setVideoSource, setIsShort, isShort, nextStep } = useDubbingStore()
-  const { uploadLocalVideo, importYouTubeVideo } = usePersoFlow()
+  const { videoMeta, setVideoSource, setIsShort, nextStep } = useDubbingStore()
+  const { uploadLocalVideo, importVideoByUrl } = usePersoFlow()
 
   const [url, setUrl] = useState('')
   const [loading, setLoading] = useState(false)
@@ -20,12 +21,12 @@ export function VideoInputStep() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleUrlSubmit = async () => {
-    if (!isValidYouTubeUrl(url)) return
+    if (!isValidVideoUrl(url)) return
     setLoading(true)
     setError(null)
     try {
       setVideoSource({ type: 'url', url })
-      await importYouTubeVideo(url)
+      await importVideoByUrl(url)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to import video')
     } finally {
@@ -69,7 +70,7 @@ export function VideoInputStep() {
     }
   }, [videoMeta, setIsShort])
 
-  const isValid = url.length > 0 && isValidYouTubeUrl(url)
+  const isValid = url.length > 0 && isValidVideoUrl(url)
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -81,7 +82,7 @@ export function VideoInputStep() {
       <Tabs defaultValue="upload">
         <TabsList className="mx-auto w-fit">
           <TabsTrigger value="url">
-            <span className="flex items-center gap-1.5"><Link2 className="h-4 w-4" /> YouTube URL</span>
+            <span className="flex items-center gap-1.5"><Link2 className="h-4 w-4" /> 영상 URL</span>
           </TabsTrigger>
           <TabsTrigger value="upload">
             <span className="flex items-center gap-1.5"><Upload className="h-4 w-4" /> 업로드</span>
@@ -95,7 +96,7 @@ export function VideoInputStep() {
           <Card>
             <div className="flex gap-2">
               <Input
-                placeholder="https://youtube.com/watch?v=..."
+                placeholder="YouTube URL 또는 영상 직접 링크 (.mp4, .mov, .webm)"
                 value={url}
                 onChange={(e) => { setUrl(e.target.value); setError(null) }}
                 icon={<Play className="h-4 w-4" />}
@@ -108,7 +109,7 @@ export function VideoInputStep() {
             </div>
             {loading && (
               <p className="mt-2 text-xs text-surface-400">
-                YouTube에서 다운로드 중... 긴 영상은 몇 분 걸릴 수 있습니다.
+                {isValidYouTubeUrl(url) ? 'YouTube에서' : '원격 서버에서'} 다운로드 중... 긴 영상은 몇 분 걸릴 수 있습니다.
               </p>
             )}
           </Card>
@@ -123,10 +124,14 @@ export function VideoInputStep() {
             onChange={handleFileInputChange}
           />
           <Card
-            className="cursor-pointer border-2 border-dashed border-surface-300 text-center transition-colors hover:border-brand-400 dark:border-surface-700"
+            role="button"
+            tabIndex={0}
+            aria-label="영상 파일 선택"
+            className="cursor-pointer border-2 border-dashed border-surface-300 text-center transition-colors hover:border-brand-400 focus-ring dark:border-surface-700"
             onDragOver={(e) => e.preventDefault()}
             onDrop={handleFileDrop}
             onClick={() => !loading && fileInputRef.current?.click()}
+            onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && !loading) { e.preventDefault(); fileInputRef.current?.click() } }}
           >
             <div className="py-8">
               {loading ? (
@@ -167,10 +172,13 @@ export function VideoInputStep() {
         <Card className="animate-slide-up">
           <div className="flex gap-4">
             {videoMeta.thumbnail ? (
-              <img
+              <Image
                 src={videoMeta.thumbnail.startsWith('http') ? videoMeta.thumbnail : getPersoFileUrl(videoMeta.thumbnail)}
                 alt={videoMeta.title}
-                className="h-20 w-32 shrink-0 rounded-lg object-cover bg-surface-200"
+                width={128}
+                height={80}
+                className="shrink-0 rounded-lg object-cover bg-surface-200"
+                unoptimized={!videoMeta.thumbnail.startsWith('http')}
               />
             ) : (
               <div className="flex h-20 w-32 shrink-0 items-center justify-center rounded-lg bg-surface-200 text-sm text-surface-400 dark:bg-surface-800">


### PR DESCRIPTION
## 관련 이슈
Closes #3

## 변경 요약

### 동영상 URL 업로드
- `VideoInputStep.tsx` — 파일/URL 탭 전환 UI 추가
- `src/lib/validators/dubbing.ts` — YouTube URL 정규식 + 일반 video URL zod 스키마
- Perso external endpoint(`/api/perso/external/upload`) 활용해 URL 더빙 파이프라인 진입

### YouTube Analytics 차트
- `AnalyticsChart.tsx` — recharts BarChart, 일별 조회수 / 국가별 조회수 탭 전환
- `/api/youtube/analytics` — YouTube Analytics API v2, libsql `analytics_cache`로 일일 캐시 (API 쿼터 보호)
- OAuth 스코프에 `yt-analytics.readonly` 추가

### 기술 조사
- `docs/research/youtube-multi-audio.md` — YouTube Data API v3 다중 오디오 트랙 미지원 확인 (YouTube Studio 전용). 대체 플랜: 언어별 별도 영상 업로드 유지.

## 체크리스트
- [x] URL 입력 탭 UI 렌더링
- [x] AnalyticsChart 컴포넌트 렌더링
- [x] analytics API 유닛 테스트 통과
- [x] `npx tsc --noEmit` 0 errors