### PR TITLE
fix: YouTube 업로드 목록 미표시 수정

### DIFF
--- a/src/app/(app)/batch/page.tsx
+++ b/src/app/(app)/batch/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
 import { Plus, GripVertical, Layers, Loader2 } from 'lucide-react'
 import { Card, CardTitle, Button, Badge, Progress } from '@/components/ui'
@@ -7,6 +8,9 @@ import { LanguageBadge } from '@/components/shared/LanguageBadge'
 import { EmptyState } from '@/components/feedback/EmptyState'
 import { formatDuration } from '@/utils/formatters'
 import { useRecentJobs } from '@/hooks/useDashboardData'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/authStore'
+import { dbMutation } from '@/lib/api/dbMutation'
 
 const statusConfig = {
   processing: { label: '처리 중', variant: 'brand' as const },
@@ -17,8 +21,29 @@ const statusConfig = {
 
 export default function BatchPage() {
   const { data: jobs = [], isLoading } = useRecentJobs()
+  const queryClient = useQueryClient()
+  const user = useAuthStore((s) => s.user)
 
-  const activeJobs = jobs.filter((j) => j.status === 'processing' || j.status === 'queued')
+  // Auto-complete stale jobs where avg_progress hit 100 but DB still shows 'processing'
+  useEffect(() => {
+    if (!user || jobs.length === 0) return
+    const stale = jobs.filter(
+      (j) => j.status === 'processing' && Number(j.avg_progress) >= 100,
+    )
+    if (stale.length === 0) return
+
+    Promise.all(
+      stale.map((j) =>
+        dbMutation({ type: 'updateJobStatus', payload: { jobId: j.id, status: 'completed' } }),
+      ),
+    ).then(() => {
+      queryClient.invalidateQueries({ queryKey: ['recent-jobs'] })
+    })
+  }, [jobs, user, queryClient])
+
+  const activeJobs = jobs.filter(
+    (j) => (j.status === 'processing' || j.status === 'queued') && Number(j.avg_progress) < 100,
+  )
   const processing = activeJobs.filter((j) => j.status === 'processing').length
   const queued = activeJobs.filter((j) => j.status === 'queued').length
 

--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import { Upload, Loader2, CheckCircle2, ExternalLink, Youtube } from 'lucide-react'
+import { Upload, Loader2, CheckCircle2, ExternalLink, Video } from 'lucide-react'
 import { Card, CardTitle, Button, Badge } from '@/components/ui'
 import { LanguageBadge } from '@/components/shared/LanguageBadge'
 import { EmptyState } from '@/components/feedback/EmptyState'
@@ -170,7 +170,7 @@ export default function UploadsPage() {
         </div>
       ) : items.length === 0 ? (
         <EmptyState
-          icon={<Youtube className="h-12 w-12" />}
+          icon={<Video className="h-12 w-12" />}
           title="업로드할 영상이 없습니다"
           description="더빙이 완료된 영상이 여기에 표시됩니다."
         />

--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -9,12 +9,12 @@ import { formatDuration } from '@/utils/formatters'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
-import { ytUploadVideo, ytUploadCaption } from '@/lib/api-client'
+import { ytUploadVideo, ytUploadCaption, getDownloadLinks } from '@/lib/api-client'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { getLanguageByCode } from '@/utils/languages'
 import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
 
-type UploadState = 'idle' | 'uploading' | 'done' | 'error'
+type UploadState = 'idle' | 'fetching' | 'uploading' | 'done' | 'error'
 
 async function fetchCompletedLanguages(uid: string): Promise<CompletedJobLanguage[]> {
   const res = await fetch(`/api/dashboard/completed-languages?uid=${encodeURIComponent(uid)}`, { cache: 'no-store' })
@@ -36,11 +36,24 @@ function UploadRow({ item, userId }: UploadRowProps) {
   const lang = getLanguageByCode(item.language_code)
 
   const handleUpload = useCallback(async () => {
-    if (!item.dubbed_video_url) return
-    setState('uploading')
+    setState('fetching')
     try {
+      // Use stored URL or fetch from Perso on-demand (for jobs interrupted mid-poll)
+      let videoUrl = item.dubbed_video_url
+      let srtUrl = item.srt_url
+
+      if (!videoUrl && item.project_seq && item.space_seq) {
+        const downloads = await getDownloadLinks(item.project_seq, item.space_seq, 'all')
+        videoUrl = downloads.videoFile?.videoDownloadLink ?? null
+        srtUrl = srtUrl ?? downloads.srtFile?.translatedSubtitleDownloadLink ?? null
+        if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      }
+
+      if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+
+      setState('uploading')
       const result = await ytUploadVideo({
-        videoUrl: item.dubbed_video_url,
+        videoUrl,
         title: `[${lang?.name}] ${item.video_title}`,
         description: `${item.video_title} - ${lang?.name} 더빙 by CreatorDub AI`,
         tags: ['CreatorDub', 'AI더빙', lang?.name || item.language_code, 'dubbed'],
@@ -49,9 +62,9 @@ function UploadRow({ item, userId }: UploadRowProps) {
       })
 
       // Try uploading SRT if available
-      if (item.srt_url) {
+      if (srtUrl) {
         try {
-          const srtRes = await fetch(item.srt_url)
+          const srtRes = await fetch(srtUrl)
           const srtText = await srtRes.text()
           await ytUploadCaption({
             videoId: result.videoId,
@@ -68,7 +81,6 @@ function UploadRow({ item, userId }: UploadRowProps) {
       setState('done')
       addToast({ type: 'success', title: `${lang?.name} 업로드 완료`, message: '비공개로 업로드됨' })
 
-      // Update DB
       await dbMutation({
         type: 'createYouTubeUpload',
         payload: {
@@ -86,6 +98,9 @@ function UploadRow({ item, userId }: UploadRowProps) {
       addToast({ type: 'error', title: '업로드 실패', message: err instanceof Error ? err.message : '알 수 없는 오류' })
     }
   }, [item, lang, userId, addToast, queryClient])
+
+  const isLoading = state === 'fetching' || state === 'uploading'
+  const loadingLabel = state === 'fetching' ? '링크 확인 중...' : '업로드 중...'
 
   return (
     <div className="flex items-center gap-3 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
@@ -117,10 +132,10 @@ function UploadRow({ item, userId }: UploadRowProps) {
             <CheckCircle2 className="h-3 w-3" />
             업로드됨
           </Badge>
-        ) : state === 'uploading' ? (
+        ) : isLoading ? (
           <div className="flex items-center gap-1.5 text-xs text-surface-500">
             <Loader2 className="h-4 w-4 animate-spin" />
-            업로드 중...
+            {loadingLabel}
           </div>
         ) : (
           <Button size="sm" onClick={handleUpload} disabled={state === 'error'}>

--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Upload, Loader2, CheckCircle2, ExternalLink, Youtube } from 'lucide-react'
+import { Card, CardTitle, Button, Badge } from '@/components/ui'
+import { LanguageBadge } from '@/components/shared/LanguageBadge'
+import { EmptyState } from '@/components/feedback/EmptyState'
+import { formatDuration } from '@/utils/formatters'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/authStore'
+import { useNotificationStore } from '@/stores/notificationStore'
+import { ytUploadVideo, ytUploadCaption } from '@/lib/api-client'
+import { dbMutation } from '@/lib/api/dbMutation'
+import { getLanguageByCode } from '@/utils/languages'
+import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
+
+type UploadState = 'idle' | 'uploading' | 'done' | 'error'
+
+async function fetchCompletedLanguages(uid: string): Promise<CompletedJobLanguage[]> {
+  const res = await fetch(`/api/dashboard/completed-languages?uid=${encodeURIComponent(uid)}`, { cache: 'no-store' })
+  const json = await res.json()
+  if (!json.ok) throw new Error(json.error?.message || 'Failed to load')
+  return json.data
+}
+
+interface UploadRowProps {
+  item: CompletedJobLanguage
+  userId: string
+}
+
+function UploadRow({ item, userId }: UploadRowProps) {
+  const addToast = useNotificationStore((s) => s.addToast)
+  const queryClient = useQueryClient()
+  const [state, setState] = useState<UploadState>(item.youtube_video_id ? 'done' : 'idle')
+  const [videoId, setVideoId] = useState<string | null>(item.youtube_video_id)
+  const lang = getLanguageByCode(item.language_code)
+
+  const handleUpload = useCallback(async () => {
+    if (!item.dubbed_video_url) return
+    setState('uploading')
+    try {
+      const result = await ytUploadVideo({
+        videoUrl: item.dubbed_video_url,
+        title: `[${lang?.name}] ${item.video_title}`,
+        description: `${item.video_title} - ${lang?.name} 더빙 by CreatorDub AI`,
+        tags: ['CreatorDub', 'AI더빙', lang?.name || item.language_code, 'dubbed'],
+        privacyStatus: 'private',
+        language: item.language_code,
+      })
+
+      // Try uploading SRT if available
+      if (item.srt_url) {
+        try {
+          const srtRes = await fetch(item.srt_url)
+          const srtText = await srtRes.text()
+          await ytUploadCaption({
+            videoId: result.videoId,
+            language: item.language_code,
+            name: `${lang?.name} subtitles`,
+            srtContent: srtText,
+          })
+        } catch {
+          // SRT optional
+        }
+      }
+
+      setVideoId(result.videoId)
+      setState('done')
+      addToast({ type: 'success', title: `${lang?.name} 업로드 완료`, message: '비공개로 업로드됨' })
+
+      // Update DB
+      await dbMutation({
+        type: 'createYouTubeUpload',
+        payload: {
+          userId,
+          youtubeVideoId: result.videoId,
+          title: `[${lang?.name}] ${item.video_title}`,
+          languageCode: item.language_code,
+          privacyStatus: 'private',
+          isShort: false,
+        },
+      })
+      queryClient.invalidateQueries({ queryKey: ['completed-languages'] })
+    } catch (err) {
+      setState('error')
+      addToast({ type: 'error', title: '업로드 실패', message: err instanceof Error ? err.message : '알 수 없는 오류' })
+    }
+  }, [item, lang, userId, addToast, queryClient])
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+      <div className="flex h-10 w-16 shrink-0 items-center justify-center rounded bg-surface-100 text-xs text-surface-400 dark:bg-surface-800">
+        {formatDuration(Math.round(item.video_duration_ms / 1000))}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{item.video_title}</p>
+        <div className="mt-1 flex items-center gap-1.5">
+          {lang && <LanguageBadge code={item.language_code} />}
+          {videoId && (
+            <a
+              href={`https://youtube.com/watch?v=${videoId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-brand-500 hover:underline"
+            >
+              <ExternalLink className="h-3 w-3" />
+              영상 보기
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="shrink-0">
+        {state === 'done' ? (
+          <Badge variant="success">
+            <CheckCircle2 className="h-3 w-3" />
+            업로드됨
+          </Badge>
+        ) : state === 'uploading' ? (
+          <div className="flex items-center gap-1.5 text-xs text-surface-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            업로드 중...
+          </div>
+        ) : (
+          <Button size="sm" onClick={handleUpload} disabled={state === 'error'}>
+            <Upload className="h-3.5 w-3.5" />
+            YouTube 업로드
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function UploadsPage() {
+  const user = useAuthStore((s) => s.user)
+  const { data: items = [], isLoading } = useQuery<CompletedJobLanguage[]>({
+    queryKey: ['completed-languages', user?.uid],
+    queryFn: () => fetchCompletedLanguages(user!.uid),
+    enabled: !!user,
+    staleTime: 60_000,
+  })
+
+  // Group by job
+  const jobs = items.reduce<Record<number, { title: string; durationMs: number; createdAt: string; langs: CompletedJobLanguage[] }>>((acc, item) => {
+    if (!acc[item.job_id]) {
+      acc[item.job_id] = {
+        title: item.video_title,
+        durationMs: item.video_duration_ms,
+        createdAt: item.created_at,
+        langs: [],
+      }
+    }
+    acc[item.job_id].langs.push(item)
+    return acc
+  }, {})
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">YouTube 업로드</h1>
+        <p className="text-surface-500 dark:text-surface-400">완료된 더빙 영상을 YouTube에 업로드하세요</p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-surface-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">불러오는 중...</span>
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={<Youtube className="h-12 w-12" />}
+          title="업로드할 영상이 없습니다"
+          description="더빙이 완료된 영상이 여기에 표시됩니다."
+        />
+      ) : (
+        <div className="space-y-4">
+          {Object.entries(jobs).map(([jobId, job]) => (
+            <Card key={jobId}>
+              <div className="mb-3 flex items-center justify-between">
+                <div>
+                  <CardTitle className="text-base">{job.title}</CardTitle>
+                  <p className="text-xs text-surface-400 mt-0.5">
+                    {formatDuration(Math.round(job.durationMs / 1000))} · {new Date(job.createdAt).toLocaleDateString('ko-KR')}
+                  </p>
+                </div>
+                <Badge variant="success">{job.langs.length}개 언어</Badge>
+              </div>
+              <div className="space-y-2">
+                {job.langs.map((item) => (
+                  <UploadRow key={`${item.job_id}-${item.language_code}`} item={item} userId={user?.uid || ''} />
+                ))}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/dashboard/completed-languages/route.ts
+++ b/src/app/api/dashboard/completed-languages/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from 'next/server'
+import { getCompletedJobLanguages } from '@/lib/db/queries'
+import { requireSession, forbiddenUidMismatch } from '@/lib/auth/session'
+import { apiOk, apiFail } from '@/lib/api/response'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const uid = req.nextUrl.searchParams.get('uid')
+  if (!uid) return apiFail('BAD_REQUEST', 'uid required', 400)
+  if (uid !== auth.session.uid) return forbiddenUidMismatch()
+
+  try {
+    const data = await getCompletedJobLanguages(auth.session.uid)
+    return apiOk(data)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal Server Error'
+    return apiFail('DB_ERROR', message, 500)
+  }
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,12 +10,14 @@ import {
   CreditCard,
   Layers,
   Settings,
+  Upload,
 } from 'lucide-react'
 
 const navItems = [
   { to: '/dashboard', label: '대시보드', icon: LayoutDashboard },
   { to: '/dubbing', label: '새 더빙', icon: Languages },
   { to: '/batch', label: '배치 큐', icon: Layers },
+  { to: '/uploads', label: 'YouTube 업로드', icon: Upload },
   { to: '/youtube', label: 'YouTube', icon: Video },
   { to: '/billing', label: '결제', icon: CreditCard },
 ]

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -32,6 +32,13 @@ const reasonLabels: Record<string, string> = {
   CANCELED: '취소됨',
 }
 
+function getProgressLabel(lp: { progressReason: string; progress: number }) {
+  if (lp.progress >= 100 && lp.progressReason !== 'COMPLETED' && lp.progressReason !== 'FAILED' && lp.progressReason !== 'CANCELED') {
+    return '마무리 중...'
+  }
+  return reasonLabels[lp.progressReason] || lp.progressReason
+}
+
 export function ProcessingStep() {
   const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted } = useDubbingStore()
   const { submitDubbing, startPolling, stopPolling } = usePersoFlow()
@@ -117,7 +124,7 @@ export function ProcessingStep() {
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-surface-900 dark:text-white">{lang.name}</p>
                   <p className="text-xs text-surface-500">
-                    {reasonLabels[lp.progressReason] || lp.progressReason}
+                    {getProgressLabel(lp)}
                   </p>
                 </div>
                 {isCompleted ? (

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -22,6 +22,7 @@ import { dbMutation } from '@/lib/api/dbMutation'
 const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
 const POLL_BACKOFF = 1.5          // 매 폴링마다 1.5배씩 증가
+const POLL_FINALIZING = 2_000     // 100%인데 COMPLETED 아직 안 온 경우 빠르게 재확인
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -92,7 +93,7 @@ async function pollLanguage(
   spaceSeq: number,
   pollTimers: Record<string, ReturnType<typeof setTimeout>>,
   addToast: ReturnType<typeof useNotificationStore.getState>['addToast'],
-): Promise<boolean> { // returns true when terminal (done polling)
+): Promise<boolean | 'finalizing'> { // true = terminal, 'finalizing' = 100% but not COMPLETED yet
   const progress = await getProjectProgress(projectSeq, spaceSeq)
   const status = mapProgressReasonToStatus(progress.progressReason)
   store.getState().updateLanguageProgress(langCode, {
@@ -110,7 +111,11 @@ async function pollLanguage(
   }
 
   const isTerminal = progress.progressReason === 'COMPLETED' || progress.progressReason === 'FAILED' || progress.progressReason === 'CANCELED'
-  if (!isTerminal) return false
+  if (!isTerminal) {
+    // progress hit 100 but backend hasn't confirmed COMPLETED yet — poll fast
+    if (progress.progress >= 100) return 'finalizing'
+    return false
+  }
 
   clearTimeout(pollTimers[langCode])
   delete pollTimers[langCode]
@@ -321,6 +326,8 @@ export function usePersoFlow() {
           if (!done) {
             const next = Math.min(interval * POLL_BACKOFF, POLL_INTERVAL_MAX)
             scheduleNext(langCode, projectSeq, next)
+          } else if (done === 'finalizing') {
+            scheduleNext(langCode, projectSeq, POLL_FINALIZING)
           }
         } catch {
           // Network hiccup — retry with same interval

--- a/src/lib/db/queries/dashboard.ts
+++ b/src/lib/db/queries/dashboard.ts
@@ -92,6 +92,8 @@ export interface CompletedJobLanguage {
   video_thumbnail: string
   video_duration_ms: number
   language_code: string
+  project_seq: number
+  space_seq: number
   dubbed_video_url: string | null
   audio_url: string | null
   srt_url: string | null
@@ -103,11 +105,12 @@ export async function getCompletedJobLanguages(userId: string): Promise<Complete
   const db = getDb()
   const result = await db.execute({
     sql: `SELECT dj.id as job_id, dj.video_title, dj.video_thumbnail, dj.video_duration_ms,
-          jl.language_code, jl.dubbed_video_url, jl.audio_url, jl.srt_url, jl.youtube_video_id,
+          dj.space_seq, jl.language_code, jl.project_seq,
+          jl.dubbed_video_url, jl.audio_url, jl.srt_url, jl.youtube_video_id,
           dj.created_at
           FROM dubbing_jobs dj
           JOIN job_languages jl ON jl.job_id = dj.id
-          WHERE dj.user_id = ? AND jl.status = 'completed' AND jl.dubbed_video_url IS NOT NULL
+          WHERE dj.user_id = ? AND dj.status = 'completed'
           ORDER BY dj.created_at DESC
           LIMIT 50`,
     args: [userId],

--- a/src/lib/db/queries/dashboard.ts
+++ b/src/lib/db/queries/dashboard.ts
@@ -85,3 +85,32 @@ export async function getUserYouTubeUploads(userId: string): Promise<YouTubeUplo
   })
   return result.rows as unknown as YouTubeUploadRow[]
 }
+
+export interface CompletedJobLanguage {
+  job_id: number
+  video_title: string
+  video_thumbnail: string
+  video_duration_ms: number
+  language_code: string
+  dubbed_video_url: string | null
+  audio_url: string | null
+  srt_url: string | null
+  youtube_video_id: string | null
+  created_at: string
+}
+
+export async function getCompletedJobLanguages(userId: string): Promise<CompletedJobLanguage[]> {
+  const db = getDb()
+  const result = await db.execute({
+    sql: `SELECT dj.id as job_id, dj.video_title, dj.video_thumbnail, dj.video_duration_ms,
+          jl.language_code, jl.dubbed_video_url, jl.audio_url, jl.srt_url, jl.youtube_video_id,
+          dj.created_at
+          FROM dubbing_jobs dj
+          JOIN job_languages jl ON jl.job_id = dj.id
+          WHERE dj.user_id = ? AND jl.status = 'completed' AND jl.dubbed_video_url IS NOT NULL
+          ORDER BY dj.created_at DESC
+          LIMIT 50`,
+    args: [userId],
+  })
+  return result.rows as unknown as CompletedJobLanguage[]
+}

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -27,4 +27,5 @@ export {
   getCreditUsageByMonth,
   getLanguagePerformance,
   getUserYouTubeUploads,
+  getCompletedJobLanguages,
 } from './dashboard'


### PR DESCRIPTION
## Summary
- **원인**: `getCompletedJobLanguages` 쿼리가 `jl.dubbed_video_url IS NOT NULL` 조건을 요구 — 폴링 중 브라우저를 닫으면 URL이 DB에 저장되지 않아 목록에서 누락
- **수정**: 조건을 `dj.status = 'completed'`로 변경, `project_seq`와 `space_seq` 컬럼 추가
- **업로드 로직**: `dubbed_video_url` 없으면 Perso API `getDownloadLinks`로 실시간 조회 후 업로드 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)