### PR TITLE
fix: 경계면 정합성 — ProgressReason 타입, 중복 훅, dead param 정리 (#38)

### DIFF
--- a/src/features/dashboard/components/AnalyticsChart.tsx
+++ b/src/features/dashboard/components/AnalyticsChart.tsx
@@ -13,7 +13,7 @@ export function AnalyticsChart({ videoIds }: { videoIds?: string[] }) {
 
   const { data, isLoading } = useQuery({
     queryKey: ['youtube-analytics', videoIds],
-    queryFn: () => ytFetchAnalytics(videoIds ?? [], user?.uid ?? ''),
+    queryFn: () => ytFetchAnalytics(videoIds ?? []),
     enabled: !!user && !!videoIds && videoIds.length > 0,
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60,

--- a/src/features/dashboard/components/RecentJobs.tsx
+++ b/src/features/dashboard/components/RecentJobs.tsx
@@ -13,6 +13,7 @@ const statusConfig: Record<string, { label: string; variant: 'success' | 'brand'
   completed: { label: '완료', variant: 'success' },
   processing: { label: '처리 중', variant: 'brand' },
   pending: { label: '대기 중', variant: 'default' },
+  queued: { label: '대기 중', variant: 'default' },
   failed: { label: '실패', variant: 'error' },
 }
 

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -66,15 +66,4 @@ export function useLanguagePerformance() {
   })
 }
 
-export function useChannelStats() {
-  const user = useAuthStore((s) => s.user)
-  return useQuery({
-    queryKey: ['channel-stats', user?.uid],
-    queryFn: () =>
-      fetchJson<{ subscriberCount: number; viewCount: number; videoCount: number; channelId: string; title: string; thumbnail: string } | null>(
-        `/api/youtube/stats?channel=true`,
-      ),
-    enabled: !!user,
-    staleTime: 5 * 60_000,
-  })
-}
+// useChannelStats is defined in useYouTubeData.ts — use that one instead

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -1,4 +1,3 @@
-export { json, getJson, sendJson } from './shared'
 export {
   getSpaces,
   getLanguages,

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -75,13 +75,11 @@ export async function ytFetchMyVideos(
 
 export async function ytFetchAnalytics(
   videoIds: string[],
-  userId: string,
   startDate?: string,
   endDate?: string,
 ): Promise<VideoAnalytics[]> {
   const params = new URLSearchParams({
     videoIds: videoIds.join(','),
-    userId,
   })
   if (startDate) params.set('startDate', startDate)
   if (endDate) params.set('endDate', endDate)

--- a/src/lib/perso/route-helpers.ts
+++ b/src/lib/perso/route-helpers.ts
@@ -57,20 +57,18 @@ export async function parseBody<T>(req: Request, schema: ZodSchema<T>): Promise<
   return result.data
 }
 
+function paramError(message: string, code: string): never {
+  throw Object.assign(new Error(message), { code, status: 400 })
+}
+
 export function requireIntParam(url: URL, name: string): number {
   const raw = url.searchParams.get(name)
   if (raw === null || raw === '') {
-    const err = new Error(`Missing required query param: ${name}`)
-    ;(err as Error & { code?: string; status?: number }).code = 'MISSING_PARAM'
-    ;(err as Error & { code?: string; status?: number }).status = 400
-    throw err
+    paramError(`Missing required query param: ${name}`, 'MISSING_PARAM')
   }
   const n = Number(raw)
   if (!Number.isFinite(n)) {
-    const err = new Error(`Invalid numeric query param: ${name}`)
-    ;(err as Error & { code?: string; status?: number }).code = 'INVALID_PARAM'
-    ;(err as Error & { code?: string; status?: number }).status = 400
-    throw err
+    paramError(`Invalid numeric query param: ${name}`, 'INVALID_PARAM')
   }
   return n
 }
@@ -78,10 +76,7 @@ export function requireIntParam(url: URL, name: string): number {
 export function requireStringParam(url: URL, name: string): string {
   const raw = url.searchParams.get(name)
   if (raw === null || raw === '') {
-    const err = new Error(`Missing required query param: ${name}`)
-    ;(err as Error & { code?: string; status?: number }).code = 'MISSING_PARAM'
-    ;(err as Error & { code?: string; status?: number }).status = 400
-    throw err
+    paramError(`Missing required query param: ${name}`, 'MISSING_PARAM')
   }
   return raw
 }

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -69,6 +69,12 @@ export interface TranslateResponse {
   startGenerateProjectIdList: number[]
 }
 
+/**
+ * Progress reason values from Perso API.
+ * Internal values (PENDING, PROCESSING, etc.) are used by our polling logic.
+ * Perso API spec also documents human-readable forms (Enqueue Pending, Transcribing, etc.)
+ * — both forms are accepted to handle API version differences.
+ */
 export type ProgressReason =
   | 'PENDING'
   | 'CREATED'
@@ -79,6 +85,15 @@ export type ProgressReason =
   | 'COMPLETED'
   | 'FAILED'
   | 'CANCELED'
+  // Perso API spec forms (human-readable)
+  | 'Enqueue Pending'
+  | 'Slow Mode Pending'
+  | 'Uploading'
+  | 'Transcribing'
+  | 'Translating'
+  | 'Generating Voice'
+  | 'Analyzing Lip Sync'
+  | 'Applying Lip Sync'
 
 export interface ProgressResponse {
   projectSeq: number


### PR DESCRIPTION
## Summary
- **타입 정합성**: `ProgressReason` 타입에 Perso API spec 값 8개 추가 (Enqueue Pending, Transcribing 등)
- **중복 훅 제거**: `useDashboardData`에서 `useChannelStats` 중복 정의 삭제 (canonical: `useYouTubeData.ts`)
- **누락 상태 추가**: `RecentJobs` statusConfig에 `queued` 상태 추가
- **Dead parameter 정리**: `ytFetchAnalytics`에서 미사용 `userId` 파라미터 제거
- **Dead export 정리**: `api-client/index.ts`에서 미사용 `shared` re-export 제거
- **반복 코드 정리**: `route-helpers.ts`의 반복 타입 캐스팅을 `paramError` 헬퍼로 추출

Closes #38

## Test plan
- [ ] Perso API에서 'Enqueue Pending', 'Transcribing' 등 진행 상태가 정상 매핑되는지 확인
- [ ] 대시보드에서 `queued` 상태 작업이 '대기 중'으로 표시되는지 확인
- [ ] YouTube analytics 차트가 userId 없이 정상 동작하는지 확인
- [ ] 빌드 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)