### PR TITLE
fix: CSP connect-src Perso CDN + Google API 도메인 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const cspDirectives = [
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' blob: data: https://*.googleusercontent.com https://perso.ai https://*.perso.ai https://i.ytimg.com",
   "font-src 'self'",
-  "connect-src 'self' https://*.blob.core.windows.net",
+  "connect-src 'self' https://*.blob.core.windows.net https://*.perso.ai https://www.googleapis.com https://accounts.google.com",
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self' https://accounts.google.com",


### PR DESCRIPTION
## Summary
파일 업로드 시 Perso SAS URL(`perso-saas-file-frontdoor.perso.ai`)이 CSP에 막히는 문제 해결

## Root Cause
`connect-src`에 `https://*.blob.core.windows.net`만 허용되어 있었으나
실제 SAS token이 `*.perso.ai` CDN URL을 반환함

## Changes
`connect-src`에 추가:
- `https://*.perso.ai` — Perso CDN/API 전체
- `https://www.googleapis.com` — YouTube API
- `https://accounts.google.com` — Google OAuth

## Test plan
- [ ] 영상 업로드 후 SAS PUT 요청 CSP 차단 없이 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)