### PR TITLE
fix: Edge Runtime 호환 및 OAuth 콜백 prerender 오류 해결

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,9 +2,9 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { SESSION_COOKIE, verifySessionCookie } from '@/lib/auth/session-cookie'
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const raw = request.cookies.get(SESSION_COOKIE)?.value
-  if (!raw || !verifySessionCookie(raw)) {
+  if (!raw || !(await verifySessionCookie(raw))) {
     return NextResponse.redirect(new URL('/', request.url))
   }
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { verifySessionCookie } from '@/lib/auth/session-cookie'
 export default async function DashboardPage() {
   const cookieStore = await cookies()
   const raw = cookieStore.get('creatordub_session')?.value
-  const uid = raw ? verifySessionCookie(raw) : null
+  const uid = raw ? await verifySessionCookie(raw) : null
 
   if (!uid) {
     return null

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -91,7 +91,7 @@ export async function POST(req: NextRequest) {
       displayName: info.name ?? null,
       photoURL: info.picture ?? null,
     })
-    res.cookies.set(SESSION_COOKIE, signSessionCookie(info.sub), cookieOpts)
+    res.cookies.set(SESSION_COOKIE, await signSessionCookie(info.sub), cookieOpts)
     res.cookies.set('google_access_token', tokens.access_token, {
       ...cookieOpts,
       maxAge: tokens.expires_in,

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
       maxAge: 60 * 60 * 24 * 7,
     }
     const res = apiOk({ id: uid })
-    res.cookies.set(SESSION_COOKIE, signSessionCookie(uid), cookieOpts)
+    res.cookies.set(SESSION_COOKIE, await signSessionCookie(uid), cookieOpts)
     if (accessToken) {
       res.cookies.set('google_access_token', accessToken, cookieOpts)
     }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,14 +3,12 @@
 export const dynamic = 'force-dynamic'
 
 import { useEffect } from 'react'
-import { useSearchParams } from 'next/navigation'
 
-// Google OAuth popup callback page.
-// Google redirects here with ?code=... — we pass it to the opener via postMessage then close.
+// Google OAuth popup callback.
+// Google redirects here with ?code=... — pass to opener via postMessage then close.
 export default function AuthCallbackPage() {
-  const params = useSearchParams()
-
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
     const code = params.get('code')
     const error = params.get('error')
 
@@ -21,7 +19,7 @@ export default function AuthCallbackPage() {
       )
     }
     window.close()
-  }, [params])
+  }, [])
 
   return null
 }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+export const dynamic = 'force-dynamic'
+
 import { useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 

--- a/src/lib/auth/session-cookie.test.ts
+++ b/src/lib/auth/session-cookie.test.ts
@@ -7,61 +7,61 @@ describe('session-cookie', () => {
   })
 
   describe('signSessionCookie', () => {
-    it('produces uid.signature format', () => {
-      const signed = signSessionCookie('user123')
+    it('produces uid.signature format', async () => {
+      const signed = await signSessionCookie('user123')
       expect(signed).toMatch(/^user123\.[a-f0-9]{64}$/)
     })
 
-    it('produces different signatures for different uids', () => {
-      const a = signSessionCookie('alice')
-      const b = signSessionCookie('bob')
-      expect(a.split('.')[1]).not.toBe(b.split('.')[1])
+    it('produces different signatures for different uids', async () => {
+      const a = await signSessionCookie('alice')
+      const b = await signSessionCookie('bob')
+      expect(a.split('.').pop()).not.toBe(b.split('.').pop())
     })
 
-    it('produces deterministic output', () => {
-      expect(signSessionCookie('uid1')).toBe(signSessionCookie('uid1'))
+    it('produces deterministic output', async () => {
+      expect(await signSessionCookie('uid1')).toBe(await signSessionCookie('uid1'))
     })
   })
 
   describe('verifySessionCookie', () => {
-    it('returns uid for valid signed cookie', () => {
-      const signed = signSessionCookie('user123')
-      expect(verifySessionCookie(signed)).toBe('user123')
+    it('returns uid for valid signed cookie', async () => {
+      const signed = await signSessionCookie('user123')
+      expect(await verifySessionCookie(signed)).toBe('user123')
     })
 
-    it('returns null for tampered uid', () => {
-      const signed = signSessionCookie('user123')
+    it('returns null for tampered uid', async () => {
+      const signed = await signSessionCookie('user123')
       const tampered = 'hacker' + signed.slice(signed.indexOf('.'))
-      expect(verifySessionCookie(tampered)).toBeNull()
+      expect(await verifySessionCookie(tampered)).toBeNull()
     })
 
-    it('returns null for tampered signature', () => {
-      const signed = signSessionCookie('user123')
+    it('returns null for tampered signature', async () => {
+      const signed = await signSessionCookie('user123')
       const tampered = signed.slice(0, -4) + 'dead'
-      expect(verifySessionCookie(tampered)).toBeNull()
+      expect(await verifySessionCookie(tampered)).toBeNull()
     })
 
-    it('returns null for plain uid (unsigned)', () => {
-      expect(verifySessionCookie('user123')).toBeNull()
+    it('returns null for plain uid (unsigned)', async () => {
+      expect(await verifySessionCookie('user123')).toBeNull()
     })
 
-    it('returns null for empty string', () => {
-      expect(verifySessionCookie('')).toBeNull()
+    it('returns null for empty string', async () => {
+      expect(await verifySessionCookie('')).toBeNull()
     })
 
-    it('returns null for just a dot', () => {
-      expect(verifySessionCookie('.')).toBeNull()
+    it('returns null for just a dot', async () => {
+      expect(await verifySessionCookie('.')).toBeNull()
     })
 
-    it('returns null when signature length differs from expected', () => {
-      const signed = signSessionCookie('user123')
+    it('returns null when signature is truncated', async () => {
+      const signed = await signSessionCookie('user123')
       const truncated = signed.slice(0, -10)
-      expect(verifySessionCookie(truncated)).toBeNull()
+      expect(await verifySessionCookie(truncated)).toBeNull()
     })
 
-    it('handles uid containing dots', () => {
-      const signed = signSessionCookie('user.with.dots')
-      expect(verifySessionCookie(signed)).toBe('user.with.dots')
+    it('handles uid containing dots', async () => {
+      const signed = await signSessionCookie('user.with.dots')
+      expect(await verifySessionCookie(signed)).toBe('user.with.dots')
     })
   })
 
@@ -77,13 +77,13 @@ describe('session-cookie', () => {
     })
 
     it('uses custom secret when SESSION_SECRET is set', async () => {
-      const defaultSigned = signSessionCookie('uid1')
+      const defaultSigned = await signSessionCookie('uid1')
 
       process.env.SESSION_SECRET = 'custom-test-secret-32chars-long!!'
 
       vi.resetModules()
       const freshMod = await vi.importActual<typeof import('./session-cookie')>('./session-cookie')
-      const customSigned = freshMod.signSessionCookie('uid1')
+      const customSigned = await freshMod.signSessionCookie('uid1')
 
       expect(customSigned).not.toBe(defaultSigned)
     })
@@ -95,7 +95,7 @@ describe('session-cookie', () => {
       vi.resetModules()
       const freshMod = await vi.importActual<typeof import('./session-cookie')>('./session-cookie')
 
-      expect(() => freshMod.signSessionCookie('uid1')).toThrow(
+      await expect(freshMod.signSessionCookie('uid1')).rejects.toThrow(
         'SESSION_SECRET env var is required in production',
       )
 

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,7 +1,7 @@
-import { createHmac, timingSafeEqual } from 'node:crypto'
-
+// Web Crypto API — compatible with both Edge Runtime and Node.js 18+
 const SESSION_COOKIE = 'creatordub_session'
 const SEPARATOR = '.'
+const enc = new TextEncoder()
 
 function getSecret(): string {
   const secret = process.env.SESSION_SECRET
@@ -12,29 +12,52 @@ function getSecret(): string {
   return 'creatordub-dev-secret-do-not-use-in-prod'
 }
 
-function hmac(data: string): string {
-  return createHmac('sha256', getSecret()).update(data).digest('hex')
+async function importKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  )
+}
+
+function toHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function fromHex(hex: string): Uint8Array {
+  const pairs = hex.match(/.{2}/g)
+  if (!pairs || pairs.length !== hex.length / 2) return new Uint8Array(0)
+  return new Uint8Array(pairs.map((b) => parseInt(b, 16)))
 }
 
 export { SESSION_COOKIE }
 
-export function signSessionCookie(uid: string): string {
-  return `${uid}${SEPARATOR}${hmac(uid)}`
+export async function signSessionCookie(uid: string): Promise<string> {
+  const key = await importKey(getSecret())
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(uid))
+  return `${uid}${SEPARATOR}${toHex(sig)}`
 }
 
-export function verifySessionCookie(cookie: string): string | null {
+export async function verifySessionCookie(cookie: string): Promise<string | null> {
   const idx = cookie.lastIndexOf(SEPARATOR)
   if (idx < 1) return null
 
   const uid = cookie.slice(0, idx)
-  const sig = cookie.slice(idx + 1)
-  const expected = hmac(uid)
+  const sigHex = cookie.slice(idx + 1)
+  if (sigHex.length === 0 || sigHex.length % 2 !== 0) return null
 
-  if (sig.length !== expected.length) return null
+  const sigBytes = fromHex(sigHex)
+  if (sigBytes.length === 0) return null
 
-  const sigBuf = Buffer.from(sig, 'utf8')
-  const expectedBuf = Buffer.from(expected, 'utf8')
-  if (!timingSafeEqual(sigBuf, expectedBuf)) return null
-
-  return uid
+  try {
+    const key = await importKey(getSecret())
+    const valid = await crypto.subtle.verify('HMAC', key, sigBytes.buffer as ArrayBuffer, enc.encode(uid))
+    return valid ? uid : null
+  } catch {
+    return null
+  }
 }

--- a/src/lib/youtube/route-helpers.ts
+++ b/src/lib/youtube/route-helpers.ts
@@ -65,7 +65,7 @@ export async function requireAccessToken(req: Request): Promise<string> {
   if (!cookieToken) {
     const sessionCookie = cookieStore.get('creatordub_session')?.value
     if (sessionCookie) {
-      const uid = verifySessionCookie(sessionCookie)
+      const uid = await verifySessionCookie(sessionCookie)
       if (uid) {
         const refreshed = await getOrRefreshAccessToken(uid)
         if (refreshed) return refreshed


### PR DESCRIPTION
## Summary
- `session-cookie.ts`: `node:crypto` → Web Crypto API로 교체 (Edge Runtime / 미들웨어 호환)
- `/auth/callback` 페이지: `useSearchParams()` 제거 → `window.location.search` 직접 사용 (Suspense 경계 불필요)
- `middleware.ts`: async 미들웨어로 업데이트
- `signSessionCookie` / `verifySessionCookie` 호출부 전체 `await` 추가
- `session-cookie.test.ts`: 비동기 테스트로 업데이트

## Test plan
- [ ] Vercel 빌드 통과 확인
- [ ] Google 로그인 팝업 정상 동작 확인
- [ ] 미인증 상태 `/dashboard` 접근 시 `/` 리디렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)