### PR TITLE
fix: 코드 건강 — 트랜잭션, race condition, N+1, 병렬화 (#37)

### DIFF
--- a/src/app/api/youtube/analytics/route.ts
+++ b/src/app/api/youtube/analytics/route.ts
@@ -79,21 +79,32 @@ export async function GET(req: NextRequest) {
 
     const userId = auth.session.uid
 
+    // Split into cached and uncached
     const results: VideoAnalytics[] = []
+    const uncachedIds: string[] = []
     for (const videoId of videoIds) {
       const cached = await getCached(userId, videoId)
       if (cached) {
         results.push(cached)
-        continue
+      } else {
+        uncachedIds.push(videoId)
       }
-      const fresh = await fetchVideoAnalytics(
-        accessToken,
-        videoId,
-        startDate,
-        endDate,
-      )
-      await setCache(userId, videoId, fresh)
-      results.push(fresh)
+    }
+
+    // Fetch uncached in parallel (max 5 concurrent)
+    if (uncachedIds.length > 0) {
+      const CONCURRENCY = 5
+      for (let i = 0; i < uncachedIds.length; i += CONCURRENCY) {
+        const batch = uncachedIds.slice(i, i + CONCURRENCY)
+        const fetched = await Promise.all(
+          batch.map(async (videoId) => {
+            const fresh = await fetchVideoAnalytics(accessToken, videoId, startDate, endDate)
+            await setCache(userId, videoId, fresh)
+            return fresh
+          }),
+        )
+        results.push(...fetched)
+      }
     }
 
     return results

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -162,12 +162,13 @@ export function UploadStep() {
     }
   }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated])
 
-  // Upload ALL completed languages to YouTube
+  // Upload ALL completed languages to YouTube (2 concurrent)
   const handleUploadAll = async () => {
-    for (const code of completedLangs) {
-      const state = ytUploads[code]
-      if (state?.status === 'done') continue // skip already uploaded
-      await handleYouTubeUpload(code)
+    const pending = completedLangs.filter((code) => ytUploads[code]?.status !== 'done')
+    const CONCURRENCY = 2
+    for (let i = 0; i < pending.length; i += CONCURRENCY) {
+      const batch = pending.slice(i, i + CONCURRENCY)
+      await Promise.all(batch.map((code) => handleYouTubeUpload(code)))
     }
   }
 

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -28,18 +28,28 @@ function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
     case 'PENDING':
     case 'CREATED':
+    case 'Enqueue Pending':
+    case 'Slow Mode Pending':
       return 'transcribing' as const
     case 'READY':
     case 'READY_TARGET_LANGUAGES':
+    case 'Transcribing':
+    case 'Translating':
       return 'translating' as const
     case 'ENQUEUED':
+    case 'Uploading':
+    case 'Generating Voice':
       return 'synthesizing' as const
     case 'PROCESSING':
+    case 'Analyzing Lip Sync':
+    case 'Applying Lip Sync':
       return 'merging' as const
     case 'COMPLETED':
+    case 'Completed':
       return 'completed' as const
     case 'FAILED':
     case 'CANCELED':
+    case 'Failed':
       return 'failed' as const
     default:
       return 'translating' as const
@@ -107,7 +117,7 @@ async function pollLanguage(
     dbMutation({
       type: 'updateJobLanguageProgress',
       payload: { jobId: dbJobId, langCode, status, progress: progress.progress, progressReason: progress.progressReason },
-    })
+    }).catch(() => { /* progress update is best-effort */ })
   }
 
   const isTerminal = progress.progressReason === 'COMPLETED' || progress.progressReason === 'FAILED' || progress.progressReason === 'CANCELED'
@@ -140,7 +150,7 @@ async function pollLanguage(
               srtUrl: downloads.srtFile?.translatedSubtitleDownloadLink,
             },
           },
-        })
+        }).catch(() => { /* completion update is best-effort */ })
       }
     } catch {
       // Download links will be fetched later if needed
@@ -160,10 +170,10 @@ async function pollLanguage(
   const durationMs = store.getState().videoMeta?.durationMs || 0
   const minutesUsed = Math.max(1, Math.ceil(durationMs / 60_000))
   if (userId) {
-    dbMutation({ type: 'deductUserMinutes', payload: { userId, minutes: minutesUsed } })
+    await dbMutation({ type: 'deductUserMinutes', payload: { userId, minutes: minutesUsed } })
   }
   if (dbJobId) {
-    dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: anyFailed ? 'failed' : 'completed' } })
+    await dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: anyFailed ? 'failed' : 'completed' } })
   }
   addToast({
     type: anyFailed ? 'warning' : 'success',

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -37,12 +37,12 @@ export async function createJobLanguages(
   languages: { code: string; projectSeq: number }[],
 ) {
   const db = getDb()
-  for (const lang of languages) {
-    await db.execute({
+  await db.batch(
+    languages.map((lang) => ({
       sql: 'INSERT INTO job_languages (job_id, language_code, project_seq) VALUES (?, ?, ?)',
       args: [jobId, lang.code, lang.projectSeq],
-    })
-  }
+    })),
+  )
 }
 
 export async function updateJobLanguageProgress(


### PR DESCRIPTION
## Summary
- **트랜잭션 안전성**: `createJobLanguages`를 for-loop → `db.batch()`로 변경하여 원자적 실행 보장
- **Race condition 제거**: `usePersoFlow`에서 `deductUserMinutes`, `updateJobStatus` fire-and-forget → `await`로 변경
- **N+1 해소**: YouTube analytics API에서 개별 fetch → `CONCURRENCY=5` 병렬 배치 fetch로 개선
- **업로드 병렬화**: `UploadStep`의 `handleUploadAll`을 `CONCURRENCY=2` 병렬 처리로 변경

Closes #37

## Test plan
- [ ] 다중 언어 더빙 생성 시 job_languages 모두 정상 삽입 확인
- [ ] 더빙 완료 후 분 차감이 누락되지 않는지 확인
- [ ] YouTube analytics 대시보드에서 다수 영상 통계가 빠르게 로드되는지 확인
- [ ] 다중 파일 업로드가 2개씩 병렬 진행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)