### PR TITLE
feat/fix/refactor: 크레딧 결제 모델 + OAuth 수정 + 코드 정리

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { SESSION_COOKIE, verifySessionCookie } from '@/lib/auth/session-cookie'
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
   const raw = request.cookies.get(SESSION_COOKIE)?.value
   if (!raw || !verifySessionCookie(raw)) {
     return NextResponse.redirect(new URL('/', request.url))

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// Google OAuth popup callback page.
+// Google redirects here with ?code=... — we pass it to the opener via postMessage then close.
+export default function AuthCallbackPage() {
+  const params = useSearchParams()
+
+  useEffect(() => {
+    const code = params.get('code')
+    const error = params.get('error')
+
+    if (window.opener) {
+      window.opener.postMessage(
+        { type: 'google_oauth_callback', code, error },
+        window.location.origin,
+      )
+    }
+    window.close()
+  }, [params])
+
+  return null
+}

--- a/src/components/layout/LandingNavBar.tsx
+++ b/src/components/layout/LandingNavBar.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Languages, Moon, Sun } from 'lucide-react'
 import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
-import { signInWithGoogle } from '@/lib/firebase'
+import { signInWithGoogle } from '@/lib/google-auth'
 import { useNotificationStore } from '@/stores/notificationStore'
 import { Button } from '@/components/ui'
 

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { Moon, Sun, Bell, LogOut } from 'lucide-react'
 import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
-import { signOut } from '@/lib/firebase'
+import { signOut } from '@/lib/google-auth'
 import { Button } from '@/components/ui'
 import { useRouter } from 'next/navigation'
 

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -6,7 +6,7 @@ import { queryClient } from '@/services/queryClient'
 import { ToastContainer } from '@/components/feedback/Toast'
 import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
-import { restoreSession } from '@/lib/firebase'
+import { restoreSession } from '@/lib/google-auth'
 
 function ThemeHydrator() {
   useEffect(() => {

--- a/src/features/billing/constants/plans.ts
+++ b/src/features/billing/constants/plans.ts
@@ -1,6 +1,3 @@
-// 1 credit = 1 minute of dubbing = $1
-export const CREDIT_RATE_PER_MINUTE = 1 // USD
-
 export interface CreditPack {
   minutes: number
   price: number

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -34,7 +34,7 @@ export async function signInWithGoogle(): Promise<{
   if (!clientId) throw new Error('NEXT_PUBLIC_GOOGLE_CLIENT_ID를 .env.local에 설정해주세요')
 
   return new Promise((resolve, reject) => {
-    const redirectUri = window.location.origin
+    const redirectUri = `${window.location.origin}/auth/callback`
     const scope = [
       'openid',
       'email',
@@ -61,63 +61,62 @@ export async function signInWithGoogle(): Promise<{
       return
     }
 
-    const timer = setInterval(async () => {
+    // Use postMessage instead of polling popup.location (avoids COOP issues)
+    const onMessage = async (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return
+      if (event.data?.type !== 'google_oauth_callback') return
+
+      window.removeEventListener('message', onMessage)
+      clearInterval(closedTimer)
+
+      const { code, error } = event.data
+
+      if (error) {
+        reject(new Error(`Google 인증 오류: ${error}`))
+        return
+      }
+      if (!code) {
+        reject(new Error('인증 코드를 받지 못했습니다.'))
+        return
+      }
+
       try {
-        if (popup.closed) {
-          clearInterval(timer)
-          reject(new Error('로그인이 취소되었습니다.'))
-          return
+        const res = await fetch('/api/auth/callback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, redirectUri }),
+        })
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => null)
+          throw new Error(body?.error?.message || '인증에 실패했습니다.')
         }
 
-        const url = popup.location.href
-        if (url.startsWith(redirectUri)) {
-          clearInterval(timer)
-          popup.close()
+        const body = await res.json()
+        const data = body.data
 
-          const parsedUrl = new URL(url)
-          const code = parsedUrl.searchParams.get('code')
-          const error = parsedUrl.searchParams.get('error')
-
-          if (error) {
-            reject(new Error(`Google 인증 오류: ${error}`))
-            return
-          }
-
-          if (!code) {
-            reject(new Error('인증 코드를 받지 못했습니다.'))
-            return
-          }
-
-          const res = await fetch('/api/auth/callback', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code, redirectUri }),
-          })
-
-          if (!res.ok) {
-            const body = await res.json().catch(() => null)
-            throw new Error(body?.error?.message || '인증에 실패했습니다.')
-          }
-
-          const body = await res.json()
-          const data = body.data
-
-          const user: GoogleUser = {
-            uid: data.id,
-            email: data.email,
-            displayName: data.displayName || null,
-            photoURL: data.photoURL || null,
-          }
-
-          storeUser(user)
-
-          resolve({ user })
+        const user: GoogleUser = {
+          uid: data.id,
+          email: data.email,
+          displayName: data.displayName || null,
+          photoURL: data.photoURL || null,
         }
+
+        storeUser(user)
+        resolve({ user })
       } catch (err) {
-        if (err instanceof Error && err.message !== '로그인이 취소되었습니다.') {
-          clearInterval(timer)
-          reject(err)
-        }
+        reject(err)
+      }
+    }
+
+    window.addEventListener('message', onMessage)
+
+    // Detect manual close without completing auth
+    const closedTimer = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(closedTimer)
+        window.removeEventListener('message', onMessage)
+        reject(new Error('로그인이 취소되었습니다.'))
       }
     }, 500)
   })

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -131,4 +131,3 @@ export function restoreSession(): { user: GoogleUser | null } {
   return { user: getStoredUser() }
 }
 
-export type User = GoogleUser

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
-import type { GoogleUser } from '@/lib/firebase'
+import type { GoogleUser } from '@/lib/google-auth'
 
 interface AuthState {
   user: GoogleUser | null

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, formatCredits, formatCurrency, formatNumber } from './formatters'
+import { formatDuration, formatCurrency, formatNumber } from './formatters'
 
 describe('formatDuration', () => {
   it('formats seconds only', () => {
@@ -26,15 +26,6 @@ describe('formatDuration', () => {
   })
 })
 
-describe('formatCredits', () => {
-  it('formats with locale separators', () => {
-    expect(formatCredits(1000)).toMatch(/1.000|1,000/)
-  })
-
-  it('handles zero', () => {
-    expect(formatCredits(0)).toBe('0')
-  })
-})
 
 describe('formatCurrency', () => {
   it('formats as USD', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -6,10 +6,6 @@ export function formatDuration(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
-export function formatCredits(credits: number): string {
-  return credits.toLocaleString()
-}
-
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)
 }


### PR DESCRIPTION
## Summary
- 구독 플랜 완전 제거, 크레딧 충전 방식으로 전환 (1분 = $1)
- Google OAuth 팝업 COOP 오류 해결 (postMessage 방식으로 전환)
- `firebase.ts` → `google-auth.ts` 이름 변경 (Firebase SDK 미사용)
- `proxy.ts` → 루트 `middleware.ts`로 이동 (실제 미들웨어로 동작)
- `vercel.json` 추가: main 브랜치만 배포

## Changes
- `src/lib/google-auth.ts` — firebase.ts 개명, User 스텁 제거
- `middleware.ts` — proxy.ts를 Next.js 표준 위치로 이동
- `src/app/auth/callback/page.tsx` — OAuth postMessage 콜백 페이지
- `src/features/billing/constants/plans.ts` — 플랜 삭제, 크레딧 팩만 유지
- `src/utils/formatters.ts` — formatCredits 제거
- `vercel.json` — main만 배포 트리거

## Test plan
- [ ] Google 로그인 팝업 정상 동작
- [ ] 미인증 상태 /dashboard 접근 시 / 리디렉트
- [ ] 빌링 페이지 크레딧 UI 확인
- [ ] `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)