### PR TITLE
fix: auth/sync 쿠키 토큰 허용 + uploads 다운로드 fallback

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -9,7 +9,7 @@ import { formatDuration } from '@/utils/formatters'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
-import { ytUploadVideo, ytUploadCaption, getDownloadLinks } from '@/lib/api-client'
+import { ytUploadVideo, ytUploadCaption, getDownloadLinks, getPersoFileUrl } from '@/lib/api-client'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { getLanguageByCode } from '@/utils/languages'
 import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
@@ -43,13 +43,28 @@ function UploadRow({ item, userId }: UploadRowProps) {
       let srtUrl = item.srt_url
 
       if (!videoUrl && item.project_seq && item.space_seq) {
-        const downloads = await getDownloadLinks(item.project_seq, item.space_seq, 'all')
-        videoUrl = downloads.videoFile?.videoDownloadLink ?? null
-        srtUrl = srtUrl ?? downloads.srtFile?.translatedSubtitleDownloadLink ?? null
-        if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+        // Fetch dubbingVideo + all in parallel
+        const [dubDl, allDl] = await Promise.all([
+          getDownloadLinks(item.project_seq, item.space_seq, 'dubbingVideo'),
+          getDownloadLinks(item.project_seq, item.space_seq, 'all'),
+        ])
+        videoUrl = dubDl.videoFile?.videoDownloadLink
+          ?? allDl.videoFile?.videoDownloadLink
+          ?? allDl.zippedFileDownloadLink
+          ?? null
+        srtUrl = srtUrl ?? allDl.srtFile?.translatedSubtitleDownloadLink ?? null
+
+        // Perso returns relative paths (/perso-storage/...) — resolve to full URL
+        if (videoUrl && !videoUrl.startsWith('http')) {
+          videoUrl = getPersoFileUrl(videoUrl)
+        }
+        if (srtUrl && !srtUrl.startsWith('http')) {
+          srtUrl = getPersoFileUrl(srtUrl)
+        }
+        if (!videoUrl) throw new Error('No dubbed video download link available')
       }
 
-      if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      if (!videoUrl) throw new Error('No dubbed video download link available')
 
       setState('uploading')
       const result = await ytUploadVideo({

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -32,9 +32,12 @@ export async function POST(req: NextRequest) {
       return apiFail('BAD_REQUEST', 'uid and email required', 400)
     }
 
-    const { uid, email, displayName, photoURL, accessToken } = parsed.data
+    const { uid, email, displayName, photoURL, accessToken: bodyToken } = parsed.data
 
-    // accessToken is required — verify it with Google to prevent auth bypass
+    // Resolve access token: body → httpOnly cookie (set by /api/auth/callback)
+    const cookieToken = req.cookies.get('google_access_token')?.value
+    const accessToken = bodyToken || cookieToken
+
     if (!accessToken) {
       return apiFail('UNAUTHORIZED', 'Google access token is required', 401)
     }


### PR DESCRIPTION
## Summary
- **auth/sync 401 수정**: 페이지 리로드 시 AuthHydrator가 accessToken 없이 sync 호출 → httpOnly 쿠키에서도 토큰을 읽도록 수정
- **uploads 다운로드 fallback**: Perso API가 videoDownloadLink를 null로 반환하는 경우 dubbingVideo 타겟 + zip fallback 추가, 상대경로 → 절대 URL 변환

## Test plan
- [ ] 페이지 새로고침 후 auth/sync가 200 반환하는지 확인
- [ ] uploads 페이지에서 YouTube 업로드 버튼 클릭 시 정상 동작 확인
- [ ] Perso에서 zip만 제공하는 경우 fallback으로 업로드 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)