### PR TITLE
fix: Perso file API base URL 수정 + /settings 404 해결

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardTitle } from '@/components/ui'
+import { Settings } from 'lucide-react'
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">설정</h1>
+        <p className="text-surface-500 dark:text-surface-400">계정 및 앱 설정을 관리하세요</p>
+      </div>
+
+      <Card>
+        <div className="flex items-center gap-3 py-8 text-surface-400">
+          <Settings className="h-5 w-5" />
+          <CardTitle>준비 중</CardTitle>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/perso/client.ts
+++ b/src/lib/perso/client.ts
@@ -7,12 +7,12 @@ import { PersoError } from '@/lib/perso/errors'
  * Base URL strategy:
  * - 'api'  → https://api.perso.ai (PERSO_API_BASE_URL)
  *   Used for /portal/*, /video-translator/*
- * - 'file' → https://perso.ai
+ * - 'file' → https://api.perso.ai
  *   Used for /file/* endpoints (metadata, upload, external, SAS, validate)
  */
 export type PersoBase = 'api' | 'file'
 
-const FILE_BASE = 'https://perso.ai'
+const FILE_BASE = 'https://api.perso.ai'
 
 export interface PersoFetchOptions extends Omit<RequestInit, 'body'> {
   baseURL?: PersoBase


### PR DESCRIPTION
## Summary
- Perso `FILE_BASE` 잘못된 URL 수정: `https://perso.ai` → `https://api.perso.ai`
- `/settings` 페이지 없어서 사이드바 클릭 시 404 나던 문제 해결

## Root Cause
- SAS token, file register, validate, external metadata 등 5개 라우트가 `baseURL: 'file'` 사용
- `FILE_BASE`가 `https://perso.ai` (Framer 마케팅 사이트)로 잘못 설정되어 있어 HTML 응답 반환
- API 문서 확인 결과 `/file/*` 엔드포인트도 `https://api.perso.ai` 사용

## Test plan
- [ ] 더빙 생성 시 SAS token 정상 발급 확인
- [ ] `/settings` 페이지 404 없이 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)