### PR TITLE
chore(security): GitHub 보안 설정 + CodeQL/Dependabot + CVE 감사 문서

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,132 @@
+# 보안 정책 (Security Policy)
+
+> CreatorDub 웹 애플리케이션의 보안 취약점 보고 절차를 정의합니다.
+> This document defines how to report security vulnerabilities for the CreatorDub web application.
+
+---
+
+## 한국어 (Primary)
+
+### 지원 버전 (Supported Versions)
+
+보안 패치는 항상 `main` 브랜치의 최신 배포 버전에만 적용됩니다. 이전 배포분은 별도 지원되지 않으므로, 취약점이 확인되면 최신 버전으로 업그레이드해 주세요.
+
+| 버전 | 지원 여부 |
+| ---- | --------- |
+| `main` (최신 배포) | 지원 |
+| 그 외 브랜치 / 과거 태그 | 미지원 |
+
+### 취약점 신고 방법
+
+**공개 이슈(Public Issue)로 보고하지 마세요.** 취약점 정보가 공개되면 악용 가능성이 높아집니다.
+
+1. GitHub의 **Private Vulnerability Reporting** 을 사용해 주세요.
+   - Repository → **Security** 탭 → **Report a vulnerability** 버튼
+   - 또는 직접 링크: `https://github.com/perso-devrel/creatordubbing/security/advisories/new`
+2. GitHub 계정이 없거나 Private Reporting 에 접근할 수 없다면 아래 이메일로 연락 바랍니다.
+   - `security@creatordub.local`
+   - PGP 공개키: 현재 미공개 (필요 시 보고자에게 별도 전달)
+
+### 보고 시 포함해 주세요
+
+- 영향받는 컴포넌트 (파일 경로, 엔드포인트, UI 화면 등)
+- 재현 절차 (PoC 또는 단계별 설명)
+- 예상되는 영향 범위 (정보 유출, 권한 상승, DoS 등)
+- 가능하다면 제안하는 완화/수정 방안
+
+### 응답 SLA (Response SLA)
+
+| 단계 | 기한 |
+| ---- | ---- |
+| 접수 확인 (Initial Acknowledgement) | 영업일 기준 **48시간 이내** |
+| 조치 계획 공유 (Remediation Plan) | 접수 후 **7일 이내** |
+| 보안 패치 배포 | 심각도에 따라 별도 조율 (Critical: 가능한 한 신속히) |
+
+보고자에게는 처리 과정이 단계별로 공유되며, 원하는 경우 GitHub Security Advisory 에 크레딧을 기재합니다.
+
+### 범위 (Scope)
+
+이 정책은 **CreatorDub 웹 애플리케이션 본체**에만 적용됩니다.
+
+**범위 내 (In-scope)**
+- 이 저장소(`perso-devrel/creatordubbing`)의 애플리케이션 코드
+- 배포된 CreatorDub 웹 서비스의 엔드포인트 / UI
+- 저장소에 포함된 빌드·배포 스크립트 및 GitHub Actions 워크플로
+
+**범위 외 (Out-of-scope)** — 해당 벤더에 직접 신고해 주세요.
+- **Perso.ai API**: Perso.ai 측 보안 담당에게 직접 문의
+- **YouTube Data API / Google OAuth**: Google Vulnerability Reward Program (`https://bughunters.google.com`)
+- **Turso / libSQL**: Turso 보안 담당 (`security@turso.tech`)
+- **Next.js / React / Vercel 등 업스트림 의존성**: 각 프로젝트의 보안 정책을 따름
+
+### Safe Harbor
+
+성실한 보안 연구(good-faith research) 로 신고된 건에 대해서는 법적 조치를 취하지 않습니다. 단, 아래 행위는 금지됩니다.
+
+- 실제 사용자 데이터 열람·유출·변조
+- 서비스 가용성에 영향을 주는 행위 (DoS, 스팸 등)
+- 비공개 취약점을 제3자에게 공개
+
+---
+
+## English
+
+### Supported Versions
+
+Security patches are applied only to the latest deployed version of the `main` branch. Older branches and legacy tags are **not** supported — please upgrade to the latest version before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| `main` (latest release) | Yes |
+| Other branches / past tags | No |
+
+### Reporting a Vulnerability
+
+**Do not open a public issue.** Public disclosure of unpatched vulnerabilities increases the risk of exploitation.
+
+1. Use GitHub's **Private Vulnerability Reporting** feature:
+   - Repository → **Security** tab → **Report a vulnerability**
+   - Direct link: `https://github.com/perso-devrel/creatordubbing/security/advisories/new`
+2. If GitHub is not an option, email the security team:
+   - `security@creatordub.local`
+   - PGP key: currently not published; will be shared on request.
+
+### What to Include
+
+- Affected component (file path, endpoint, UI surface)
+- Reproduction steps (PoC or step-by-step explanation)
+- Expected impact (data disclosure, privilege escalation, DoS, etc.)
+- Suggested mitigation or patch, if any
+
+### Response SLA
+
+| Stage | Target |
+| ----- | ------ |
+| Initial acknowledgement | Within **48 business hours** |
+| Remediation plan shared | Within **7 days** of acknowledgement |
+| Patch release | Depends on severity; Critical issues are prioritized |
+
+Reporters are updated at each stage and may be credited in the GitHub Security Advisory upon request.
+
+### Scope
+
+This policy covers the **CreatorDub web application only**.
+
+**In-scope**
+- Application code in this repository (`perso-devrel/creatordubbing`)
+- Endpoints and UI of the deployed CreatorDub web service
+- Build, deployment scripts, and GitHub Actions workflows in this repo
+
+**Out-of-scope** — report to the respective vendor instead.
+- **Perso.ai API**: contact the Perso.ai security team directly.
+- **YouTube Data API / Google OAuth**: Google Vulnerability Reward Program (`https://bughunters.google.com`).
+- **Turso / libSQL**: `security@turso.tech`.
+- **Next.js / React / Vercel and other upstream dependencies**: follow the respective project's security policy.
+
+### Safe Harbor
+
+We will not pursue legal action against researchers acting in good faith. The following activities are prohibited:
+
+- Accessing, exfiltrating, or modifying real user data
+- Degrading service availability (DoS, spam, etc.)
+- Disclosing unpatched vulnerabilities to third parties

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -1,0 +1,20 @@
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": {
+    "users": ["alpaka206"],
+    "teams": [],
+    "apps": []
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true,
+  "required_linear_history": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,86 @@
+version: 2
+updates:
+  # Application dependencies (npm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"
+    ignore:
+      # Major updates handled as individual PRs, never grouped
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # Major-version updates (npm) — opened as separate, non-grouped PRs
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+      - "major-update"
+    commit-message:
+      prefix: "chore(deps-major)"
+      include: "scope"
+    allow:
+      - dependency-type: "direct"
+    # Only major updates here; grouped config above ignores majors
+    versioning-strategy: "increase"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      actions-security:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    # Every Monday at 06:00 UTC (15:00 KST)
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript
+          - typescript
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,51 @@
+name: npm audit
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit production dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run npm audit (fail on high/critical)
+        run: npm audit --audit-level=high
+
+      - name: Generate audit report (always)
+        if: always()
+        run: |
+          npm audit --json > npm-audit.json || true
+          echo "### npm audit summary" >> "$GITHUB_STEP_SUMMARY"
+          node -e "const r=require('./npm-audit.json');const m=r.metadata&&r.metadata.vulnerabilities||{};console.log('| Severity | Count |\n| --- | --- |');for(const k of ['critical','high','moderate','low','info']){console.log('| '+k+' | '+(m[k]||0)+' |');}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: npm-audit.json
+          retention-days: 30

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,101 @@
+# Security Audit Report — CreatorDub
+
+- **Scan date**: 2026-04-16
+- **Tool**: `npm audit` (auditReportVersion 2)
+- **Scope**: root `package.json` dependency tree (prod + dev + optional)
+- **Command**: `npm audit --json`
+
+---
+
+## 요약 (Korean Summary)
+
+- **결과**: 현재 의존성 트리에서 알려진 취약점이 **0건** 확인되었습니다.
+- **스캔 범위**: 총 **809개** 패키지 (production 94 / dev 670 / optional 111 / peer 0).
+- **심각도별 건수**: critical 0 · high 0 · moderate 0 · low 0 · info 0.
+- **조치 필요 사항**: 현 시점 즉시 조치 필요한 CVE는 없습니다. Dependabot 일일 스캔과 CI 의 `npm audit --audit-level=high` 게이트로 지속 감시합니다.
+- **권고**:
+  1. `.github/dependabot.yml` 의 일일 업데이트를 활성 상태로 유지합니다.
+  2. PR CI 에서 `npm-audit.yml` 워크플로가 실패하면 병합 전 반드시 해결합니다.
+  3. 매주 월요일 CodeQL 스케줄 스캔 결과를 Security 탭에서 확인합니다.
+  4. 새로운 의존성 추가 시 로컬에서 `npm audit` 재확인.
+  5. 다음 정기 점검 예정일: **2026-05-16** (월 1회 권장).
+
+---
+
+## English Details
+
+### Vulnerability counts
+
+| Severity | Count |
+| -------- | ----- |
+| critical | 0 |
+| high     | 0 |
+| moderate | 0 |
+| low      | 0 |
+| info     | 0 |
+| **total**| **0** |
+
+### Dependency inventory
+
+| Type     | Count |
+| -------- | ----- |
+| prod     | 94 |
+| dev      | 670 |
+| optional | 111 |
+| peer     | 0 |
+| peerOptional | 0 |
+| **total** | **809** |
+
+### High / Critical findings
+
+None. No packages in the dependency tree currently match a known GHSA advisory at HIGH or CRITICAL severity.
+
+Because there are no HIGH or CRITICAL entries, the per-package table (package name, vulnerable version, CVE ID, fix version, affected path) is intentionally empty. Once `npm audit` reports such entries, each will be recorded here with:
+
+- Package name
+- Vulnerable version range
+- CVE / GHSA identifier
+- Patched version
+- Affected dependency path (root → vulnerable package)
+
+### Raw audit output
+
+```json
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 94,
+      "dev": 670,
+      "optional": 111,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 809
+    }
+  }
+}
+```
+
+### Recommended actions
+
+1. **Keep Dependabot daily updates enabled** for the `npm` ecosystem (see `.github/dependabot.yml`). Minor + patch are grouped; majors land as individual PRs for isolated review.
+2. **Enforce `npm audit --audit-level=high`** on every PR via the `npm-audit.yml` workflow — CI must stay green before merge.
+3. **Review weekly CodeQL runs** (`security-extended` + `security-and-quality` queries) under the Security tab every Monday.
+4. **Re-run `npm audit` locally** before opening PRs that touch `package.json` or `package-lock.json`.
+5. **Monthly re-scan**: next scheduled review is **2026-05-16**. Update this document with the new date and any findings.
+6. **Supply-chain hygiene**: prefer packages with active maintenance and provenance-signed releases (`npm --provenance`) when possible.
+
+### Methodology notes
+
+- `npm audit` consults the npm advisory database (GHSA-backed) and reports both direct and transitive vulnerabilities.
+- Results reflect the state of `package-lock.json` at scan time and may change as upstream advisories are published.
+- Absence of findings does **not** imply absence of vulnerabilities — only that none are currently known to the public advisory database.


### PR DESCRIPTION
## Summary
저장소 보안 체계 일괄 설정.

- SECURITY.md (KR+EN), Dependabot, CodeQL, npm audit CI 추가
- main 브랜치 보호 규칙 설정(owner alpaka206 only merge)
- CVE 스캔: 0건 / 809개 의존성 (2026-04-16)

## 이미 활성화된 GitHub 설정
- Private Vulnerability Reporting ON
- Secret Scanning + Push Protection ON
- Dependabot Alerts + Automated Security Fixes ON
- Main branch protection ON

## Test plan
- [ ] Dependabot이 develop 타겟으로 PR 생성하는지 확인 (주간 관찰)
- [ ] CodeQL 주간 실행 결과 확인
- [ ] 임의 PR에서 npm-audit job 통과 확인

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)