### PR TITLE
feat: 크레딧 전용 결제 모델로 전환 + Vercel main 전용 배포

### DIFF
--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -1,116 +1,43 @@
 'use client'
 
 import { useState } from 'react'
-import { Check, CreditCard, Download, Coins, ArrowRight } from 'lucide-react'
-import { Card, CardTitle, Button, Badge, Progress } from '@/components/ui'
+import { CreditCard, Download, Coins, ArrowRight } from 'lucide-react'
+import { Card, CardTitle, Button, Badge } from '@/components/ui'
 import { cn } from '@/utils/cn'
-import { PLANS, CREDIT_PACKS } from '@/features/billing/constants/plans'
+import { CREDIT_PACKS } from '@/features/billing/constants/plans'
 import { formatCurrency } from '@/utils/formatters'
 
-const mockSubscription = {
-  plan: 'creator' as const,
-  creditsUsed: 344,
-  creditsTotal: 500,
-  billingDate: 'May 1, 2026',
-  minutesUsed: 245,
-}
+// TODO: replace with real user credits from API
+const mockCreditsRemaining = 0
 
 const mockInvoices = [
-  { id: 'INV-001', date: 'Apr 1, 2026', amount: 29.99, status: 'paid' },
-  { id: 'INV-002', date: 'Mar 1, 2026', amount: 29.99, status: 'paid' },
-  { id: 'INV-003', date: 'Feb 1, 2026', amount: 29.99, status: 'paid' },
-  { id: 'INV-004', date: 'Jan 1, 2026', amount: 9.99, status: 'paid' },
+  { id: 'INV-001', date: 'Apr 1, 2026', amount: 30, status: 'paid' },
+  { id: 'INV-002', date: 'Mar 1, 2026', amount: 60, status: 'paid' },
 ]
 
 export default function BillingPage() {
   const [selectedPack, setSelectedPack] = useState<number | null>(null)
 
-  const currentPlan = PLANS.find((p) => p.tier === mockSubscription.plan)!
-
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-surface-900 dark:text-white">결제</h1>
-        <p className="text-surface-500 dark:text-surface-400">구독 및 크레딧을 관리하세요</p>
+        <p className="text-surface-500 dark:text-surface-400">크레딧을 구매하고 사용 내역을 확인하세요</p>
       </div>
 
-      {/* Current plan */}
+      {/* Current credits */}
       <Card className="border-brand-200 dark:border-brand-800">
-        <div className="flex items-start justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <CardTitle>현재 플랜</CardTitle>
-              <Badge variant="brand">{currentPlan.name}</Badge>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="rounded-xl bg-amber-50 p-3 dark:bg-amber-900/20">
+              <Coins className="h-6 w-6 text-amber-500" />
             </div>
-            <p className="mt-1 text-sm text-surface-500">
-              {currentPlan.priceLabel}/month · 다음 결제: {mockSubscription.billingDate}
-            </p>
+            <div>
+              <p className="text-sm text-surface-500">남은 크레딧</p>
+              <p className="text-3xl font-bold text-surface-900 dark:text-white">{mockCreditsRemaining}분</p>
+            </div>
           </div>
-          <Button variant="outline" size="sm">구독 관리</Button>
-        </div>
-
-        <div className="mt-4 grid gap-4 sm:grid-cols-2">
-          <div className="rounded-lg bg-surface-50 p-4 dark:bg-surface-800">
-            <p className="text-xs text-surface-500 mb-1">크레딧 사용량</p>
-            <p className="text-lg font-bold text-surface-900 dark:text-white">
-              {mockSubscription.creditsUsed} / {mockSubscription.creditsTotal}
-            </p>
-            <Progress value={mockSubscription.creditsUsed} max={mockSubscription.creditsTotal} size="sm" className="mt-2" />
-          </div>
-          <div className="rounded-lg bg-surface-50 p-4 dark:bg-surface-800">
-            <p className="text-xs text-surface-500 mb-1">이번 달 더빙 시간</p>
-            <p className="text-lg font-bold text-surface-900 dark:text-white">
-              {mockSubscription.minutesUsed} min
-            </p>
-            <Badge variant="success" className="mt-2">무제한</Badge>
-          </div>
-        </div>
-      </Card>
-
-      {/* Plan comparison */}
-      <Card>
-        <CardTitle>플랜 변경</CardTitle>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {PLANS.map((plan) => {
-            const isCurrent = plan.tier === mockSubscription.plan
-            return (
-              <div
-                key={plan.tier}
-                className={cn(
-                  'rounded-xl border p-4 transition-all',
-                  isCurrent
-                    ? 'border-brand-500 bg-brand-50/50 dark:bg-brand-900/10'
-                    : 'border-surface-200 dark:border-surface-800',
-                  plan.popular && !isCurrent && 'border-brand-200 dark:border-brand-800',
-                )}
-              >
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-semibold text-surface-900 dark:text-white">{plan.name}</h3>
-                  {isCurrent && <Badge variant="brand">현재</Badge>}
-                </div>
-                <p className="text-2xl font-bold text-surface-900 dark:text-white">
-                  {plan.priceLabel}
-                  {plan.price > 0 && <span className="text-sm font-normal text-surface-500">/mo</span>}
-                </p>
-                <ul className="mt-3 space-y-1.5">
-                  {plan.features.slice(0, 4).map((f) => (
-                    <li key={f} className="flex items-start gap-1.5 text-xs text-surface-600 dark:text-surface-400">
-                      <Check className="h-3 w-3 shrink-0 mt-0.5 text-brand-500" />
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  variant={isCurrent ? 'secondary' : 'outline'}
-                  size="sm"
-                  className="w-full mt-3"
-                  disabled={isCurrent}
-                >
-                  {isCurrent ? '현재 플랜' : '변경'}
-                </Button>
-              </div>
-            )
-          })}
+          <Badge variant="default">1분 = $1</Badge>
         </div>
       </Card>
 
@@ -120,26 +47,26 @@ export default function BillingPage() {
           <Coins className="h-5 w-5 text-amber-500" />
           <CardTitle>크레딧 구매</CardTitle>
         </div>
+        <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">
+          1분 더빙 = 1크레딧 = $1. 만료 없음.
+        </p>
 
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-4">
           {CREDIT_PACKS.map((pack) => (
             <button
-              key={pack.credits}
-              onClick={() => setSelectedPack(pack.credits)}
+              key={pack.minutes}
+              onClick={() => setSelectedPack(pack.minutes)}
               className={cn(
                 'rounded-xl border-2 p-4 text-left transition-all cursor-pointer',
-                selectedPack === pack.credits
+                selectedPack === pack.minutes
                   ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/20'
                   : 'border-surface-200 hover:border-surface-300 dark:border-surface-800 dark:hover:border-surface-700',
               )}
             >
-              <p className="text-2xl font-bold text-surface-900 dark:text-white">{pack.credits}</p>
-              <p className="text-xs text-surface-500">크레딧</p>
-              <p className="mt-2 text-lg font-semibold text-surface-900 dark:text-white">
+              <p className="text-2xl font-bold text-surface-900 dark:text-white">{pack.minutes}분</p>
+              <p className="text-xs text-surface-500 mb-2">{pack.label}</p>
+              <p className="text-lg font-semibold text-surface-900 dark:text-white">
                 {formatCurrency(pack.price)}
-              </p>
-              <p className="text-xs text-emerald-600 dark:text-emerald-400">
-                {formatCurrency(pack.perCredit)}/credit
               </p>
             </button>
           ))}
@@ -148,7 +75,7 @@ export default function BillingPage() {
         {selectedPack && (
           <Button className="mt-4">
             <CreditCard className="h-4 w-4" />
-            {selectedPack} 크레딧 구매
+            {selectedPack}분 크레딧 구매 ({formatCurrency(selectedPack)})
             <ArrowRight className="h-4 w-4" />
           </Button>
         )}

--- a/src/features/billing/constants/plans.ts
+++ b/src/features/billing/constants/plans.ts
@@ -1,69 +1,15 @@
-import type { PlanTier } from '@/utils/constants'
+// 1 credit = 1 minute of dubbing = $1
+export const CREDIT_RATE_PER_MINUTE = 1 // USD
 
-export interface PlanDefinition {
-  tier: PlanTier
-  name: string
+export interface CreditPack {
+  minutes: number
   price: number
-  priceLabel: string
-  description: string
-  popular?: boolean
-  features: string[]
-  limits: {
-    monthlyMinutes: number | null
-    maxLanguages: number
-    maxResolution: string
-    watermark: boolean
-    lipSync: boolean
-    autoUpload: boolean
-    priorityQueue: boolean
-    teamMembers: number
-    apiAccess: boolean
-    customGlossary: boolean
-  }
+  label: string
 }
 
-export const PLANS: PlanDefinition[] = [
-  {
-    tier: 'free',
-    name: 'Free',
-    price: 0,
-    priceLabel: '$0',
-    description: '무료 체험',
-    features: ['월 3분 더빙', '2개 언어', '720p 출력', '워터마크 포함'],
-    limits: { monthlyMinutes: 3, maxLanguages: 2, maxResolution: '720p', watermark: true, lipSync: false, autoUpload: false, priorityQueue: false, teamMembers: 1, apiAccess: false, customGlossary: false },
-  },
-  {
-    tier: 'starter',
-    name: 'Starter',
-    price: 9.99,
-    priceLabel: '$9.99',
-    description: '성장하는 크리에이터',
-    features: ['월 30분 더빙', '5개 언어', '1080p 출력', '워터마크 없음', '번역 에디터'],
-    limits: { monthlyMinutes: 30, maxLanguages: 5, maxResolution: '1080p', watermark: false, lipSync: false, autoUpload: false, priorityQueue: false, teamMembers: 1, apiAccess: false, customGlossary: false },
-  },
-  {
-    tier: 'creator',
-    name: 'Creator',
-    price: 29.99,
-    priceLabel: '$29.99',
-    description: '본격 크리에이터',
-    popular: true,
-    features: ['무제한 더빙', '10개 언어', '4K 출력', '립싱크', 'YouTube 자동 업로드', '우선 처리 큐', '맞춤 용어집'],
-    limits: { monthlyMinutes: null, maxLanguages: 10, maxResolution: '4K', watermark: false, lipSync: true, autoUpload: true, priorityQueue: true, teamMembers: 1, apiAccess: false, customGlossary: true },
-  },
-  {
-    tier: 'agency',
-    name: 'Agency',
-    price: 99.99,
-    priceLabel: '$99.99',
-    description: '팀 & 에이전시',
-    features: ['Creator 전체 포함', '팀 계정 5명', '전용 API 접근', '맞춤 용어집', '우선 지원', '대량 할인'],
-    limits: { monthlyMinutes: null, maxLanguages: 10, maxResolution: '4K', watermark: false, lipSync: true, autoUpload: true, priorityQueue: true, teamMembers: 5, apiAccess: true, customGlossary: true },
-  },
-]
-
-export const CREDIT_PACKS = [
-  { credits: 100, price: 80, perCredit: 0.80 },
-  { credits: 500, price: 350, perCredit: 0.70 },
-  { credits: 1000, price: 600, perCredit: 0.60 },
+export const CREDIT_PACKS: CreditPack[] = [
+  { minutes: 10, price: 10, label: '10분' },
+  { minutes: 30, price: 30, label: '30분' },
+  { minutes: 60, price: 60, label: '1시간' },
+  { minutes: 120, price: 120, label: '2시간' },
 ]

--- a/src/features/dashboard/components/DashboardSummary.tsx
+++ b/src/features/dashboard/components/DashboardSummary.tsx
@@ -27,7 +27,7 @@ export function DashboardSummary({ initialData }: DashboardSummaryProps) {
     },
     {
       label: '남은 크레딧',
-      value: data ? Number(data.credits_remaining) : 100,
+      value: data ? Number(data.credits_remaining) : 0,
       icon: Coins,
       color: 'text-amber-500 bg-amber-50 dark:bg-amber-900/20',
     },

--- a/src/features/landing/PricingSection.tsx
+++ b/src/features/landing/PricingSection.tsx
@@ -1,8 +1,17 @@
 import { Check } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui'
-import { cn } from '@/utils/cn'
-import { PLANS } from '@/features/billing/constants/plans'
+import { CREDIT_PACKS } from '@/features/billing/constants/plans'
+import { formatCurrency } from '@/utils/formatters'
+
+const INCLUDED_FEATURES = [
+  '모든 언어 지원',
+  '1080p 출력',
+  '워터마크 없음',
+  '립싱크',
+  'YouTube 자동 업로드',
+  '크레딧 만료 없음',
+]
 
 export function PricingSection() {
   return (
@@ -13,49 +22,45 @@ export function PricingSection() {
             심플하고 투명한 요금제
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-lg text-surface-500 dark:text-surface-400">
-            무료로 시작, 성장에 따라 확장. 숨겨진 비용 없음.
+            구독 없음. 1분 더빙 = $1. 원하는 만큼 충전해서 사용하세요.
           </p>
         </div>
 
-        <div className="mt-16 grid gap-6 lg:grid-cols-4">
-          {PLANS.map((plan) => (
-            <div
-              key={plan.tier}
-              className={cn(
-                'relative rounded-2xl border p-6 transition-all',
-                plan.popular
-                  ? 'border-brand-500 bg-white shadow-xl shadow-brand-500/10 dark:bg-surface-900 scale-[1.02]'
-                  : 'border-surface-200 bg-white dark:border-surface-800 dark:bg-surface-900',
-              )}
-            >
-              {plan.popular && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gradient-to-r from-brand-600 to-brand-500 px-4 py-1 text-xs font-bold text-white shadow-lg">
-                  가장 인기
-                </div>
-              )}
-              <div className="mb-6">
-                <h3 className="text-lg font-bold text-surface-900 dark:text-white">{plan.name}</h3>
-                <p className="text-sm text-surface-600 dark:text-surface-300">{plan.description}</p>
-                <div className="mt-4">
-                  <span className="text-4xl font-extrabold text-surface-900 dark:text-white">{plan.priceLabel}</span>
-                  {plan.price > 0 && <span className="text-surface-600 dark:text-surface-300">/월</span>}
-                </div>
+        <div className="mt-16 mx-auto max-w-3xl">
+          {/* Feature list */}
+          <div className="mb-10 rounded-2xl border border-surface-200 bg-white p-6 dark:border-surface-800 dark:bg-surface-900">
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-surface-500 mb-4">모든 플랜 포함</h3>
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {INCLUDED_FEATURES.map((feature) => (
+                <li key={feature} className="flex items-center gap-2 text-sm text-surface-700 dark:text-surface-300">
+                  <Check className="h-4 w-4 shrink-0 text-brand-500" />
+                  {feature}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Credit packs */}
+          <div className="grid gap-4 sm:grid-cols-4">
+            {CREDIT_PACKS.map((pack) => (
+              <div
+                key={pack.minutes}
+                className="rounded-2xl border border-surface-200 bg-white p-6 text-center dark:border-surface-800 dark:bg-surface-900"
+              >
+                <p className="text-3xl font-extrabold text-surface-900 dark:text-white">{pack.minutes}분</p>
+                <p className="mt-1 text-2xl font-bold text-brand-600">{formatCurrency(pack.price)}</p>
+                <p className="mt-1 text-xs text-surface-500">$1/분</p>
               </div>
-              <Link href="/billing">
-                <Button variant={plan.popular ? 'primary' : 'outline'} className="w-full">
-                  {plan.price === 0 ? '무료로 시작' : '구독하기'}
-                </Button>
-              </Link>
-              <ul className="mt-6 space-y-3">
-                {plan.features.map((feature) => (
-                  <li key={feature} className="flex items-start gap-2 text-sm">
-                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-brand-500" />
-                    <span className="text-surface-700 dark:text-surface-300">{feature}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+            ))}
+          </div>
+
+          <div className="mt-8 text-center">
+            <Link href="/billing">
+              <Button variant="primary" size="lg">
+                지금 시작하기
+              </Button>
+            </Link>
+          </div>
         </div>
       </div>
     </section>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,1 @@
-export const PLAN_TIERS = ['free', 'starter', 'creator', 'agency'] as const
-export type PlanTier = (typeof PLAN_TIERS)[number]
+export const CREDIT_RATE_PER_MINUTE = 1 // $1 per minute of dubbing

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 구독 플랜(Free/Starter/Creator/Agency) 완전 제거, 크레딧 충전 방식으로 전환
- 1분 더빙 = 1크레딧 = $1, 충전 팩: 10/30/60/120분, 신규 유저 기본 크레딧 0
- `vercel.json` 추가: main 브랜치만 배포 트리거 (ralph/* 배포 차단)

## Changes
- `billing/constants/plans.ts` — 플랜 정의 삭제, 크레딧 팩 단순화
- `utils/constants.ts` — PLAN_TIERS 삭제
- `billing/page.tsx` — 구독 UI 제거, 크레딧 충전 UI로 교체
- `landing/PricingSection.tsx` — 랜딩 요금제 섹션 크레딧 팩으로 교체
- `DashboardSummary.tsx` — 기본 크레딧 100 → 0
- `vercel.json` — main 브랜치만 배포

## Test plan
- [ ] 빌링 페이지 크레딧 잔액 표시 확인
- [ ] 크레딧 팩 선택 UI 동작 확인
- [ ] 랜딩 요금제 섹션 렌더링 확인
- [ ] ralph/* 푸시 시 Vercel 배포 안 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)