### PR TITLE
fix: 버그 10개 수정 + UploadStep 원본 링크 첨부 + 오디오+Studio 도우미

### DIFF
--- a/src/app/(app)/batch/page.tsx
+++ b/src/app/(app)/batch/page.tsx
@@ -24,12 +24,22 @@ export default function BatchPage() {
   const queryClient = useQueryClient()
   const user = useAuthStore((s) => s.user)
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
 
   const handleDeleteJob = async (jobId: number) => {
+    if (deletingId === jobId) return
     if (confirmDeleteId === jobId) {
-      await dbMutation({ type: 'deleteDubbingJob', payload: { jobId } })
-      queryClient.invalidateQueries({ queryKey: ['recent-jobs'] })
+      setDeletingId(jobId)
       setConfirmDeleteId(null)
+      queryClient.setQueryData(['recent-jobs', user?.uid], (old: typeof jobs) =>
+        old ? old.filter((j) => j.id !== jobId) : old,
+      )
+      try {
+        await dbMutation({ type: 'deleteDubbingJob', payload: { jobId } })
+      } finally {
+        setDeletingId(null)
+        queryClient.invalidateQueries({ queryKey: ['recent-jobs'] })
+      }
     } else {
       setConfirmDeleteId(jobId)
       setTimeout(() => setConfirmDeleteId((prev) => (prev === jobId ? null : prev)), 3000)
@@ -156,14 +166,21 @@ export default function BatchPage() {
 
                 <button
                   onClick={() => handleDeleteJob(job.id)}
+                  disabled={deletingId === job.id}
                   className={`shrink-0 rounded-md p-1.5 transition-colors ${
-                    confirmDeleteId === job.id
-                      ? 'bg-red-50 text-red-500 dark:bg-red-900/20'
-                      : 'text-surface-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20'
+                    deletingId === job.id
+                      ? 'text-surface-300 cursor-not-allowed'
+                      : confirmDeleteId === job.id
+                        ? 'bg-red-50 text-red-500 dark:bg-red-900/20'
+                        : 'text-surface-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20'
                   }`}
-                  title={confirmDeleteId === job.id ? '한번 더 클릭하면 삭제됩니다' : '작업 삭제'}
+                  title={deletingId === job.id ? '삭제 중...' : confirmDeleteId === job.id ? '한번 더 클릭하면 삭제됩니다' : '작업 삭제'}
                 >
-                  <Trash2 className="h-4 w-4" />
+                  {deletingId === job.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
                 </button>
               </div>
             )

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe, Loader2 } from 'lucide-react'
 import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from '@/components/ui'
@@ -8,6 +9,7 @@ import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
 
 export default function YouTubeSettingsPage() {
+  const router = useRouter()
   const [defaultVisibility, setDefaultVisibility] = useState('public')
   const [autoSubtitles, setAutoSubtitles] = useState(true)
 
@@ -170,7 +172,7 @@ export default function YouTubeSettingsPage() {
                       </p>
                     </div>
                   </div>
-                  <Button variant="outline" size="sm" className="shrink-0 ml-3">
+                  <Button variant="outline" size="sm" className="shrink-0 ml-3" onClick={() => router.push(`/dubbing?url=${encodeURIComponent(`https://www.youtube.com/watch?v=${video.videoId}`)}`)}>
                     이 영상 더빙
                   </Button>
                 </div>

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from 'next/server'
 import { upsertUser } from '@/lib/db/queries'
-import { SESSION_COOKIE, signSessionCookie } from '@/lib/auth/session-cookie'
+import { SESSION_COOKIE, signSessionCookie, verifySessionCookie } from '@/lib/auth/session-cookie'
 import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
 import { syncBodySchema } from '@/lib/validators/auth'
+import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -34,16 +35,41 @@ export async function POST(req: NextRequest) {
 
     const { uid, email, displayName, photoURL, accessToken: bodyToken } = parsed.data
 
-    // Resolve access token: body → httpOnly cookie (set by /api/auth/callback)
+    // Resolve access token: body → httpOnly cookie → DB (refresh if expired)
     const cookieToken = req.cookies.get('google_access_token')?.value
-    const accessToken = bodyToken || cookieToken
+    let accessToken = bodyToken || cookieToken
+
+    // Helper: attempt token refresh via session cookie + DB
+    const tryRefreshFromSession = async (): Promise<string | null> => {
+      const sessionCookie = req.cookies.get(SESSION_COOKIE)?.value
+      if (!sessionCookie) return null
+      const sessionUid = await verifySessionCookie(sessionCookie)
+      if (!sessionUid || sessionUid !== uid) return null
+      return getOrRefreshAccessToken(sessionUid)
+    }
+
+    // No token from body/cookie — try DB refresh
+    if (!accessToken) {
+      accessToken = (await tryRefreshFromSession()) ?? undefined
+    }
 
     if (!accessToken) {
-      return apiFail('UNAUTHORIZED', 'Google access token is required', 401)
+      return apiFail('UNAUTHORIZED', 'Google access token is required — please sign in again', 401)
     }
-    const googleUser = await verifyGoogleToken(accessToken)
+
+    let googleUser = await verifyGoogleToken(accessToken)
+
+    // Token expired/invalid — try DB refresh as last resort
     if (!googleUser) {
-      return apiFail('UNAUTHORIZED', 'Invalid or expired Google access token', 401)
+      const refreshed = (await tryRefreshFromSession()) ?? undefined
+      if (refreshed && refreshed !== accessToken) {
+        accessToken = refreshed
+        googleUser = await verifyGoogleToken(accessToken)
+      }
+    }
+
+    if (!googleUser) {
+      return apiFail('UNAUTHORIZED', 'Invalid or expired Google access token — please sign in again', 401)
     }
     if (googleUser.sub !== uid) {
       return apiFail('FORBIDDEN', 'Token subject does not match uid', 403)

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -30,7 +30,14 @@ function AuthHydrator() {
           displayName: user.displayName,
           photoURL: user.photoURL,
         }),
-      }).catch(() => {})
+      })
+        .then((res) => {
+          if (res.status === 401) {
+            // Token expired and refresh failed — clear session so user can re-login
+            auth.clear()
+          }
+        })
+        .catch(() => {})
     } else {
       auth.setLoading(false)
     }

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -25,9 +25,11 @@ const FOCUSABLE = 'a[href],button:not(:disabled),input:not(:disabled),select:not
 export function Modal({ open, onClose, title, children, className, size = 'md' }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') { onClose(); return }
+    if (e.key === 'Escape') { onCloseRef.current(); return }
     if (e.key !== 'Tab') return
     const el = dialogRef.current
     if (!el) return
@@ -37,7 +39,7 @@ export function Modal({ open, onClose, title, children, className, size = 'md' }
     const last = focusable[focusable.length - 1]
     if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus() }
     else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus() }
-  }, [onClose])
+  }, [])
 
   useEffect(() => {
     if (!open) return

--- a/src/features/dashboard/components/QuickStart.tsx
+++ b/src/features/dashboard/components/QuickStart.tsx
@@ -12,7 +12,7 @@ export function QuickStart() {
   const isValid = url.length > 0 && isValidYouTubeUrl(url)
 
   const handleStart = () => {
-    if (isValid) router.push('/dubbing')
+    if (isValid) router.push(`/dubbing?url=${encodeURIComponent(url)}`)
   }
 
   return (

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -28,12 +28,14 @@ const reasonLabels: Record<string, string> = {
   ENQUEUED: '합성 대기 중...',
   PROCESSING: '더빙 오디오 생성 중...',
   COMPLETED: '완료!',
+  Completed: '완료!',
   FAILED: '처리 실패',
+  Failed: '처리 실패',
   CANCELED: '취소됨',
 }
 
 function getProgressLabel(lp: { progressReason: string; progress: number }) {
-  if (lp.progress >= 100 && lp.progressReason !== 'COMPLETED' && lp.progressReason !== 'FAILED' && lp.progressReason !== 'CANCELED') {
+  if (lp.progress >= 100 && lp.progressReason !== 'COMPLETED' && lp.progressReason !== 'Completed' && lp.progressReason !== 'FAILED' && lp.progressReason !== 'Failed' && lp.progressReason !== 'CANCELED') {
     return '마무리 중...'
   }
   return reasonLabels[lp.progressReason] || lp.progressReason
@@ -63,7 +65,7 @@ export function ProcessingStep() {
 
   // Auto-advance when all complete
   const allCompleted = languageProgress.length > 0 && languageProgress.every(
-    (p) => p.progressReason === 'COMPLETED' || p.progressReason === 'FAILED' || p.progressReason === 'CANCELED',
+    (p) => p.progressReason === 'COMPLETED' || p.progressReason === 'Completed' || p.progressReason === 'FAILED' || p.progressReason === 'Failed' || p.progressReason === 'CANCELED',
   )
 
   useEffect(() => {
@@ -107,8 +109,8 @@ export function ProcessingStep() {
           const lang = getLanguageByCode(lp.langCode)
           if (!lang) return null
 
-          const isCompleted = lp.progressReason === 'COMPLETED'
-          const isFailed = lp.progressReason === 'FAILED' || lp.progressReason === 'CANCELED'
+          const isCompleted = lp.progressReason === 'COMPLETED' || lp.progressReason === 'Completed'
+          const isFailed = lp.progressReason === 'FAILED' || lp.progressReason === 'Failed' || lp.progressReason === 'CANCELED'
 
           return (
             <Card

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2 } from 'lucide-react'
-import { useState, useCallback } from 'react'
+import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2, Link2 } from 'lucide-react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
 import { getLanguageByCode } from '@/utils/languages'
+import { extractVideoId } from '@/utils/validators'
 import { useNotificationStore } from '@/stores/notificationStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
@@ -23,17 +24,41 @@ interface LangUploadState {
 }
 
 export function UploadStep() {
-  const { selectedLanguages, videoMeta, languageProgress, isShort, dbJobId, spaceSeq, projectMap, reset } = useDubbingStore()
+  const { selectedLanguages, videoMeta, videoSource, languageProgress, isShort, dbJobId, spaceSeq, projectMap, reset } = useDubbingStore()
   const { fetchDownloads } = usePersoFlow()
   const addToast = useNotificationStore((s) => s.addToast)
   const userId = useAuthStore((s) => s.user?.uid)
   const router = useRouter()
 
+  // Original YouTube link detection (for auto-attach)
+  const originalYouTubeId =
+    videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
+  const originalYouTubeUrl = originalYouTubeId
+    ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
+    : null
+
   const [copiedLang, setCopiedLang] = useState<string | null>(null)
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
   const [uploadAsShort, setUploadAsShort] = useState(isShort)
+  const [autoUpload, setAutoUpload] = useState(false)
+  // 원본 링크 첨부 — YouTube URL일 때 기본 ON
+  const [attachOriginalLink, setAttachOriginalLink] = useState(!!originalYouTubeUrl)
+  const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
+  const autoUploadTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  // Build description with optional original link
+  const buildDescription = useCallback(
+    (langName: string) => {
+      const base = `${videoMeta?.title || 'Video'} - ${langName} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+      if (attachOriginalLink && originalYouTubeUrl) {
+        return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
+      }
+      return base
+    },
+    [videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
+  )
 
   const handleCopy = (langCode: string, text: string) => {
     navigator.clipboard.writeText(text)
@@ -43,6 +68,44 @@ export function UploadStep() {
 
   const handleNewDubbing = () => reset()
   const handleGoToDashboard = () => { reset(); router.push('/dashboard') }
+
+  // Audio + Studio helper — downloads audio and opens Studio in popup
+  // (iframe embed is blocked by YouTube's X-Frame-Options: DENY, so we use a popup)
+  const handleAudioToStudio = useCallback(async (langCode: string) => {
+    const lang = getLanguageByCode(langCode)
+    if (!lang) return
+    setStudioOpenedLang(langCode)
+    try {
+      // 1. Fetch audio download link
+      const data = await fetchDownloads(langCode, 'voiceAudio')
+      const audioUrl = data?.audioFile?.voiceAudioDownloadLink
+      if (audioUrl) {
+        // Trigger download in new tab
+        window.open(audioUrl, '_blank')
+      }
+
+      // 2. Copy language code to clipboard (Studio audio track needs it)
+      try {
+        await navigator.clipboard.writeText(langCode)
+      } catch {
+        // Clipboard may fail on insecure contexts — ignore
+      }
+
+      // 3. Open Studio in popup — deep-link to original video's audio page if available
+      const studioUrl = originalYouTubeId
+        ? `https://studio.youtube.com/video/${originalYouTubeId}/translations/audio`
+        : 'https://studio.youtube.com'
+      window.open(studioUrl, 'yt-studio', 'width=1400,height=900,noopener')
+
+      addToast({
+        type: 'info',
+        title: `${lang.name} 오디오 준비 완료`,
+        message: '오디오 다운로드 + Studio 팝업 열림. 언어 코드가 클립보드에 복사됐습니다.',
+      })
+    } finally {
+      setTimeout(() => setStudioOpenedLang(null), 1500)
+    }
+  }, [fetchDownloads, originalYouTubeId, addToast])
 
   const handleDownload = useCallback(async (langCode: string, type: 'video' | 'voiceAudio' | 'translatedSubtitle') => {
     setLoadingDownload(`${langCode}-${type}`)
@@ -88,7 +151,7 @@ export function UploadStep() {
       const result = await ytUploadVideo({
         videoUrl,
         title: ytTitle,
-        description: `${videoMeta?.title || 'Video'} - ${lang.name} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`,
+        description: buildDescription(lang.name),
         tags: ['CreatorDub', 'AI더빙', lang.name, 'dubbed', ...(uploadAsShort ? ['Shorts'] : [])],
         privacyStatus: 'private',
         language: langCode,
@@ -174,15 +237,23 @@ export function UploadStep() {
 
   const completedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
-    return lp?.progressReason === 'COMPLETED'
+    return lp?.progressReason === 'COMPLETED' || lp?.progressReason === 'Completed'
   })
 
   const failedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
-    return lp?.progressReason === 'FAILED' || lp?.progressReason === 'CANCELED'
+    return lp?.progressReason === 'FAILED' || lp?.progressReason === 'Failed' || lp?.progressReason === 'CANCELED'
   })
 
   const anyUploading = Object.values(ytUploads).some((s) => s.status === 'uploading')
+
+  // Auto-upload on mount if enabled
+  useEffect(() => {
+    if (autoUpload && isAuthenticated && completedLangs.length > 0 && !autoUploadTriggered.current && !anyUploading) {
+      autoUploadTriggered.current = true
+      handleUploadAll()
+    }
+  }, [autoUpload, isAuthenticated, completedLangs.length, anyUploading, handleUploadAll])
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -215,12 +286,14 @@ export function UploadStep() {
               더빙된 영상을 YouTube에 새 영상으로 업로드합니다. 안전을 위해 비공개로 업로드되며, 이후 YouTube Studio에서 공개 설정을 변경할 수 있습니다.
             </p>
 
-            {isShort && (
-              <div className="mb-4 flex items-center justify-between rounded-lg bg-brand-50 p-3 dark:bg-brand-900/20">
+            {/* Upload options */}
+            <div className="mb-4 space-y-2">
+              {/* Shorts toggle — always visible */}
+              <div className="flex items-center justify-between rounded-lg bg-brand-50 p-3 dark:bg-brand-900/20">
                 <div className="flex items-center gap-2">
-                  <Badge variant="brand">Shorts 감지됨</Badge>
+                  {isShort && <Badge variant="brand">Shorts 감지됨</Badge>}
                   <span className="text-sm text-surface-600 dark:text-surface-400">
-                    3분 이하 영상 — #Shorts 태그 자동 추가
+                    {isShort ? '3분 이하 영상 — #Shorts 태그 자동 추가' : 'Shorts로 업로드 (#Shorts 태그 추가)'}
                   </span>
                 </div>
                 <button
@@ -234,7 +307,66 @@ export function UploadStep() {
                   {uploadAsShort ? 'Shorts ON' : 'Shorts OFF'}
                 </button>
               </div>
-            )}
+
+              {/* Auto upload toggle */}
+              <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+                <span className="text-sm text-surface-600 dark:text-surface-400">
+                  완료 즉시 자동 업로드
+                </span>
+                <button
+                  onClick={() => { setAutoUpload(!autoUpload); autoUploadTriggered.current = false }}
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
+                    autoUpload
+                      ? 'bg-emerald-500 text-white'
+                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+                  }`}
+                >
+                  {autoUpload ? 'ON' : 'OFF'}
+                </button>
+              </div>
+
+              {/* 원본 링크 첨부 — YouTube URL 감지 시만 표시 */}
+              {originalYouTubeUrl && (
+                <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Link2 className="h-4 w-4 flex-shrink-0 text-surface-400" />
+                    <div className="min-w-0">
+                      <p className="text-sm text-surface-600 dark:text-surface-400">
+                        설명란에 원본 YouTube 링크 첨부
+                      </p>
+                      <p className="truncate text-xs text-surface-400">{originalYouTubeUrl}</p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => setAttachOriginalLink(!attachOriginalLink)}
+                    className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
+                      attachOriginalLink
+                        ? 'bg-brand-500 text-white'
+                        : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+                    }`}
+                  >
+                    {attachOriginalLink ? '첨부 ON' : '첨부 OFF'}
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Upload info */}
+            <div className="mb-4 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <div className="flex items-center gap-2 mb-2">
+                <Upload className="h-4 w-4 text-surface-400" />
+                <span className="text-sm font-medium text-surface-700 dark:text-surface-300">더빙 영상을 새 영상으로 업로드</span>
+              </div>
+              <p className="text-xs text-surface-500">
+                각 언어별 더빙된 영상이 별도의 새 영상으로 YouTube에 업로드됩니다. 원본 영상은 변경되지 않습니다.
+              </p>
+              <div className="flex items-center gap-2 mt-2">
+                <Volume2 className="h-4 w-4 text-surface-400" />
+                <span className="text-xs text-surface-500">
+                  오디오만 필요하면 아래 다운로드에서 Audio를 받아 YouTube Studio에서 수동 추가하세요.
+                </span>
+              </div>
+            </div>
 
             <div className="space-y-2">
               {completedLangs.map((code) => {
@@ -388,26 +520,66 @@ export function UploadStep() {
         </Card>
       )}
 
-      {/* YouTube Studio guide (for multi-audio track) */}
-      <Card>
-        <CardTitle>YouTube Multi-Audio Track (수동)</CardTitle>
-        <p className="text-xs text-surface-500 mb-3">
-          위 자동 업로드는 각 언어별 새 영상으로 업로드됩니다.
-          하나의 영상에 여러 오디오 트랙을 추가하려면 YouTube Studio에서 수동으로 설정하세요.
-        </p>
-        <div className="rounded-lg bg-amber-50 border border-amber-200 p-3 text-sm text-amber-800 dark:bg-amber-900/10 dark:border-amber-800 dark:text-amber-300">
-          Multi-Audio Track 업로드는 YouTube 채널 자격 요건(구독자 1,000명 이상)이 필요합니다.
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-3"
-          onClick={() => window.open('https://studio.youtube.com', '_blank')}
-        >
-          <ExternalLink className="h-4 w-4" />
-          YouTube Studio 열기
-        </Button>
-      </Card>
+      {/* YouTube Multi-Audio Track — audio + Studio popup helper */}
+      {completedLangs.length > 0 && (
+        <Card>
+          <CardTitle>원본 영상에 오디오 트랙 추가 (Multi-Audio)</CardTitle>
+          <p className="text-xs text-surface-500 mb-3">
+            하나의 영상에 여러 오디오 트랙을 붙이려면 YouTube Studio에서 수동 적용이 필요합니다.
+            아래 버튼을 누르면 오디오가 다운로드되고 Studio가 팝업으로 열립니다. 언어 코드는 클립보드에 복사됩니다.
+          </p>
+          <div className="mb-3 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800 dark:bg-amber-900/10 dark:border-amber-800 dark:text-amber-300">
+            Multi-Audio Track 업로드는 YouTube 채널 자격 요건(구독자 1,000명 이상)이 필요합니다.
+            {!originalYouTubeId && ' 원본이 YouTube URL이 아니면 Studio 홈으로 이동합니다 — 대상 영상을 직접 선택하세요.'}
+          </div>
+          <div className="space-y-2">
+            {completedLangs.map((code) => {
+              const lang = getLanguageByCode(code)
+              if (!lang) return null
+              const opening = studioOpenedLang === code
+              return (
+                <div
+                  key={code}
+                  className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-lg">{lang.flag}</span>
+                    <div>
+                      <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                      <p className="text-xs text-surface-400">오디오 다운로드 + Studio 팝업</p>
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleAudioToStudio(code)}
+                    loading={opening}
+                  >
+                    <Volume2 className="h-3.5 w-3.5" />
+                    오디오 + Studio
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-3"
+            onClick={() =>
+              window.open(
+                originalYouTubeId
+                  ? `https://studio.youtube.com/video/${originalYouTubeId}/translations/audio`
+                  : 'https://studio.youtube.com',
+                '_blank',
+              )
+            }
+          >
+            <ExternalLink className="h-4 w-4" />
+            Studio만 열기
+          </Button>
+        </Card>
+      )}
 
       {/* Translated metadata */}
       <Card>
@@ -418,7 +590,7 @@ export function UploadStep() {
             const lang = getLanguageByCode(code)
             if (!lang) return null
             const title = `[${lang.name}] ${videoMeta?.title || 'Video Title'}`
-            const desc = `${videoMeta?.title || 'Video'} - ${lang.name} 더빙 by CreatorDub AI`
+            const desc = buildDescription(lang.name)
             return (
               <div key={code} className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">
                 <div className="flex items-center justify-between mb-2">
@@ -435,7 +607,7 @@ export function UploadStep() {
                   </button>
                 </div>
                 <p className="text-sm font-medium text-surface-900 dark:text-white">{title}</p>
-                <p className="text-xs text-surface-500 mt-1">{desc}</p>
+                <p className="text-xs text-surface-500 mt-1 whitespace-pre-line">{desc}</p>
               </div>
             )
           })}

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap } from 'lucide-react'
 import { Card, Button, Input, Badge, Tabs, TabsList, TabsTrigger, TabsContent, Progress } from '@/components/ui'
@@ -14,7 +15,8 @@ export function VideoInputStep() {
   const { videoMeta, setVideoSource, setIsShort, nextStep } = useDubbingStore()
   const { uploadLocalVideo, importVideoByUrl } = usePersoFlow()
 
-  const [url, setUrl] = useState('')
+  const searchParams = useSearchParams()
+  const [url, setUrl] = useState(searchParams.get('url') ?? '')
   const [loading, setLoading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [error, setError] = useState<string | null>(null)
@@ -79,7 +81,7 @@ export function VideoInputStep() {
         <p className="mt-1 text-surface-500">YouTube URL을 붙여넣거나 영상 파일을 업로드하세요</p>
       </div>
 
-      <Tabs defaultValue="upload">
+      <Tabs defaultValue={searchParams.get('url') ? 'url' : 'upload'}>
         <TabsList className="mx-auto w-fit">
           <TabsTrigger value="url">
             <span className="flex items-center gap-1.5"><Link2 className="h-4 w-4" /> 영상 URL</span>
@@ -162,7 +164,7 @@ export function VideoInputStep() {
           <Card className="py-12 text-center">
             <Film className="mx-auto h-10 w-10 text-surface-400" />
             <p className="mt-3 text-sm text-surface-500">YouTube 채널을 연결하면 영상을 바로 선택할 수 있습니다</p>
-            <Button variant="outline" className="mt-4">채널 연결</Button>
+            <Button variant="outline" className="mt-4" onClick={() => window.location.href = '/youtube'}>채널 연결</Button>
           </Card>
         </TabsContent>
       </Tabs>

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -120,7 +120,8 @@ async function pollLanguage(
     }).catch(() => { /* progress update is best-effort */ })
   }
 
-  const isTerminal = progress.progressReason === 'COMPLETED' || progress.progressReason === 'FAILED' || progress.progressReason === 'CANCELED'
+  const reason = progress.progressReason
+  const isTerminal = reason === 'COMPLETED' || reason === 'Completed' || reason === 'FAILED' || reason === 'Failed' || reason === 'CANCELED'
   if (!isTerminal) {
     // progress hit 100 but backend hasn't confirmed COMPLETED yet — poll fast
     if (progress.progress >= 100) return 'finalizing'
@@ -130,7 +131,7 @@ async function pollLanguage(
   clearTimeout(pollTimers[langCode])
   delete pollTimers[langCode]
 
-  if (progress.progressReason === 'COMPLETED') {
+  if (reason === 'COMPLETED' || reason === 'Completed') {
     try {
       const downloads = await getDownloadLinks(projectSeq, spaceSeq, 'all')
       store.getState().updateLanguageProgress(langCode, {
@@ -159,11 +160,11 @@ async function pollLanguage(
 
   const allProgress = store.getState().languageProgress
   const allDone = allProgress.every(
-    (lp) => lp.progressReason === 'COMPLETED' || lp.progressReason === 'FAILED' || lp.progressReason === 'CANCELED',
+    (lp) => lp.progressReason === 'COMPLETED' || lp.progressReason === 'Completed' || lp.progressReason === 'FAILED' || lp.progressReason === 'Failed' || lp.progressReason === 'CANCELED',
   )
   if (!allDone) return true
 
-  const anyFailed = allProgress.some((lp) => lp.progressReason === 'FAILED')
+  const anyFailed = allProgress.some((lp) => lp.progressReason === 'FAILED' || lp.progressReason === 'Failed')
   store.getState().setJobStatus(anyFailed ? 'failed' : 'completed')
 
   const userId = useAuthStore.getState().user?.uid

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -94,6 +94,8 @@ export type ProgressReason =
   | 'Generating Voice'
   | 'Analyzing Lip Sync'
   | 'Applying Lip Sync'
+  | 'Completed'
+  | 'Failed'
 
 export interface ProgressResponse {
   projectSeq: number


### PR DESCRIPTION
## Summary
- 버그 하네스로 발견한 10개 버그 번들 수정 (URL 유지·auth/sync·Processing 전환·Modal 포커스·삭제 속도·크레딧 차감 등)
- UploadStep에 **원본 링크 첨부** 토글 추가 — 원본이 YouTube URL일 때 더빙 설명란에 원본 링크 자동 첨부
- UploadStep에 **오디오 + Studio 도우미** — 언어별 오디오 다운로드 + YouTube Studio 팝업 오픈 + 언어코드 클립보드 복사를 한 번에 실행

## 설계 메모
- iframe 임베드는 YouTube가 `X-Frame-Options: DENY` 로 차단하므로 팝업(`window.open`) 전략으로 대체
- 원본 YouTube ID가 있으면 `studio.youtube.com/video/{id}/translations/audio` 로 딥링크하여 사용자의 네비게이션 단계를 최소화

## Test plan
- [ ] 빠른 시작 → URL 입력 → 새 더빙 진입 시 URL 값 유지 확인
- [ ] 대시보드 401/500 재현 불가 확인
- [ ] YouTube 탭 '이 영상 더빙' 버튼 동작 확인
- [ ] 더빙 100% 시 'Completed' 수신 후 Upload 단계로 전환 확인
- [ ] 배치 큐 삭제 버튼 1-클릭 반응 확인
- [ ] 업로드 모달 입력 중 포커스 유지 확인
- [ ] 남은 시간 크레딧 차감 확인 (더빙 후 billing에서 감소)
- [ ] Shorts/자동 업로드 토글 동작
- [ ] 원본이 YouTube URL일 때 설명란에 원본 링크 첨부 확인
- [ ] '오디오 + Studio' 버튼: 오디오 다운 + Studio 팝업 + 언어코드 클립보드 복사 확인

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)