### PR TITLE
perf/refactor: 배치 큐 실제 데이터 + 폴링 지수 백오프

### DIFF
--- a/src/app/(app)/batch/page.tsx
+++ b/src/app/(app)/batch/page.tsx
@@ -1,81 +1,43 @@
 'use client'
 
-import { useState } from 'react'
 import Link from 'next/link'
-import { Plus, GripVertical, Trash2, Layers } from 'lucide-react'
+import { Plus, GripVertical, Layers, Loader2 } from 'lucide-react'
 import { Card, CardTitle, Button, Badge, Progress } from '@/components/ui'
 import { LanguageBadge } from '@/components/shared/LanguageBadge'
 import { EmptyState } from '@/components/feedback/EmptyState'
 import { formatDuration } from '@/utils/formatters'
-
-interface BatchJob {
-  id: string
-  videoTitle: string
-  duration: number
-  languages: string[]
-  status: 'queued' | 'processing' | 'completed' | 'failed'
-  progress: number
-  priority: 'normal' | 'high' | 'rush'
-}
-
-const initialJobs: BatchJob[] = [
-  {
-    id: '1',
-    videoTitle: 'How I Built a $1M SaaS in 6 Months',
-    duration: 845,
-    languages: ['es', 'pt-BR', 'ja', 'ko', 'fr'],
-    status: 'processing',
-    progress: 72,
-    priority: 'high',
-  },
-  {
-    id: '2',
-    videoTitle: 'React 20 New Features Explained',
-    duration: 1230,
-    languages: ['es', 'hi', 'pt-BR', 'ja', 'ko', 'de', 'zh'],
-    status: 'processing',
-    progress: 34,
-    priority: 'normal',
-  },
-  {
-    id: '3',
-    videoTitle: 'Day in the Life of a Software Engineer',
-    duration: 620,
-    languages: ['es', 'ko', 'ja'],
-    status: 'queued',
-    progress: 0,
-    priority: 'normal',
-  },
-  {
-    id: '4',
-    videoTitle: 'Ultimate Productivity Setup 2026',
-    duration: 980,
-    languages: ['es', 'hi', 'pt-BR', 'fr', 'de', 'ar', 'id', 'zh'],
-    status: 'queued',
-    progress: 0,
-    priority: 'rush',
-  },
-]
-
-const priorityConfig = {
-  normal: { label: '보통', variant: 'default' as const },
-  high: { label: '높음', variant: 'warning' as const },
-  rush: { label: '긴급', variant: 'error' as const },
-}
+import { useRecentJobs } from '@/hooks/useDashboardData'
 
 const statusConfig = {
-  queued: { label: '대기 중', variant: 'default' as const },
   processing: { label: '처리 중', variant: 'brand' as const },
   completed: { label: '완료', variant: 'success' as const },
   failed: { label: '실패', variant: 'error' as const },
+  queued: { label: '대기 중', variant: 'default' as const },
 }
 
 export default function BatchPage() {
-  const [jobs, setJobs] = useState<BatchJob[]>(initialJobs)
+  const { data: jobs = [], isLoading } = useRecentJobs()
 
-  const removeJob = (id: string) => setJobs(jobs.filter((j) => j.id !== id))
+  const activeJobs = jobs.filter((j) => j.status === 'processing' || j.status === 'queued')
+  const processing = activeJobs.filter((j) => j.status === 'processing').length
+  const queued = activeJobs.filter((j) => j.status === 'queued').length
 
-  if (jobs.length === 0) {
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">배치 큐</h1>
+          <p className="text-surface-500 dark:text-surface-400">여러 영상을 더빙 큐에 추가하세요</p>
+        </div>
+        <div className="flex items-center gap-2 text-surface-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">불러오는 중...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (activeJobs.length === 0) {
     return (
       <div className="space-y-6">
         <div>
@@ -96,16 +58,15 @@ export default function BatchPage() {
     )
   }
 
-  const processing = jobs.filter((j) => j.status === 'processing').length
-  const queued = jobs.filter((j) => j.status === 'queued').length
-
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-surface-900 dark:text-white">배치 큐</h1>
           <p className="text-surface-500 dark:text-surface-400">
-            {processing} 처리 중 · {queued} 대기 중
+            {processing > 0 && `${processing} 처리 중`}
+            {processing > 0 && queued > 0 && ' · '}
+            {queued > 0 && `${queued} 대기 중`}
           </p>
         </div>
         <Link href="/dubbing">
@@ -114,12 +75,16 @@ export default function BatchPage() {
       </div>
 
       <Card>
-        <CardTitle>큐 ({jobs.length}개 작업)</CardTitle>
+        <CardTitle>큐 ({activeJobs.length}개 작업)</CardTitle>
 
         <div className="mt-4 space-y-2">
-          {jobs.map((job) => {
-            const priority = priorityConfig[job.priority]
-            const status = statusConfig[job.status]
+          {activeJobs.map((job) => {
+            const langList = job.languages
+              ? String(job.languages).split(',').filter(Boolean)
+              : []
+            const progress = Math.round(Number(job.avg_progress) || 0)
+            const status = statusConfig[job.status as keyof typeof statusConfig] ?? statusConfig.queued
+
             return (
               <div
                 key={job.id}
@@ -127,43 +92,30 @@ export default function BatchPage() {
               >
                 <GripVertical className="h-4 w-4 shrink-0 cursor-grab text-surface-300" />
 
-                {/* Thumbnail placeholder */}
                 <div className="flex h-12 w-20 shrink-0 items-center justify-center rounded-md bg-surface-200 text-xs text-surface-400 dark:bg-surface-800">
-                  {formatDuration(job.duration)}
+                  {formatDuration(Math.round(job.video_duration_ms / 1000))}
                 </div>
 
-                {/* Info */}
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-medium text-surface-900 dark:text-white">
-                    {job.videoTitle}
+                    {job.video_title}
                   </p>
                   <div className="mt-1 flex flex-wrap gap-1">
-                    {job.languages.slice(0, 3).map((lang) => (
+                    {langList.slice(0, 3).map((lang) => (
                       <LanguageBadge key={lang} code={lang} />
                     ))}
-                    {job.languages.length > 3 && (
-                      <span className="text-xs text-surface-400">+{job.languages.length - 3}</span>
+                    {langList.length > 3 && (
+                      <span className="text-xs text-surface-400">+{langList.length - 3}</span>
                     )}
                   </div>
                 </div>
 
-                {/* Status & Priority */}
                 <div className="flex shrink-0 flex-col items-end gap-1.5">
-                  <div className="flex gap-1.5">
-                    <Badge variant={priority.variant}>{priority.label}</Badge>
-                    <Badge variant={status.variant}>{status.label}</Badge>
-                  </div>
+                  <Badge variant={status.variant}>{status.label}</Badge>
                   {job.status === 'processing' && (
-                    <Progress value={job.progress} size="sm" className="w-24" />
+                    <Progress value={progress} size="sm" className="w-24" />
                   )}
                 </div>
-
-                <button
-                  onClick={() => removeJob(job.id)}
-                  className="shrink-0 rounded-md p-1.5 text-surface-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
               </div>
             )
           })}

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -19,7 +19,9 @@ import type { DownloadTarget } from '@/lib/perso/types'
 import type { LanguageProgress } from '../types/dubbing.types'
 import { dbMutation } from '@/lib/api/dbMutation'
 
-const POLL_INTERVAL = 5000
+const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
+const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
+const POLL_BACKOFF = 1.5          // 매 폴링마다 1.5배씩 증가
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -88,9 +90,9 @@ async function pollLanguage(
   langCode: string,
   projectSeq: number,
   spaceSeq: number,
-  pollTimers: Record<string, ReturnType<typeof setInterval>>,
+  pollTimers: Record<string, ReturnType<typeof setTimeout>>,
   addToast: ReturnType<typeof useNotificationStore.getState>['addToast'],
-) {
+): Promise<boolean> { // returns true when terminal (done polling)
   const progress = await getProjectProgress(projectSeq, spaceSeq)
   const status = mapProgressReasonToStatus(progress.progressReason)
   store.getState().updateLanguageProgress(langCode, {
@@ -108,9 +110,9 @@ async function pollLanguage(
   }
 
   const isTerminal = progress.progressReason === 'COMPLETED' || progress.progressReason === 'FAILED' || progress.progressReason === 'CANCELED'
-  if (!isTerminal) return
+  if (!isTerminal) return false
 
-  clearInterval(pollTimers[langCode])
+  clearTimeout(pollTimers[langCode])
   delete pollTimers[langCode]
 
   if (progress.progressReason === 'COMPLETED') {
@@ -144,7 +146,7 @@ async function pollLanguage(
   const allDone = allProgress.every(
     (lp) => lp.progressReason === 'COMPLETED' || lp.progressReason === 'FAILED' || lp.progressReason === 'CANCELED',
   )
-  if (!allDone) return
+  if (!allDone) return true
 
   const anyFailed = allProgress.some((lp) => lp.progressReason === 'FAILED')
   store.getState().setJobStatus(anyFailed ? 'failed' : 'completed')
@@ -155,6 +157,7 @@ async function pollLanguage(
     type: anyFailed ? 'warning' : 'success',
     title: anyFailed ? 'Dubbing completed with errors' : 'All dubbing complete!',
   })
+  return true
 }
 
 export function usePersoFlow() {
@@ -301,22 +304,31 @@ export function usePersoFlow() {
     const { spaceSeq, projectMap } = store.getState()
     if (!spaceSeq) return
 
-    Object.values(pollTimers.current).forEach(clearInterval)
+    Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
 
-    Object.entries(projectMap).forEach(([langCode, projectSeq]) => {
-      pollTimers.current[langCode] = setInterval(async () => {
+    function scheduleNext(langCode: string, projectSeq: number, interval: number) {
+      pollTimers.current[langCode] = setTimeout(async () => {
         try {
-          await pollLanguage(langCode, projectSeq, spaceSeq, pollTimers.current, addToast)
+          const done = await pollLanguage(langCode, projectSeq, spaceSeq!, pollTimers.current, addToast)
+          if (!done) {
+            const next = Math.min(interval * POLL_BACKOFF, POLL_INTERVAL_MAX)
+            scheduleNext(langCode, projectSeq, next)
+          }
         } catch {
-          // Network hiccup — retry on next interval
+          // Network hiccup — retry with same interval
+          scheduleNext(langCode, projectSeq, interval)
         }
-      }, POLL_INTERVAL)
+      }, interval)
+    }
+
+    Object.entries(projectMap).forEach(([langCode, projectSeq]) => {
+      scheduleNext(langCode, projectSeq, POLL_INTERVAL_MIN)
     })
   }, [addToast])
 
   const stopPolling = useCallback(() => {
-    Object.values(pollTimers.current).forEach(clearInterval)
+    Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
   }, [])
 


### PR DESCRIPTION
## Summary
- 배치 큐 더미 데이터 제거, 실제 DB 데이터 연결
- 더빙 폴링 5초 고정 → 지수 백오프 (8초~30초)

## Changes

### 배치 큐
- `initialJobs` 하드코딩 제거
- `useRecentJobs` 훅으로 실제 processing/queued 작업 표시

### 폴링 백오프
| | 전 | 후 |
|--|--|--|
| 방식 | setInterval 고정 5초 | setTimeout 재귀 + 백오프 |
| 첫 폴링 | 5초 | 8초 |
| 최대 간격 | 5초 | 30초 |
| 5분 작업 요청 수 | ~60회 | ~15회 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)