### PR TITLE
fix: YouTube 토큰 자동 갱신 + uploads 페이지 수정 (#29)

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -81,17 +81,27 @@ function UploadRow({ item, userId }: UploadRowProps) {
       setState('done')
       addToast({ type: 'success', title: `${lang?.name} 업로드 완료`, message: '비공개로 업로드됨' })
 
-      await dbMutation({
-        type: 'createYouTubeUpload',
-        payload: {
-          userId,
-          youtubeVideoId: result.videoId,
-          title: `[${lang?.name}] ${item.video_title}`,
-          languageCode: item.language_code,
-          privacyStatus: 'private',
-          isShort: false,
-        },
-      })
+      await Promise.all([
+        dbMutation({
+          type: 'createYouTubeUpload',
+          payload: {
+            userId,
+            youtubeVideoId: result.videoId,
+            title: `[${lang?.name}] ${item.video_title}`,
+            languageCode: item.language_code,
+            privacyStatus: 'private',
+            isShort: false,
+          },
+        }),
+        dbMutation({
+          type: 'updateJobLanguageYouTube',
+          payload: {
+            jobId: item.job_id,
+            langCode: item.language_code,
+            youtubeVideoId: result.videoId,
+          },
+        }),
+      ])
       queryClient.invalidateQueries({ queryKey: ['completed-languages'] })
     } catch (err) {
       setState('error')

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -2,6 +2,10 @@ import 'server-only'
 
 import { NextRequest } from 'next/server'
 import { apiFail } from '@/lib/api/response'
+import { verifySessionCookie } from '@/lib/auth/session-cookie'
+import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
+import { getUser } from '@/lib/db/queries'
+import { logger } from '@/lib/logger'
 
 export interface Session {
   uid: string
@@ -25,43 +29,61 @@ function getAccessToken(req: NextRequest): string | null {
   )
 }
 
+async function verifyTokenWithGoogle(
+  token: string,
+): Promise<{ uid: string; email: string } | null> {
+  try {
+    const res = await fetch(
+      `${GOOGLE_TOKENINFO_URL}?access_token=${encodeURIComponent(token)}`,
+    )
+    if (!res.ok) return null
+    const info = (await res.json()) as GoogleTokenInfo
+    if (!info.sub || !info.email) return null
+    return { uid: info.sub, email: info.email }
+  } catch {
+    return null
+  }
+}
+
 export async function requireSession(
   req: NextRequest,
 ): Promise<
   | { ok: true; session: Session }
   | { ok: false; response: Response }
 > {
-  const token = getAccessToken(req)
-  if (!token) {
-    return {
-      ok: false,
-      response: apiFail('UNAUTHORIZED', 'Missing access token', 401),
+  // 1) Try the access token cookie / header (fast path)
+  const cookieToken = getAccessToken(req)
+  if (cookieToken) {
+    const info = await verifyTokenWithGoogle(cookieToken)
+    if (info) return { ok: true, session: info }
+  }
+
+  // 2) Cookie expired or invalid — try refreshing via session cookie
+  const sessionCookie = req.cookies.get('creatordub_session')?.value
+  if (sessionCookie) {
+    const uid = await verifySessionCookie(sessionCookie)
+    if (uid) {
+      const refreshedToken = await getOrRefreshAccessToken(uid)
+      if (refreshedToken) {
+        const info = await verifyTokenWithGoogle(refreshedToken)
+        if (info) {
+          logger.info('session restored via token refresh', { uid })
+          return { ok: true, session: info }
+        }
+      }
+
+      // Token refresh failed but session cookie is valid — use DB email as fallback
+      const user = await getUser(uid)
+      if (user?.email) {
+        logger.info('session restored from DB (token refresh failed)', { uid })
+        return { ok: true, session: { uid, email: user.email as string } }
+      }
     }
   }
 
-  try {
-    const res = await fetch(`${GOOGLE_TOKENINFO_URL}?access_token=${encodeURIComponent(token)}`)
-    if (!res.ok) {
-      return {
-        ok: false,
-        response: apiFail('UNAUTHORIZED', 'Invalid or expired access token', 401),
-      }
-    }
-
-    const info = (await res.json()) as GoogleTokenInfo
-    if (!info.sub || !info.email) {
-      return {
-        ok: false,
-        response: apiFail('UNAUTHORIZED', 'Token missing required claims', 401),
-      }
-    }
-
-    return { ok: true, session: { uid: info.sub, email: info.email } }
-  } catch {
-    return {
-      ok: false,
-      response: apiFail('AUTH_ERROR', 'Failed to verify access token', 500),
-    }
+  return {
+    ok: false,
+    response: apiFail('UNAUTHORIZED', 'Missing or expired access token', 401),
   }
 }
 

--- a/src/lib/db/queries/dashboard.ts
+++ b/src/lib/db/queries/dashboard.ts
@@ -111,6 +111,7 @@ export async function getCompletedJobLanguages(userId: string): Promise<Complete
           FROM dubbing_jobs dj
           JOIN job_languages jl ON jl.job_id = dj.id
           WHERE dj.user_id = ? AND dj.status = 'completed'
+            AND jl.youtube_video_id IS NULL
           ORDER BY dj.created_at DESC
           LIMIT 50`,
     args: [userId],


### PR DESCRIPTION
## Summary
- `requireSession()`에 session cookie → refresh token 폴백 추가 (1시간 후 연동 끊김 해결)
- completed-languages 쿼리에 `youtube_video_id IS NULL` 필터 추가 (업로드 완료 영상 목록 제외)
- 업로드 성공 시 `updateJobLanguageYouTube` 병렬 호출 추가 (목록 즉시 갱신)

## Test plan
- [ ] 로그인 후 1시간 이상 경과 → YouTube 설정 페이지에서 채널 연결 상태 유지 확인
- [ ] /uploads 페이지에서 완료된(미업로드) 영상 정상 표시 확인
- [ ] 영상 업로드 후 목록에서 해당 항목 자동 제거 확인

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)