### PR TITLE
test: Vitest 도입, 커버리지 99%+, Lighthouse CI 게이트, 문서 최신화 (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,81 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# CreatorDub
 
-## Getting Started
+AI 기반 영상 더빙 플랫폼. YouTube 영상을 여러 언어로 더빙하고, 더빙 결과를 YouTube에 업로드하며, 시청 분석 데이터를 대시보드에서 확인할 수 있다.
 
-First, run the development server:
+## 스택
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- **Next.js 16.2.3** (App Router) / React 19 / TypeScript
+- **Tailwind CSS v4** / Zustand / React Query
+- **Turso (libsql)** — DB
+- **Perso.ai API** — 더빙 엔진
+- **YouTube Data API v3** — 업로드, 통계
+- **YouTube Analytics API v2** — 시청 분석
+- **Google OAuth 2.0** — 인증
+
+## 환경 변수
+
+`.env.local`에 다음을 설정:
+
+```
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=
+PERSO_API_KEY=
+PERSO_API_BASE_URL=
+TURSO_URL=
+TURSO_AUTH_TOKEN=
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## 개발 서버
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+npm install
+npm run dev        # http://localhost:3000
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## 테스트
 
-## Learn More
+```bash
+npx tsc --noEmit              # 타입 체크
+npm run lint                  # ESLint
+npm run test                  # Vitest 유닛 테스트
+npm run build                 # 프로덕션 빌드
+npm run test:e2e              # Playwright E2E
+npm run test:lighthouse:gate  # Lighthouse 성능 게이트
+```
 
-To learn more about Next.js, take a look at the following resources:
+## 디렉토리 구조
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```
+src/
+  app/                    # Next.js App Router
+    (app)/                # 인증 필요 라우트 (dashboard, dubbing, batch, billing, youtube)
+    api/                  # API Route Handlers
+      dashboard/          # 대시보드 데이터 API
+      perso/              # Perso.ai 프록시 API
+      youtube/            # YouTube 업로드/통계/분석 API
+      auth/               # 인증 관련 API
+  features/               # 기능별 컴포넌트
+    dubbing/              # 더빙 워크플로우 (5단계 위저드)
+    dashboard/            # 대시보드 차트 및 요약
+    landing/              # 랜딩 페이지
+    auth/                 # 인증 UI
+    billing/              # 결제/크레딧
+  lib/                    # 서버 유틸
+    db/                   # Turso DB 클라이언트 + 쿼리
+    perso/                # Perso.ai API 헬퍼
+    youtube/              # YouTube API 서버 함수
+    auth/                 # 세션 검증
+    api/                  # 공용 API 응답 헬퍼
+    validators/           # Zod 스키마
+  stores/                 # Zustand 스토어 (auth, notification, theme)
+  hooks/                  # React Query 훅
+  components/             # 공용 UI 컴포넌트
+  proxy.ts                # 인증 미들웨어
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## 알려진 제약
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- YouTube 다중 오디오 트랙은 API 미지원 — 언어별 별도 영상 업로드 방식 사용
+- Google OAuth implicit flow 사용 중 — authorization code flow 전환 예정
+- `creatordub_session` 쿠키 하드닝 필요

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,60 @@
+# Architecture
+
+## 서버/클라이언트 경계
+
+```
+브라우저 (CSR)                   Next.js 서버 (SSR + API)              외부 서비스
+─────────────                   ────────────────────────              ──────────
+Zustand stores                  proxy.ts (미들웨어)                    Google OAuth
+React Query hooks ──────────▶   /api/* Route Handlers ──────────▶    Perso.ai API
+features/* components           lib/db/ (Turso 직접)                  YouTube Data API
+lib/api-client.ts               lib/youtube/server.ts                 YouTube Analytics API
+lib/firebase.ts (OAuth)         lib/perso/*.ts                        Turso (libsql)
+                                lib/auth/session.ts
+```
+
+### 인증 플로우
+
+1. 클라이언트: `signInWithGoogle()` → Google OAuth popup → authorization code 획득
+2. 클라이언트: `POST /api/auth/callback` → 서버가 code를 access_token + refresh_token으로 교환
+3. 서버: `creatordub_session` + `google_access_token` httpOnly 쿠키 설정, refresh_token DB 저장
+4. 서버: `proxy.ts` 미들웨어가 `creatordub_session` 쿠키로 인증 상태 확인
+5. API 라우트: `requireSession()` (대시보드) 또는 `requireAccessToken()` (YouTube) 로 인가
+
+### 더빙 데이터 플로우
+
+```
+파일/URL 입력 → Perso.ai 업로드 → 언어 선택 → Perso.ai 더빙 요청
+    → 진행률 폴링 → 더빙 완료 → (선택) YouTube 업로드
+    → DB 기록 (dubbing_jobs, job_languages, youtube_uploads)
+```
+
+### 대시보드 데이터 플로우
+
+서버 컴포넌트(`dashboard/page.tsx`)가 Turso DB 직접 조회 → `initialData`로 클라이언트에 전달 → React Query가 `staleTime` 이후 자동 갱신.
+
+YouTube Analytics 데이터는 클라이언트에서 `/api/youtube/analytics` 호출 → 서버가 YouTube Analytics API v2 쿼리 + `analytics_cache` 테이블로 24시간 TTL 캐시.
+
+## DB 테이블
+
+| 테이블 | 용도 |
+|--------|------|
+| `users` | 사용자 프로필, 크레딧, 플랜 |
+| `dubbing_jobs` | 더빙 작업 단위 |
+| `job_languages` | 작업별 언어 진행 상태 |
+| `youtube_uploads` | YouTube 업로드 기록 + 통계 |
+| `analytics_cache` | YouTube Analytics API 응답 캐시 (24h TTL) |
+
+## API 라우트 맵
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/auth/sync` | POST | OAuth 토큰 동기화 + 쿠키 설정 |
+| `/api/auth/signout` | POST | 세션 쿠키 클리어 |
+| `/api/dashboard/*` | GET/POST | 대시보드 데이터 (세션 인가) |
+| `/api/perso/*` | GET/POST | Perso.ai API 프록시 |
+| `/api/youtube/upload` | POST | 영상 업로드 (resumable) |
+| `/api/youtube/caption` | POST | 자막(SRT) 업로드 |
+| `/api/youtube/stats` | GET | 영상/채널 통계 |
+| `/api/youtube/videos` | GET | 사용자 영상 목록 |
+| `/api/youtube/analytics` | GET | 시청 분석 데이터 |

--- a/src/components/feedback/Toast.test.tsx
+++ b/src/components/feedback/Toast.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ToastContainer } from './Toast'
+import { useNotificationStore } from '@/stores/notificationStore'
+
+describe('ToastContainer', () => {
+  beforeEach(() => {
+    useNotificationStore.getState().clearAll()
+  })
+
+  afterEach(cleanup)
+
+  it('renders nothing when there are no toasts', () => {
+    const { container } = render(<ToastContainer />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders toasts with aria-live="polite"', () => {
+    useNotificationStore.getState().addToast({ type: 'info', title: 'Hello' })
+    render(<ToastContainer />)
+    const region = screen.getByRole('status')
+    expect(region.getAttribute('aria-live')).toBe('polite')
+    expect(region.getAttribute('aria-atomic')).toBe('false')
+    expect(screen.getByText('Hello')).toBeTruthy()
+  })
+
+  it('renders toast with message', () => {
+    useNotificationStore.getState().addToast({ type: 'success', title: 'Done', message: 'All good' })
+    render(<ToastContainer />)
+    expect(screen.getByText('Done')).toBeTruthy()
+    expect(screen.getByText('All good')).toBeTruthy()
+  })
+
+  it('renders close button with aria-label', () => {
+    useNotificationStore.getState().addToast({ type: 'error', title: 'Err' })
+    render(<ToastContainer />)
+    expect(screen.getByLabelText('알림 닫기')).toBeTruthy()
+  })
+})

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { Modal } from './Modal'
+
+describe('Modal', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    onClose.mockClear()
+    document.body.style.overflow = ''
+  })
+
+  afterEach(cleanup)
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<Modal open={false} onClose={onClose}>content</Modal>)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders content when open', () => {
+    render(<Modal open onClose={onClose}>hello</Modal>)
+    expect(screen.getByText('hello')).toBeTruthy()
+  })
+
+  it('renders title and close button', () => {
+    render(<Modal open onClose={onClose} title="My Title">body</Modal>)
+    expect(screen.getByText('My Title')).toBeTruthy()
+    expect(screen.getByLabelText('닫기')).toBeTruthy()
+  })
+
+  it('has role="dialog" and aria-modal', () => {
+    render(<Modal open onClose={onClose} title="Test">body</Modal>)
+    const dialogs = screen.getAllByRole('dialog')
+    const dialog = dialogs[0]
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(dialog.getAttribute('aria-label')).toBe('Test')
+  })
+
+  it('calls onClose on Escape key', () => {
+    const { container } = render(<Modal open onClose={onClose}>body</Modal>)
+    fireEvent.keyDown(container.ownerDocument, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when backdrop clicked', () => {
+    render(<Modal open onClose={onClose}>body</Modal>)
+    const backdrop = document.querySelector('[aria-hidden="true"]')!
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('locks body scroll when open', () => {
+    render(<Modal open onClose={onClose}>body</Modal>)
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('focus traps: Tab wraps from last to first focusable', () => {
+    render(
+      <Modal open onClose={onClose} title="Trap">
+        <button data-testid="btn1">First</button>
+        <button data-testid="btn2">Second</button>
+      </Modal>,
+    )
+    const btn2 = screen.getByTestId('btn2')
+    btn2.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(screen.getByLabelText('닫기'))
+  })
+
+  it('focus traps: Shift+Tab wraps from first to last focusable', () => {
+    render(
+      <Modal open onClose={onClose} title="Trap">
+        <button data-testid="btn1">First</button>
+        <button data-testid="btn2">Second</button>
+      </Modal>,
+    )
+    const closeBtn = screen.getByLabelText('닫기')
+    closeBtn.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(screen.getByTestId('btn2'))
+  })
+
+  it('auto-focuses first focusable element on open', () => {
+    render(
+      <Modal open onClose={onClose} title="Focus">
+        <input data-testid="input1" />
+      </Modal>,
+    )
+    expect(document.activeElement).toBe(screen.getByLabelText('닫기'))
+  })
+
+  it('focuses dialog panel when no focusable children exist', () => {
+    render(<Modal open onClose={onClose}><p>no buttons</p></Modal>)
+    const panel = document.querySelector('[tabindex="-1"]')!
+    expect(document.activeElement).toBe(panel)
+  })
+
+  it('prevents Tab when there are no focusable elements', () => {
+    render(<Modal open onClose={onClose}><p>text only</p></Modal>)
+    const event = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true, bubbles: true })
+    const spy = vi.spyOn(event, 'preventDefault')
+    document.dispatchEvent(event)
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import {
+  getPersoFileUrl,
+  getSpaces,
+  getLanguages,
+  getExternalMetadata,
+  uploadExternalVideo,
+  getSasToken,
+  uploadFileToBlob,
+  registerUploadedVideo,
+  uploadVideoFile,
+  validateMedia,
+  initializeQueue,
+  submitTranslation,
+  getProjectProgress,
+  listProjects,
+  getProjectDetail,
+  getProjectScript,
+  updateSentenceTranslation,
+  regenerateSentenceAudio,
+  getDownloadLinks,
+  requestLipSync,
+  ytUploadVideo,
+  ytUploadCaption,
+  ytFetchAnalytics,
+  ytFetchVideoStats,
+  ytFetchChannelStats,
+  ytFetchMyVideos,
+} from './api-client'
+
+function okResponse<T>(data: T) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: true, data }),
+  }
+}
+
+function errorResponse(code: string, message: string, status = 400) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ ok: false, error: { code, message } }),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getPersoFileUrl', () => {
+  it('returns empty string for empty path', () => {
+    expect(getPersoFileUrl('')).toBe('')
+  })
+
+  it('returns absolute URL as-is', () => {
+    expect(getPersoFileUrl('https://example.com/file.mp4')).toBe('https://example.com/file.mp4')
+  })
+
+  it('prepends base URL for relative path with leading slash', () => {
+    const result = getPersoFileUrl('/files/video.mp4')
+    expect(result).toContain('/files/video.mp4')
+  })
+
+  it('prepends base URL for relative path without leading slash', () => {
+    const result = getPersoFileUrl('files/video.mp4')
+    expect(result).toContain('/files/video.mp4')
+  })
+})
+
+describe('ytFetchAnalytics', () => {
+  it('fetches analytics with videoIds and userId', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ videoId: 'v1', daily: [], countries: [], totals: {} }]))
+    const result = await ytFetchAnalytics(['v1'], 'user1')
+    expect(result).toHaveLength(1)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/youtube/analytics?'),
+      expect.objectContaining({ cache: 'no-store' }),
+    )
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('videoIds=v1')
+    expect(url).toContain('userId=user1')
+  })
+
+  it('includes optional date range', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]))
+    await ytFetchAnalytics(['v1'], 'u1', '2026-01-01', '2026-01-31')
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('startDate=2026-01-01')
+    expect(url).toContain('endDate=2026-01-31')
+  })
+
+  it('throws on error response', async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse('QUOTA', 'Quota exceeded', 429))
+    await expect(ytFetchAnalytics(['v1'], 'u1')).rejects.toThrow('Quota exceeded')
+  })
+})
+
+describe('ytFetchVideoStats', () => {
+  it('sends videoIds as comma-separated query', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ videoId: 'v1', viewCount: 100 }]))
+    const result = await ytFetchVideoStats(['v1', 'v2'])
+    expect(result).toHaveLength(1)
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('videoIds=v1%2Cv2')
+  })
+})
+
+describe('ytFetchChannelStats', () => {
+  it('fetches channel stats', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ channelId: 'ch1', subscriberCount: 500 }))
+    const result = await ytFetchChannelStats()
+    expect(result?.channelId).toBe('ch1')
+  })
+})
+
+describe('ytFetchMyVideos', () => {
+  it('fetches videos with maxResults', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ videoId: 'v1' }]))
+    const result = await ytFetchMyVideos(5)
+    expect(result).toHaveLength(1)
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('maxResults=5')
+  })
+})
+
+// ── json helper edge cases ──────────────────────────────────
+
+describe('json envelope edge cases', () => {
+  it('throws on unparseable response body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => { throw new SyntaxError('Unexpected token') },
+    })
+    await expect(getSpaces()).rejects.toThrow(/invalid response body/)
+  })
+
+  it('throws HTTP status when error has no message', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ ok: false }),
+    })
+    await expect(getSpaces()).rejects.toThrow('HTTP 403')
+  })
+})
+
+// ── Perso GET wrappers ──────────────────────────────────────
+
+describe('Perso GET endpoints', () => {
+  it('getSpaces calls /api/perso/spaces', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ id: 1 }]))
+    const data = await getSpaces()
+    expect(data).toEqual([{ id: 1 }])
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/perso/spaces')
+  })
+
+  it('getLanguages calls /api/perso/languages', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ code: 'ko' }]))
+    const data = await getLanguages()
+    expect(data).toEqual([{ code: 'ko' }])
+  })
+
+  it('getSasToken passes fileName as query', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ blobSasUrl: 'https://blob/sas' }))
+    const data = await getSasToken('test.mp4')
+    expect(data.blobSasUrl).toBe('https://blob/sas')
+    expect(mockFetch.mock.calls[0][0]).toContain('fileName=test.mp4')
+  })
+
+  it('getProjectProgress passes projectSeq and spaceSeq', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ progress: 50 }))
+    await getProjectProgress(10, 2)
+    expect(mockFetch.mock.calls[0][0]).toContain('projectSeq=10')
+    expect(mockFetch.mock.calls[0][0]).toContain('spaceSeq=2')
+  })
+
+  it('listProjects passes spaceSeq', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]))
+    await listProjects(3)
+    expect(mockFetch.mock.calls[0][0]).toContain('spaceSeq=3')
+  })
+
+  it('getProjectDetail passes both params', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ seq: 5 }))
+    await getProjectDetail(5, 1)
+    expect(mockFetch.mock.calls[0][0]).toContain('projectSeq=5')
+  })
+
+  it('getProjectScript passes both params', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]))
+    await getProjectScript(5, 1)
+    expect(mockFetch.mock.calls[0][0]).toContain('projectSeq=5')
+  })
+
+  it('getDownloadLinks passes target param', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ urls: [] }))
+    await getDownloadLinks(5, 1, 'voiceAudio')
+    expect(mockFetch.mock.calls[0][0]).toContain('target=voiceAudio')
+  })
+
+  it('getDownloadLinks defaults target to all', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ urls: [] }))
+    await getDownloadLinks(5, 1)
+    expect(mockFetch.mock.calls[0][0]).toContain('target=all')
+  })
+})
+
+// ── Perso mutation endpoints ────────────────────────────────
+
+describe('Perso mutation endpoints', () => {
+  it('getExternalMetadata posts to external/metadata', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ title: 'Test' }))
+    const data = await getExternalMetadata(1, 'https://youtube.com/watch?v=abc')
+    expect(data).toEqual({ title: 'Test' })
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+  })
+
+  it('getExternalMetadata uses default lang ko', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ title: 'T' }))
+    await getExternalMetadata(1, 'https://youtube.com/watch?v=abc')
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.lang).toBe('ko')
+  })
+
+  it('uploadExternalVideo puts to external/upload', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ seq: 10 }))
+    const data = await uploadExternalVideo(1, 'https://youtube.com/watch?v=abc', 'en')
+    expect(data.seq).toBe(10)
+    expect(mockFetch.mock.calls[0][1].method).toBe('PUT')
+  })
+
+  it('registerUploadedVideo puts to upload/register', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ seq: 20 }))
+    await registerUploadedVideo(1, 'https://blob/file', 'test.mp4')
+    expect(mockFetch.mock.calls[0][1].method).toBe('PUT')
+  })
+
+  it('validateMedia posts body', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ valid: true }))
+    await validateMedia({ spaceSeq: 1, mediaSeq: 2 } as never)
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+  })
+
+  it('initializeQueue puts with spaceSeq', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(null))
+    await initializeQueue(5)
+    expect(mockFetch.mock.calls[0][0]).toContain('spaceSeq=5')
+    expect(mockFetch.mock.calls[0][1].method).toBe('PUT')
+  })
+
+  it('submitTranslation posts with spaceSeq', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ projectSeq: 1 }))
+    await submitTranslation(5, { languages: ['ko'] } as never)
+    expect(mockFetch.mock.calls[0][0]).toContain('spaceSeq=5')
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+  })
+
+  it('updateSentenceTranslation patches with params', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(null))
+    await updateSentenceTranslation(10, 20, 'translated')
+    expect(mockFetch.mock.calls[0][1].method).toBe('PATCH')
+    expect(mockFetch.mock.calls[0][0]).toContain('projectSeq=10')
+    expect(mockFetch.mock.calls[0][0]).toContain('sentenceSeq=20')
+  })
+
+  it('regenerateSentenceAudio patches with params', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(null))
+    await regenerateSentenceAudio(10, 30)
+    expect(mockFetch.mock.calls[0][1].method).toBe('PATCH')
+    expect(mockFetch.mock.calls[0][0]).toContain('audioSentenceSeq=30')
+  })
+
+  it('requestLipSync posts with params', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse(null))
+    await requestLipSync(5, 1)
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+    expect(mockFetch.mock.calls[0][0]).toContain('projectSeq=5')
+  })
+})
+
+// ── YouTube upload/caption wrappers ─────────────────────────
+
+describe('ytUploadVideo', () => {
+  it('sends FormData with all fields', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'yt1' }))
+    const blob = new Blob(['fake'], { type: 'video/mp4' })
+    const result = await ytUploadVideo({
+      video: blob,
+      title: 'Test',
+      description: 'desc',
+      tags: ['a', 'b'],
+      categoryId: '22',
+      privacyStatus: 'unlisted',
+      language: 'ko',
+    })
+    expect(result.videoId).toBe('yt1')
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/upload')
+    const body = mockFetch.mock.calls[0][1].body as FormData
+    expect(body.get('title')).toBe('Test')
+    expect(body.get('tags')).toBe('a,b')
+    expect(body.get('categoryId')).toBe('22')
+    expect(body.get('privacyStatus')).toBe('unlisted')
+    expect(body.get('language')).toBe('ko')
+  })
+
+  it('omits optional fields when not provided', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'yt2' }))
+    const blob = new Blob(['fake'], { type: 'video/mp4' })
+    await ytUploadVideo({
+      video: blob,
+      title: 'Test',
+      description: '',
+      tags: [],
+    })
+    const body = mockFetch.mock.calls[0][1].body as FormData
+    expect(body.get('categoryId')).toBeNull()
+    expect(body.get('privacyStatus')).toBeNull()
+    expect(body.get('language')).toBeNull()
+  })
+})
+
+describe('ytUploadCaption', () => {
+  it('sends JSON body to /api/youtube/caption', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ uploaded: true }))
+    const result = await ytUploadCaption({
+      videoId: 'v1',
+      language: 'ko',
+      name: 'Korean',
+      srtContent: '1\n00:00:01,000 --> 00:00:02,000\nHello',
+    })
+    expect(result.uploaded).toBe(true)
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/caption')
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+  })
+})
+
+// ── uploadFileToBlob (XHR) ─────────────────────────────────
+
+describe('uploadFileToBlob', () => {
+  let xhrInstances: Array<Record<string, unknown>>
+
+  beforeEach(() => {
+    xhrInstances = []
+    function MockXHR(this: Record<string, unknown>) {
+      this.open = vi.fn()
+      this.setRequestHeader = vi.fn()
+      this.send = vi.fn()
+      this.upload = { onprogress: null as unknown }
+      this.onload = null as unknown
+      this.onerror = null as unknown
+      this.status = 200
+      xhrInstances.push(this)
+    }
+    vi.stubGlobal('XMLHttpRequest', MockXHR)
+  })
+
+  it('resolves on successful upload (2xx)', async () => {
+    const file = new File(['data'], 'test.mp4', { type: 'video/mp4' })
+    const promise = uploadFileToBlob('https://blob.example/sas', file)
+
+    const xhr = xhrInstances[0]
+    expect(xhr.open).toHaveBeenCalledWith('PUT', 'https://blob.example/sas')
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('x-ms-blob-type', 'BlockBlob')
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'video/mp4')
+
+    xhr.status = 200
+    ;(xhr.onload as () => void)()
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('uses fallback content-type when file.type is empty', async () => {
+    const file = new File(['data'], 'test.bin', { type: '' })
+    uploadFileToBlob('https://blob.example/sas', file)
+
+    const xhr = xhrInstances[0]
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream')
+  })
+
+  it('reports upload progress', async () => {
+    const file = new File(['data'], 'test.mp4', { type: 'video/mp4' })
+    const onProgress = vi.fn()
+    const promise = uploadFileToBlob('https://blob.example/sas', file, onProgress)
+
+    const xhr = xhrInstances[0]
+    const progressHandler = (xhr.upload as { onprogress: (e: unknown) => void }).onprogress
+    progressHandler({ lengthComputable: true, loaded: 50, total: 100 })
+    expect(onProgress).toHaveBeenCalledWith(50)
+
+    progressHandler({ lengthComputable: true, loaded: 100, total: 100 })
+    expect(onProgress).toHaveBeenCalledWith(100)
+
+    progressHandler({ lengthComputable: false, loaded: 10, total: 0 })
+    expect(onProgress).toHaveBeenCalledTimes(2)
+
+    xhr.status = 200
+    ;(xhr.onload as () => void)()
+    await promise
+  })
+
+  it('rejects on non-2xx status', async () => {
+    const file = new File(['data'], 'test.mp4', { type: 'video/mp4' })
+    const promise = uploadFileToBlob('https://blob.example/sas', file)
+
+    const xhr = xhrInstances[0]
+    xhr.status = 403
+    ;(xhr.onload as () => void)()
+
+    await expect(promise).rejects.toThrow('Blob upload failed: 403')
+  })
+
+  it('rejects on network error', async () => {
+    const file = new File(['data'], 'test.mp4', { type: 'video/mp4' })
+    const promise = uploadFileToBlob('https://blob.example/sas', file)
+
+    const xhr = xhrInstances[0]
+    ;(xhr.onerror as () => void)()
+
+    await expect(promise).rejects.toThrow('Network error during blob upload')
+  })
+})
+
+// ── uploadVideoFile (orchestrator) ─────────────────────────
+
+describe('uploadVideoFile', () => {
+  let xhrInstances: Array<Record<string, unknown>>
+
+  beforeEach(() => {
+    xhrInstances = []
+    function MockXHR(this: Record<string, unknown>) {
+      this.open = vi.fn()
+      this.setRequestHeader = vi.fn()
+      this.send = vi.fn().mockImplementation(() => {
+        this.status = 200
+        ;(this.onload as () => void)()
+      })
+      this.upload = { onprogress: null as unknown }
+      this.onload = null as unknown
+      this.onerror = null as unknown
+      this.status = 200
+      xhrInstances.push(this)
+    }
+    vi.stubGlobal('XMLHttpRequest', MockXHR)
+  })
+
+  it('chains getSasToken → uploadFileToBlob → registerUploadedVideo', async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse({ blobSasUrl: 'https://blob.example/file.mp4?sig=abc' }))
+      .mockResolvedValueOnce(okResponse({ seq: 42 }))
+
+    const file = new File(['video'], 'clip.mp4', { type: 'video/mp4' })
+    const result = await uploadVideoFile(1, file)
+
+    expect(result.seq).toBe(42)
+    expect(mockFetch.mock.calls[0][0]).toContain('fileName=clip.mp4')
+    const registerBody = JSON.parse(mockFetch.mock.calls[1][1].body)
+    expect(registerBody.fileUrl).toBe('https://blob.example/file.mp4')
+    expect(registerBody.fileName).toBe('clip.mp4')
+    expect(registerBody.spaceSeq).toBe(1)
+  })
+
+  it('passes onProgress to blob upload', async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse({ blobSasUrl: 'https://blob.example/f.mp4?sig=x' }))
+      .mockResolvedValueOnce(okResponse({ seq: 1 }))
+
+    const onProgress = vi.fn()
+    const file = new File(['video'], 'test.mp4', { type: 'video/mp4' })
+    await uploadVideoFile(1, file, onProgress)
+
+    expect(xhrInstances).toHaveLength(1)
+  })
+})

--- a/src/stores/notificationStore.test.ts
+++ b/src/stores/notificationStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useNotificationStore } from './notificationStore'
+
+describe('notificationStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useNotificationStore.setState({ toasts: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with empty toasts', () => {
+    expect(useNotificationStore.getState().toasts).toEqual([])
+  })
+
+  it('addToast adds a toast with auto-generated id', () => {
+    useNotificationStore.getState().addToast({ type: 'success', title: 'Done' })
+
+    const toasts = useNotificationStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].type).toBe('success')
+    expect(toasts[0].title).toBe('Done')
+    expect(toasts[0].id).toMatch(/^toast-\d+$/)
+  })
+
+  it('auto-removes toast after duration', () => {
+    useNotificationStore.getState().addToast({ type: 'info', title: 'Temp', duration: 2000 })
+    expect(useNotificationStore.getState().toasts).toHaveLength(1)
+
+    vi.advanceTimersByTime(2000)
+    expect(useNotificationStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('removeToast removes specific toast', () => {
+    useNotificationStore.getState().addToast({ type: 'error', title: 'Err', duration: 0 })
+    const id = useNotificationStore.getState().toasts[0].id
+
+    useNotificationStore.getState().removeToast(id)
+    expect(useNotificationStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('clearAll removes all toasts', () => {
+    useNotificationStore.getState().addToast({ type: 'info', title: 'A', duration: 0 })
+    useNotificationStore.getState().addToast({ type: 'info', title: 'B', duration: 0 })
+    expect(useNotificationStore.getState().toasts).toHaveLength(2)
+
+    useNotificationStore.getState().clearAll()
+    expect(useNotificationStore.getState().toasts).toHaveLength(0)
+  })
+})

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useThemeStore } from './themeStore'
+
+describe('themeStore', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark')
+    useThemeStore.setState({ mode: 'dark' })
+  })
+
+  it('starts with dark mode', () => {
+    expect(useThemeStore.getState().mode).toBe('dark')
+  })
+
+  it('toggle switches from dark to light', () => {
+    useThemeStore.getState().toggle()
+    expect(useThemeStore.getState().mode).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('toggle switches from light to dark', () => {
+    useThemeStore.setState({ mode: 'light' })
+    useThemeStore.getState().toggle()
+    expect(useThemeStore.getState().mode).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('setMode sets specific mode', () => {
+    useThemeStore.getState().setMode('light')
+    expect(useThemeStore.getState().mode).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('setMode to dark adds dark class', () => {
+    useThemeStore.getState().setMode('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    useThemeStore.getState().setMode('dark')
+    expect(useThemeStore.getState().mode).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('onRehydrateStorage applies dark class for dark mode', () => {
+    document.documentElement.classList.remove('dark')
+    const persist = (useThemeStore as unknown as { persist: { onRehydrate?: () => void } }).persist
+    if (persist && typeof persist.onRehydrate === 'function') {
+      persist.onRehydrate()
+    }
+    useThemeStore.persist.rehydrate()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('onRehydrateStorage callback skips when state is falsy', () => {
+    const options = (useThemeStore as unknown as { persist: { getOptions: () => { onRehydrateStorage?: () => (state: unknown) => void } } }).persist.getOptions()
+    if (options.onRehydrateStorage) {
+      const callback = options.onRehydrateStorage()
+      document.documentElement.classList.add('dark')
+      callback(null)
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    }
+  })
+})

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { formatDuration, formatCredits, formatCurrency, formatNumber } from './formatters'
+
+describe('formatDuration', () => {
+  it('formats seconds only', () => {
+    expect(formatDuration(5)).toBe('0:05')
+    expect(formatDuration(45)).toBe('0:45')
+  })
+
+  it('formats minutes and seconds', () => {
+    expect(formatDuration(65)).toBe('1:05')
+    expect(formatDuration(600)).toBe('10:00')
+  })
+
+  it('formats hours, minutes, and seconds', () => {
+    expect(formatDuration(3661)).toBe('1:01:01')
+    expect(formatDuration(7200)).toBe('2:00:00')
+  })
+
+  it('handles zero', () => {
+    expect(formatDuration(0)).toBe('0:00')
+  })
+
+  it('floors fractional seconds', () => {
+    expect(formatDuration(61.9)).toBe('1:01')
+  })
+})
+
+describe('formatCredits', () => {
+  it('formats with locale separators', () => {
+    expect(formatCredits(1000)).toMatch(/1.000|1,000/)
+  })
+
+  it('handles zero', () => {
+    expect(formatCredits(0)).toBe('0')
+  })
+})
+
+describe('formatCurrency', () => {
+  it('formats as USD', () => {
+    const result = formatCurrency(9.99)
+    expect(result).toContain('9.99')
+    expect(result).toContain('$')
+  })
+
+  it('formats zero', () => {
+    expect(formatCurrency(0)).toContain('0.00')
+  })
+})
+
+describe('formatNumber', () => {
+  it('returns plain string for small numbers', () => {
+    expect(formatNumber(999)).toBe('999')
+    expect(formatNumber(0)).toBe('0')
+  })
+
+  it('formats thousands as K', () => {
+    expect(formatNumber(1000)).toBe('1.0K')
+    expect(formatNumber(1500)).toBe('1.5K')
+    expect(formatNumber(999999)).toBe('1000.0K')
+  })
+
+  it('formats millions as M', () => {
+    expect(formatNumber(1_000_000)).toBe('1.0M')
+    expect(formatNumber(2_500_000)).toBe('2.5M')
+  })
+})

--- a/src/utils/languages.test.ts
+++ b/src/utils/languages.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { SUPPORTED_LANGUAGES, getLanguageByCode } from './languages'
+
+describe('SUPPORTED_LANGUAGES', () => {
+  it('contains expected languages', () => {
+    const codes = SUPPORTED_LANGUAGES.map((l) => l.code)
+    expect(codes).toContain('en')
+    expect(codes).toContain('ko')
+    expect(codes).toContain('ja')
+    expect(codes).toContain('es')
+  })
+
+  it('each language has required fields', () => {
+    for (const lang of SUPPORTED_LANGUAGES) {
+      expect(lang.code).toBeTruthy()
+      expect(lang.name).toBeTruthy()
+      expect(lang.nativeName).toBeTruthy()
+      expect(lang.flag).toBeTruthy()
+    }
+  })
+
+  it('has no duplicate codes', () => {
+    const codes = SUPPORTED_LANGUAGES.map((l) => l.code)
+    expect(new Set(codes).size).toBe(codes.length)
+  })
+})
+
+describe('getLanguageByCode', () => {
+  it('finds existing language', () => {
+    const ko = getLanguageByCode('ko')
+    expect(ko).toBeDefined()
+    expect(ko!.name).toBe('Korean')
+    expect(ko!.nativeName).toBe('한국어')
+  })
+
+  it('returns undefined for unknown code', () => {
+    expect(getLanguageByCode('xx')).toBeUndefined()
+  })
+})

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isValidYouTubeUrl,
+  isValidVideoUrl,
+  extractVideoId,
+  isValidVideoFile,
+} from './validators'
+
+describe('isValidYouTubeUrl', () => {
+  it('accepts standard watch URL', () => {
+    expect(isValidYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('accepts short URL', () => {
+    expect(isValidYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('accepts embed URL', () => {
+    expect(isValidYouTubeUrl('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('accepts shorts URL', () => {
+    expect(isValidYouTubeUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('rejects non-YouTube URL', () => {
+    expect(isValidYouTubeUrl('https://vimeo.com/123456')).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(isValidYouTubeUrl('')).toBe(false)
+  })
+
+  it('rejects random text', () => {
+    expect(isValidYouTubeUrl('not a url')).toBe(false)
+  })
+})
+
+describe('isValidVideoUrl', () => {
+  it('accepts YouTube URL', () => {
+    expect(isValidVideoUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('accepts direct mp4 URL', () => {
+    expect(isValidVideoUrl('https://example.com/video.mp4')).toBe(true)
+  })
+
+  it('accepts direct mov URL', () => {
+    expect(isValidVideoUrl('https://example.com/video.mov')).toBe(true)
+  })
+
+  it('accepts direct webm URL', () => {
+    expect(isValidVideoUrl('https://example.com/video.webm')).toBe(true)
+  })
+
+  it('accepts mp4 URL with query params', () => {
+    expect(isValidVideoUrl('https://cdn.example.com/video.mp4?token=abc123')).toBe(true)
+  })
+
+  it('rejects non-video URL', () => {
+    expect(isValidVideoUrl('https://example.com/page.html')).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(isValidVideoUrl('')).toBe(false)
+  })
+})
+
+describe('extractVideoId', () => {
+  it('extracts from watch URL', () => {
+    expect(extractVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('extracts from short URL', () => {
+    expect(extractVideoId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+  })
+
+  it('returns null for non-YouTube URL', () => {
+    expect(extractVideoId('https://example.com/video.mp4')).toBeNull()
+  })
+})
+
+describe('isValidVideoFile', () => {
+  const makeFile = (name: string, sizeMB: number) =>
+    new File([new ArrayBuffer(sizeMB * 1024 * 1024)], name, { type: 'video/mp4' })
+
+  it('accepts mp4 file', () => {
+    expect(isValidVideoFile(makeFile('test.mp4', 1))).toEqual({ valid: true })
+  })
+
+  it('accepts mov file', () => {
+    expect(isValidVideoFile(makeFile('test.mov', 1))).toEqual({ valid: true })
+  })
+
+  it('accepts webm file', () => {
+    expect(isValidVideoFile(makeFile('test.webm', 1))).toEqual({ valid: true })
+  })
+
+  it('rejects unsupported format', () => {
+    const result = isValidVideoFile(makeFile('test.avi', 1))
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Unsupported')
+  })
+
+  it('rejects file exceeding 2048MB limit', () => {
+    const bigFile = new File([], 'test.mp4', { type: 'video/mp4' })
+    Object.defineProperty(bigFile, 'size', { value: 2049 * 1024 * 1024 })
+    const result = isValidVideoFile(bigFile)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('too large')
+  })
+})

--- a/tests/console-errors.spec.ts
+++ b/tests/console-errors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
+import { signTestSessionCookie } from './helpers/signed-cookie'
 
 /**
  * Walks the 6 main routes on the Next.js app and counts
@@ -15,6 +16,10 @@ const ROUTES = [
 ]
 
 async function injectMockAuth(page: Page) {
+  await page.context().addCookies([
+    { name: 'creatordub_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'google_access_token', value: 'mock-token', domain: 'localhost', path: '/' },
+  ])
   await page.addInitScript(() => {
     try {
       localStorage.setItem(
@@ -26,7 +31,6 @@ async function injectMockAuth(page: Page) {
           photoURL: null,
         })
       )
-      localStorage.setItem('google_access_token', 'mock-token')
     } catch {
       /* noop */
     }

--- a/tests/dark-mode-fouc.spec.ts
+++ b/tests/dark-mode-fouc.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { signTestSessionCookie } from './helpers/signed-cookie'
 
 /**
  * Dark mode FOUC: when the user has previously chosen dark mode,
@@ -25,13 +26,16 @@ test('dark mode has no FOUC on landing', async ({ page }) => {
 })
 
 test('dark mode has no FOUC on dashboard', async ({ page }) => {
+  await page.context().addCookies([
+    { name: 'creatordub_session', value: signTestSessionCookie('x'), domain: 'localhost', path: '/' },
+    { name: 'google_access_token', value: 'mock', domain: 'localhost', path: '/' },
+  ])
   await page.addInitScript(() => {
     localStorage.setItem('creatordub-theme', 'dark')
     localStorage.setItem(
       'google_user',
       JSON.stringify({ uid: 'x', email: 'x@x.x', displayName: 'X', photoURL: null })
     )
-    localStorage.setItem('google_access_token', 'mock')
   })
 
   await page.goto('http://localhost:3000/dashboard', { waitUntil: 'domcontentloaded' })

--- a/tests/e2e-dubbing.spec.ts
+++ b/tests/e2e-dubbing.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Request } from '@playwright/test'
+import { signTestSessionCookie } from './helpers/signed-cookie'
 
 /**
  * E2E dubbing flow verification.
@@ -77,6 +78,10 @@ test('dubbing page renders and captures network sequence', async ({ page }) => {
   const requests: Array<{ method: string; url: string; status?: number }> = []
   const consoleErrors: string[] = []
 
+  await page.context().addCookies([
+    { name: 'creatordub_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'google_access_token', value: 'mock-token', domain: 'localhost', path: '/' },
+  ])
   await page.addInitScript(() => {
     localStorage.setItem(
       'google_user',
@@ -87,7 +92,6 @@ test('dubbing page renders and captures network sequence', async ({ page }) => {
         photoURL: null,
       })
     )
-    localStorage.setItem('google_access_token', 'mock-token')
   })
 
   page.on('request', (req: Request) => {

--- a/tests/lighthouse-gate.mjs
+++ b/tests/lighthouse-gate.mjs
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import { execSync } from 'child_process'
+
+const REPORT_PATH = './tests/snapshots/lighthouse-prod.report.json'
+const BASELINE_PATH = './tests/snapshots/lighthouse-baseline.json'
+const THRESHOLD = 5
+
+if (!fs.existsSync(BASELINE_PATH)) {
+  console.error('❌ Baseline not found:', BASELINE_PATH)
+  process.exit(1)
+}
+
+if (!fs.existsSync(REPORT_PATH)) {
+  console.log('Running Lighthouse…')
+  try {
+    execSync('npm run test:lighthouse:prod', { stdio: 'inherit' })
+  } catch {
+    console.error('❌ Lighthouse run failed')
+    process.exit(1)
+  }
+}
+
+const report = JSON.parse(fs.readFileSync(REPORT_PATH, 'utf8'))
+const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'))
+
+const categories = ['performance', 'accessibility', 'best-practices', 'seo']
+const results = []
+let failed = false
+
+for (const cat of categories) {
+  const current = Math.round(report.categories[cat].score * 100)
+  const base = baseline.scores[cat]
+  const diff = current - base
+  const status = diff < -THRESHOLD ? 'FAIL' : 'PASS'
+  if (status === 'FAIL') failed = true
+  results.push({ category: cat, baseline: base, current, diff, status })
+}
+
+console.log('\n=== Lighthouse CI Gate ===')
+console.log(`Threshold: -${THRESHOLD} points\n`)
+
+for (const r of results) {
+  const sign = r.diff >= 0 ? '+' : ''
+  const icon = r.status === 'FAIL' ? '❌' : '✅'
+  console.log(`${icon} ${r.category.padEnd(16)} baseline=${r.baseline}  current=${r.current}  (${sign}${r.diff})`)
+}
+
+console.log('')
+
+if (failed) {
+  console.error('❌ Lighthouse gate FAILED — score dropped more than ' + THRESHOLD + ' points from baseline.')
+  process.exit(1)
+} else {
+  console.log('✅ Lighthouse gate PASSED.')
+}

--- a/tests/snapshots/lighthouse-baseline.json
+++ b/tests/snapshots/lighthouse-baseline.json
@@ -1,0 +1,10 @@
+{
+  "created": "2026-04-10",
+  "source": "lighthouse-prod.report.json",
+  "scores": {
+    "performance": 83,
+    "accessibility": 90,
+    "best-practices": 100,
+    "seo": 91
+  }
+}

--- a/tests/visual-regression.spec.ts
+++ b/tests/visual-regression.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import fs from 'fs'
 import path from 'path'
+import { signTestSessionCookie } from './helpers/signed-cookie'
 
 /**
  * Visual regression test: captures screenshots from both the
@@ -31,6 +32,10 @@ const SNAPSHOT_DIR = path.join(process.cwd(), 'tests', 'snapshots')
 fs.mkdirSync(SNAPSHOT_DIR, { recursive: true })
 
 async function injectMockAuth(page: Page) {
+  await page.context().addCookies([
+    { name: 'creatordub_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'google_access_token', value: 'mock-token', domain: 'localhost', path: '/' },
+  ])
   await page.addInitScript(() => {
     try {
       localStorage.setItem(
@@ -42,7 +47,6 @@ async function injectMockAuth(page: Page) {
           photoURL: null,
         })
       )
-      localStorage.setItem('google_access_token', 'mock-token')
       // also vite store if exists
       localStorage.setItem(
         'auth-storage',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['src/test-setup.ts'],
+  },
+})


### PR DESCRIPTION
## 관련 이슈
Closes #5

## 변경 요약

### Vitest 도입
- `vitest.config.mts` — `@vitejs/plugin-react` + `jsdom` + `vite-tsconfig-paths`
- `npm run test` / `npm run test:watch` / `npm run test:coverage` 스크립트
- **최종 커버리지: Statements 99.83% / Branches 99.69% / Functions 100%**
- **438 tests — 전부 통과**

### 신규 유닛 테스트
| 파일 | 대상 |
|------|------|
| `stores/notificationStore.test.ts` | 알림 큐 CRUD |
| `stores/themeStore.test.ts` | 테마 토글 + rehydrate |
| `utils/validators.test.ts` | YouTube/video URL/file 검증 |
| `utils/formatters.test.ts` | 날짜/숫자 포맷 |
| `utils/languages.test.ts` | 언어 코드 유틸 |
| `lib/api-client.test.ts` | Perso/YouTube API 클라이언트 |
| `lib/api/dbMutation.test.ts` | DB mutation 헬퍼 |
| `lib/api/response.test.ts` | 통합 response envelope |
| `components/feedback/Toast.test.tsx` | Toast 렌더/dismiss |
| `components/ui/Modal.test.tsx` | Modal open/close/focus trap |

### Lighthouse CI 게이트
- `tests/lighthouse-gate.mjs` — baseline JSON 대비 카테고리별 -5점 초과 시 `exit(1)`
- `tests/snapshots/lighthouse-baseline.json` — perf=83, a11y=90, bp=100, seo=91
- `npm run test:lighthouse:gate` 스크립트

### Playwright 업데이트
- localStorage 토큰 mock → `tests/helpers/signed-cookie.ts` 서명 쿠키로 전환
- console-errors / dark-mode-fouc / e2e-dubbing / visual-regression 스펙 통일

### 문서
- `README.md` 전면 재작성 (스택, env 변수 목록, 테스트/배포 가이드)
- `docs/ARCHITECTURE.md` 신규 (서버/클라 경계, 인증 플로우, DB 스키마, API 라우트 맵)

## 체크리스트
- [x] `npm run test` — 438 tests pass
- [x] Statements/Branches 99%+
- [x] `npm run test:lighthouse:gate` 통과