### PR TITLE
feat: YouTube 실제 데이터 연결 + 빌링 UI 개선 + 목 데이터 제거

### DIFF
--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import { useState } from 'react'
-import { CreditCard, Download, Coins, ArrowRight } from 'lucide-react'
-import { Card, CardTitle, Button, Badge } from '@/components/ui'
+import { CreditCard, Download, Coins, ArrowRight, Loader2 } from 'lucide-react'
+import { Card, CardTitle, Button } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { CREDIT_PACKS } from '@/features/billing/constants/plans'
 import { formatCurrency } from '@/utils/formatters'
+import { useDashboardSummary } from '@/hooks/useDashboardData'
 
 export default function BillingPage() {
   const [selectedPack, setSelectedPack] = useState<number | null>(null)
+  const { data: summary, isLoading } = useDashboardSummary()
+
+  const minutesRemaining = summary ? Number(summary.credits_remaining) : null
 
   return (
     <div className="space-y-6">
@@ -17,7 +21,7 @@ export default function BillingPage() {
         <p className="text-surface-500 dark:text-surface-400">크레딧을 구매하고 사용 내역을 확인하세요</p>
       </div>
 
-      {/* Current credits */}
+      {/* Remaining time */}
       <Card className="border-brand-200 dark:border-brand-800">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -25,11 +29,17 @@ export default function BillingPage() {
               <Coins className="h-6 w-6 text-amber-500" />
             </div>
             <div>
-              <p className="text-sm text-surface-500">남은 크레딧</p>
-              <p className="text-3xl font-bold text-surface-900 dark:text-white">0분</p>
+              <p className="text-sm text-surface-500">남은 시간</p>
+              {isLoading ? (
+                <Loader2 className="mt-1 h-6 w-6 animate-spin text-surface-300" />
+              ) : (
+                <p className="text-3xl font-bold text-surface-900 dark:text-white">
+                  {minutesRemaining ?? 0}분
+                </p>
+              )}
             </div>
           </div>
-          <Badge variant="default">1분 = $1</Badge>
+          <p className="text-sm text-surface-400">1분 = $1</p>
         </div>
       </Card>
 
@@ -37,10 +47,10 @@ export default function BillingPage() {
       <Card>
         <div className="flex items-center gap-2 mb-4">
           <Coins className="h-5 w-5 text-amber-500" />
-          <CardTitle>크레딧 구매</CardTitle>
+          <CardTitle>시간 충전</CardTitle>
         </div>
         <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">
-          1분 더빙 = 1크레딧 = $1. 만료 없음.
+          1분 더빙 = $1. 만료 없음.
         </p>
 
         <div className="grid gap-3 sm:grid-cols-4">
@@ -67,7 +77,7 @@ export default function BillingPage() {
         {selectedPack && (
           <Button className="mt-4">
             <CreditCard className="h-4 w-4" />
-            {selectedPack}분 크레딧 구매 ({formatCurrency(selectedPack)})
+            {selectedPack}분 충전 ({formatCurrency(selectedPack)})
             <ArrowRight className="h-4 w-4" />
           </Button>
         )}
@@ -75,7 +85,7 @@ export default function BillingPage() {
 
       {/* Invoices */}
       <Card>
-        <CardTitle>인보이스</CardTitle>
+        <CardTitle>결제 내역</CardTitle>
         <div className="mt-4 py-8 text-center text-sm text-surface-400">
           결제 내역이 없습니다
         </div>

--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -7,14 +7,6 @@ import { cn } from '@/utils/cn'
 import { CREDIT_PACKS } from '@/features/billing/constants/plans'
 import { formatCurrency } from '@/utils/formatters'
 
-// TODO: replace with real user credits from API
-const mockCreditsRemaining = 0
-
-const mockInvoices = [
-  { id: 'INV-001', date: 'Apr 1, 2026', amount: 30, status: 'paid' },
-  { id: 'INV-002', date: 'Mar 1, 2026', amount: 60, status: 'paid' },
-]
-
 export default function BillingPage() {
   const [selectedPack, setSelectedPack] = useState<number | null>(null)
 
@@ -34,7 +26,7 @@ export default function BillingPage() {
             </div>
             <div>
               <p className="text-sm text-surface-500">남은 크레딧</p>
-              <p className="text-3xl font-bold text-surface-900 dark:text-white">{mockCreditsRemaining}분</p>
+              <p className="text-3xl font-bold text-surface-900 dark:text-white">0분</p>
             </div>
           </div>
           <Badge variant="default">1분 = $1</Badge>
@@ -84,35 +76,8 @@ export default function BillingPage() {
       {/* Invoices */}
       <Card>
         <CardTitle>인보이스</CardTitle>
-        <div className="mt-4 overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-surface-200 dark:border-surface-800">
-                <th className="pb-2 text-left font-medium text-surface-500">인보이스</th>
-                <th className="pb-2 text-left font-medium text-surface-500">날짜</th>
-                <th className="pb-2 text-left font-medium text-surface-500">금액</th>
-                <th className="pb-2 text-left font-medium text-surface-500">상태</th>
-                <th className="pb-2 text-right font-medium text-surface-500"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {mockInvoices.map((inv) => (
-                <tr key={inv.id} className="border-b border-surface-100 dark:border-surface-800">
-                  <td className="py-3 font-medium text-surface-900 dark:text-white">{inv.id}</td>
-                  <td className="py-3 text-surface-500">{inv.date}</td>
-                  <td className="py-3 text-surface-900 dark:text-white">{formatCurrency(inv.amount)}</td>
-                  <td className="py-3">
-                    <Badge variant="success">결제 완료</Badge>
-                  </td>
-                  <td className="py-3 text-right">
-                    <button className="text-surface-400 hover:text-surface-600">
-                      <Download className="h-4 w-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="mt-4 py-8 text-center text-sm text-surface-400">
+          결제 내역이 없습니다
         </div>
       </Card>
     </div>

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import { useState } from 'react'
-import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe } from 'lucide-react'
+import Image from 'next/image'
+import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe, Loader2 } from 'lucide-react'
 import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from '@/components/ui'
+import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
+import { formatNumber } from '@/utils/formatters'
 
 export default function YouTubeSettingsPage() {
-  const [isConnected, setIsConnected] = useState(false)
   const [defaultVisibility, setDefaultVisibility] = useState('public')
   const [autoSubtitles, setAutoSubtitles] = useState(true)
+
+  const { data: channel, isLoading: channelLoading } = useChannelStats()
+  const isConnected = !!channel
+  const { data: videos = [], isLoading: videosLoading } = useMyVideos(10)
 
   return (
     <div className="space-y-6">
@@ -19,19 +25,39 @@ export default function YouTubeSettingsPage() {
       {/* Channel Connection */}
       <Card>
         <CardTitle>연결된 채널</CardTitle>
-        {isConnected ? (
+        {channelLoading ? (
+          <div className="mt-4 flex items-center gap-2 text-surface-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-sm">채널 정보 불러오는 중...</span>
+          </div>
+        ) : isConnected ? (
           <div className="mt-4 flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-red-500 to-red-600 text-lg font-bold text-white">
-                YT
-              </div>
+              {channel.thumbnail ? (
+                <Image
+                  src={channel.thumbnail}
+                  alt={channel.title}
+                  width={48}
+                  height={48}
+                  className="rounded-full object-cover"
+                  referrerPolicy="no-referrer"
+                />
+              ) : (
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-red-500 to-red-600 text-lg font-bold text-white">
+                  {channel.title[0]?.toUpperCase() || 'Y'}
+                </div>
+              )}
               <div>
-                <p className="font-semibold text-surface-900 dark:text-white">내 채널</p>
-                <p className="text-sm text-surface-500">YouTube 채널 연결됨</p>
+                <p className="font-semibold text-surface-900 dark:text-white">{channel.title}</p>
+                <p className="text-sm text-surface-500">
+                  구독자 {formatNumber(channel.subscriberCount)} · 영상 {formatNumber(channel.videoCount)}개
+                </p>
               </div>
               <Badge variant="success">연결됨</Badge>
             </div>
-            <Button variant="outline" size="sm" onClick={() => setIsConnected(false)}>
+            <Button variant="outline" size="sm" onClick={() => {
+              fetch('/api/auth/signout', { method: 'POST' }).then(() => window.location.reload())
+            }}>
               <Unlink className="h-4 w-4" />
               연결 해제
             </Button>
@@ -40,9 +66,10 @@ export default function YouTubeSettingsPage() {
           <div className="mt-4 flex flex-col items-center gap-4 py-8">
             <Video className="h-12 w-12 text-surface-300" />
             <p className="text-surface-500">연결된 YouTube 채널이 없습니다</p>
-            <Button onClick={() => setIsConnected(true)}>
+            <p className="text-xs text-surface-400">Google 로그인 시 YouTube 권한이 함께 연결됩니다</p>
+            <Button onClick={() => window.location.href = '/'}>
               <Globe className="h-4 w-4" />
-              YouTube 채널 연결
+              Google 계정으로 연결
             </Button>
           </div>
         )}
@@ -57,10 +84,20 @@ export default function YouTubeSettingsPage() {
             <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
               YouTube Multi-Audio Track 업로드는 구독자 수, 커뮤니티 가이드라인 준수 등 채널 자격 요건을 충족해야 합니다. YouTube Studio에서 자격 여부를 확인하세요.
             </p>
-            <Button variant="outline" size="sm" className="mt-3">
-              <ExternalLink className="h-3.5 w-3.5" />
-              자격 확인
-            </Button>
+            <a
+              href={
+                channel?.channelId
+                  ? `https://studio.youtube.com/channel/${channel.channelId}/editing/details`
+                  : 'https://studio.youtube.com'
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="outline" size="sm" className="mt-3">
+                <ExternalLink className="h-3.5 w-3.5" />
+                YouTube Studio에서 확인
+              </Button>
+            </a>
           </div>
         </div>
       </Card>
@@ -99,11 +136,47 @@ export default function YouTubeSettingsPage() {
         <Card>
           <div className="flex items-center justify-between mb-4">
             <CardTitle>내 영상</CardTitle>
-            <CardDescription>채널 영상</CardDescription>
+            <CardDescription>{formatNumber(channel.videoCount)}개 영상</CardDescription>
           </div>
-          <div className="py-8 text-center text-sm text-surface-400">
-            영상 목록을 불러올 수 없습니다
-          </div>
+
+          {videosLoading ? (
+            <div className="flex items-center gap-2 py-4 text-surface-400">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">영상 목록 불러오는 중...</span>
+            </div>
+          ) : videos.length === 0 ? (
+            <p className="py-4 text-center text-sm text-surface-400">영상이 없습니다</p>
+          ) : (
+            <div className="space-y-2">
+              {videos.map((video) => (
+                <div
+                  key={video.videoId}
+                  className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
+                >
+                  <div className="flex items-center gap-3 min-w-0 flex-1">
+                    {video.thumbnail && (
+                      <Image
+                        src={video.thumbnail}
+                        alt={video.title}
+                        width={64}
+                        height={36}
+                        className="rounded object-cover shrink-0"
+                      />
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
+                      <p className="text-xs text-surface-500">
+                        {new Date(video.publishedAt).toLocaleDateString('ko-KR')}
+                      </p>
+                    </div>
+                  </div>
+                  <Button variant="outline" size="sm" className="shrink-0 ml-3">
+                    이 영상 더빙
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
         </Card>
       )}
     </div>

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -4,25 +4,8 @@ import { useState } from 'react'
 import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe } from 'lucide-react'
 import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from '@/components/ui'
 
-const mockChannel = {
-  name: 'Tech Creator',
-  handle: '@techcreator',
-  subscribers: '245K',
-  videos: 312,
-  avatar: 'TC',
-  connected: true,
-}
-
-const mockVideos = [
-  { id: '1', title: 'How I Built a $1M SaaS in 6 Months', views: '1.2M', published: '2 days ago' },
-  { id: '2', title: 'React 20 New Features Explained', views: '890K', published: '1 week ago' },
-  { id: '3', title: 'Day in the Life of a Software Engineer', views: '560K', published: '2 weeks ago' },
-  { id: '4', title: 'Ultimate Productivity Setup 2026', views: '340K', published: '3 weeks ago' },
-  { id: '5', title: 'I Quit My Job at Google — Here is Why', views: '2.1M', published: '1 month ago' },
-]
-
 export default function YouTubeSettingsPage() {
-  const [isConnected, setIsConnected] = useState(true)
+  const [isConnected, setIsConnected] = useState(false)
   const [defaultVisibility, setDefaultVisibility] = useState('public')
   const [autoSubtitles, setAutoSubtitles] = useState(true)
 
@@ -40,11 +23,11 @@ export default function YouTubeSettingsPage() {
           <div className="mt-4 flex items-center justify-between">
             <div className="flex items-center gap-4">
               <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-red-500 to-red-600 text-lg font-bold text-white">
-                {mockChannel.avatar}
+                YT
               </div>
               <div>
-                <p className="font-semibold text-surface-900 dark:text-white">{mockChannel.name}</p>
-                <p className="text-sm text-surface-500">{mockChannel.handle} · {mockChannel.subscribers} subscribers</p>
+                <p className="font-semibold text-surface-900 dark:text-white">내 채널</p>
+                <p className="text-sm text-surface-500">YouTube 채널 연결됨</p>
               </div>
               <Badge variant="success">연결됨</Badge>
             </div>
@@ -116,24 +99,10 @@ export default function YouTubeSettingsPage() {
         <Card>
           <div className="flex items-center justify-between mb-4">
             <CardTitle>내 영상</CardTitle>
-            <CardDescription>{mockChannel.videos}개 영상</CardDescription>
+            <CardDescription>채널 영상</CardDescription>
           </div>
-
-          <div className="space-y-2">
-            {mockVideos.map((video) => (
-              <div
-                key={video.id}
-                className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
-                  <p className="text-xs text-surface-500">{video.views} 조회 · {video.published}</p>
-                </div>
-                <Button variant="outline" size="sm">
-                  이 영상 더빙
-                </Button>
-              </div>
-            ))}
+          <div className="py-8 text-center text-sm text-surface-400">
+            영상 목록을 불러올 수 없습니다
           </div>
         </Card>
       )}

--- a/src/hooks/useYouTubeData.ts
+++ b/src/hooks/useYouTubeData.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/authStore'
+import type { ChannelStats, MyVideoItem } from '@/lib/youtube/types'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const json = await res.json()
+  if (!json.ok) throw new Error(json.error?.message || 'Request failed')
+  return json.data as T
+}
+
+export function useChannelStats() {
+  const user = useAuthStore((s) => s.user)
+  return useQuery<ChannelStats | null>({
+    queryKey: ['channel-stats', user?.uid],
+    queryFn: () => fetchJson<ChannelStats | null>('/api/youtube/stats?channel=true'),
+    enabled: !!user,
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
+}
+
+export function useMyVideos(maxResults = 10) {
+  const user = useAuthStore((s) => s.user)
+  return useQuery<MyVideoItem[]>({
+    queryKey: ['my-videos', user?.uid, maxResults],
+    queryFn: () => fetchJson<MyVideoItem[]>(`/api/youtube/videos?maxResults=${maxResults}`),
+    enabled: !!user,
+    staleTime: 2 * 60_000,
+    retry: false,
+  })
+}


### PR DESCRIPTION
## Summary
- YouTube 설정 페이지 실제 API 데이터 연결
- 빌링 페이지 "크레딧" → "남은 시간(분)" 변경, DB 실제값 표시
- 목 데이터 전체 제거

## Changes
**YouTube 설정 페이지**
- `useChannelStats` → 실제 채널명, 구독자/영상 수, 썸네일 표시
- `useMyVideos` → 실제 영상 목록 (썸네일 + 날짜)
- Multi-Audio 자격 확인 버튼 → YouTube Studio 실제 링크
- 채널 미연결 시 Google 로그인 유도

**빌링 페이지**
- "크레딧" → "남은 시간(분)"으로 변경
- `useDashboardSummary`로 DB `credits_remaining` 실제값 표시
- 로딩 상태 추가

## Test plan
- [ ] 로그인 후 YouTube 설정 페이지에서 실제 채널 정보 표시 확인
- [ ] 영상 목록 표시 확인
- [ ] 빌링 페이지 남은 시간(분) 실제 DB 값 표시 확인
- [ ] Multi-Audio 버튼 → YouTube Studio 링크 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)