### PR TITLE
release: develop → main — 보안 설정 + 4개국어 README + prompt.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,132 @@
+# 보안 정책 (Security Policy)
+
+> CreatorDub 웹 애플리케이션의 보안 취약점 보고 절차를 정의합니다.
+> This document defines how to report security vulnerabilities for the CreatorDub web application.
+
+---
+
+## 한국어 (Primary)
+
+### 지원 버전 (Supported Versions)
+
+보안 패치는 항상 `main` 브랜치의 최신 배포 버전에만 적용됩니다. 이전 배포분은 별도 지원되지 않으므로, 취약점이 확인되면 최신 버전으로 업그레이드해 주세요.
+
+| 버전 | 지원 여부 |
+| ---- | --------- |
+| `main` (최신 배포) | 지원 |
+| 그 외 브랜치 / 과거 태그 | 미지원 |
+
+### 취약점 신고 방법
+
+**공개 이슈(Public Issue)로 보고하지 마세요.** 취약점 정보가 공개되면 악용 가능성이 높아집니다.
+
+1. GitHub의 **Private Vulnerability Reporting** 을 사용해 주세요.
+   - Repository → **Security** 탭 → **Report a vulnerability** 버튼
+   - 또는 직접 링크: `https://github.com/perso-devrel/creatordubbing/security/advisories/new`
+2. GitHub 계정이 없거나 Private Reporting 에 접근할 수 없다면 아래 이메일로 연락 바랍니다.
+   - `security@creatordub.local`
+   - PGP 공개키: 현재 미공개 (필요 시 보고자에게 별도 전달)
+
+### 보고 시 포함해 주세요
+
+- 영향받는 컴포넌트 (파일 경로, 엔드포인트, UI 화면 등)
+- 재현 절차 (PoC 또는 단계별 설명)
+- 예상되는 영향 범위 (정보 유출, 권한 상승, DoS 등)
+- 가능하다면 제안하는 완화/수정 방안
+
+### 응답 SLA (Response SLA)
+
+| 단계 | 기한 |
+| ---- | ---- |
+| 접수 확인 (Initial Acknowledgement) | 영업일 기준 **48시간 이내** |
+| 조치 계획 공유 (Remediation Plan) | 접수 후 **7일 이내** |
+| 보안 패치 배포 | 심각도에 따라 별도 조율 (Critical: 가능한 한 신속히) |
+
+보고자에게는 처리 과정이 단계별로 공유되며, 원하는 경우 GitHub Security Advisory 에 크레딧을 기재합니다.
+
+### 범위 (Scope)
+
+이 정책은 **CreatorDub 웹 애플리케이션 본체**에만 적용됩니다.
+
+**범위 내 (In-scope)**
+- 이 저장소(`perso-devrel/creatordubbing`)의 애플리케이션 코드
+- 배포된 CreatorDub 웹 서비스의 엔드포인트 / UI
+- 저장소에 포함된 빌드·배포 스크립트 및 GitHub Actions 워크플로
+
+**범위 외 (Out-of-scope)** — 해당 벤더에 직접 신고해 주세요.
+- **Perso.ai API**: Perso.ai 측 보안 담당에게 직접 문의
+- **YouTube Data API / Google OAuth**: Google Vulnerability Reward Program (`https://bughunters.google.com`)
+- **Turso / libSQL**: Turso 보안 담당 (`security@turso.tech`)
+- **Next.js / React / Vercel 등 업스트림 의존성**: 각 프로젝트의 보안 정책을 따름
+
+### Safe Harbor
+
+성실한 보안 연구(good-faith research) 로 신고된 건에 대해서는 법적 조치를 취하지 않습니다. 단, 아래 행위는 금지됩니다.
+
+- 실제 사용자 데이터 열람·유출·변조
+- 서비스 가용성에 영향을 주는 행위 (DoS, 스팸 등)
+- 비공개 취약점을 제3자에게 공개
+
+---
+
+## English
+
+### Supported Versions
+
+Security patches are applied only to the latest deployed version of the `main` branch. Older branches and legacy tags are **not** supported — please upgrade to the latest version before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| `main` (latest release) | Yes |
+| Other branches / past tags | No |
+
+### Reporting a Vulnerability
+
+**Do not open a public issue.** Public disclosure of unpatched vulnerabilities increases the risk of exploitation.
+
+1. Use GitHub's **Private Vulnerability Reporting** feature:
+   - Repository → **Security** tab → **Report a vulnerability**
+   - Direct link: `https://github.com/perso-devrel/creatordubbing/security/advisories/new`
+2. If GitHub is not an option, email the security team:
+   - `security@creatordub.local`
+   - PGP key: currently not published; will be shared on request.
+
+### What to Include
+
+- Affected component (file path, endpoint, UI surface)
+- Reproduction steps (PoC or step-by-step explanation)
+- Expected impact (data disclosure, privilege escalation, DoS, etc.)
+- Suggested mitigation or patch, if any
+
+### Response SLA
+
+| Stage | Target |
+| ----- | ------ |
+| Initial acknowledgement | Within **48 business hours** |
+| Remediation plan shared | Within **7 days** of acknowledgement |
+| Patch release | Depends on severity; Critical issues are prioritized |
+
+Reporters are updated at each stage and may be credited in the GitHub Security Advisory upon request.
+
+### Scope
+
+This policy covers the **CreatorDub web application only**.
+
+**In-scope**
+- Application code in this repository (`perso-devrel/creatordubbing`)
+- Endpoints and UI of the deployed CreatorDub web service
+- Build, deployment scripts, and GitHub Actions workflows in this repo
+
+**Out-of-scope** — report to the respective vendor instead.
+- **Perso.ai API**: contact the Perso.ai security team directly.
+- **YouTube Data API / Google OAuth**: Google Vulnerability Reward Program (`https://bughunters.google.com`).
+- **Turso / libSQL**: `security@turso.tech`.
+- **Next.js / React / Vercel and other upstream dependencies**: follow the respective project's security policy.
+
+### Safe Harbor
+
+We will not pursue legal action against researchers acting in good faith. The following activities are prohibited:
+
+- Accessing, exfiltrating, or modifying real user data
+- Degrading service availability (DoS, spam, etc.)
+- Disclosing unpatched vulnerabilities to third parties

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -1,0 +1,20 @@
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": {
+    "users": ["alpaka206"],
+    "teams": [],
+    "apps": []
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true,
+  "required_linear_history": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,86 @@
+version: 2
+updates:
+  # Application dependencies (npm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"
+    ignore:
+      # Major updates handled as individual PRs, never grouped
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # Major-version updates (npm) — opened as separate, non-grouped PRs
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+      - "major-update"
+    commit-message:
+      prefix: "chore(deps-major)"
+      include: "scope"
+    allow:
+      - dependency-type: "direct"
+    # Only major updates here; grouped config above ignores majors
+    versioning-strategy: "increase"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      actions-security:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    # Every Monday at 06:00 UTC (15:00 KST)
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript
+          - typescript
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,51 @@
+name: npm audit
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit production dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run npm audit (fail on high/critical)
+        run: npm audit --audit-level=high
+
+      - name: Generate audit report (always)
+        if: always()
+        run: |
+          npm audit --json > npm-audit.json || true
+          echo "### npm audit summary" >> "$GITHUB_STEP_SUMMARY"
+          node -e "const r=require('./npm-audit.json');const m=r.metadata&&r.metadata.vulnerabilities||{};console.log('| Severity | Count |\n| --- | --- |');for(const k of ['critical','high','moderate','low','info']){console.log('| '+k+' | '+(m[k]||0)+' |');}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: npm-audit.json
+          retention-days: 30

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,169 @@
+# CreatorDub
+
+[🇰🇷 한국어](./README.md) | [🇺🇸 English](./README.en.md) | [🇯🇵 日本語](./README.ja.md) | [🇨🇳 中文](./README.zh.md)
+
+> **AI-powered multilingual dubbing & YouTube upload automation for creators.**
+> Upload one video and CreatorDub dubs it into multiple languages, uploads the results to YouTube with captions, and surfaces watch-time analytics in a single dashboard.
+
+Powered by the [Perso.ai](https://developers.perso.ai) API.
+
+## Features
+
+- **AI dubbing** — a 5-step wizard dubs your video into multiple languages while preserving the source speaker's tone.
+- **Lip-sync** — optional mouth re-animation to match the translated audio.
+- **Script editing** — edit the translated transcript sentence-by-sentence and regenerate audio.
+- **YouTube auto-upload** — dubbed videos are uploaded through our server to YouTube Data API v3 along with SRT captions.
+- **Multi-audio track helper** — YouTube's multi-audio-track API is unavailable, so CreatorDub organises per-language videos instead.
+- **Credit system** — per-minute credit pre-check before dubbing, deduction on completion.
+- **Dashboard & analytics** — per-language views/likes, monthly credit usage, and YouTube Analytics integration.
+
+## Tech Stack
+
+| Area | Stack |
+| ---- | ----- |
+| Framework | Next.js 16.2.3 (App Router) |
+| Runtime | React 19, TypeScript 5 |
+| Styling | Tailwind CSS v4 |
+| State | Zustand 5 |
+| Data fetching | TanStack React Query v5 |
+| Validation | Zod v4 |
+| Database | Turso (libSQL) via `@libsql/client` |
+| Dubbing engine | Perso.ai API |
+| Upload & stats | YouTube Data API v3 + Analytics API v2 |
+| Auth | Google OAuth 2.0 + signed session cookie |
+| Testing | Vitest, Playwright, Lighthouse |
+
+> **Note:** This project builds on Next.js 16's breaking changes. Read the guides in `node_modules/next/dist/docs/` before modifying any code.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- A [Perso.ai](https://developers.perso.ai) API key
+- A Turso database
+- A Google Cloud Console project with OAuth and the YouTube Data API enabled
+
+### Install
+
+```bash
+git clone https://github.com/perso-devrel/creatordubbing.git
+cd creatordubbing
+npm install
+```
+
+### Environment Variables
+
+Copy `.env.example` to `.env.local`:
+
+```bash
+cp .env.example .env.local
+```
+
+```env
+# Perso.ai
+PERSO_API_KEY=
+PERSO_API_BASE_URL=https://api.perso.ai
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://perso.ai
+
+# Google OAuth
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Session cookie signing
+SESSION_SECRET=
+
+# Turso DB
+TURSO_URL=
+TURSO_AUTH_TOKEN=
+```
+
+### Development Server
+
+```bash
+npm run dev         # http://localhost:3000
+```
+
+### Testing & Verification
+
+```bash
+npx tsc --noEmit              # Type check
+npm run lint                  # ESLint
+npm run test                  # Vitest (unit)
+npm run build                 # Production build
+npm run test:e2e              # Playwright E2E
+npm run test:lighthouse:gate  # Lighthouse performance gate
+```
+
+## Project Structure
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── (app)/              # Authenticated routes (dashboard, dubbing, batch, billing, youtube, uploads, settings)
+│   ├── (marketing)/        # Public pages (landing)
+│   ├── api/                # Route handlers
+│   │   ├── auth/           # Login, session, token sync
+│   │   ├── dashboard/      # mutations (single endpoint), jobs, summary, credit-usage, language-performance
+│   │   ├── perso/          # Perso.ai proxy (spaces, upload, project, queue, progress, download, …)
+│   │   └── youtube/        # upload, caption, stats, analytics, videos
+│   └── layout.tsx
+├── features/               # Domain-grouped features
+│   ├── dubbing/            # 5-step wizard, Zustand store, types
+│   ├── dashboard/          # Charts, tables, summary cards
+│   ├── landing/            # Landing sections
+│   ├── auth/               # OAuth UI
+│   └── billing/            # Credits & plans
+├── lib/
+│   ├── db/                 # libSQL client + queries/{users,jobs,youtube,dashboard}
+│   ├── perso/              # persoFetch wrapper, error mapping, route helpers
+│   ├── youtube/            # Upload, captions, stats, analytics
+│   ├── validators/         # Zod schemas (discriminated-union mutations)
+│   ├── auth/               # Session verification
+│   └── env.ts              # Env parsing
+├── stores/                 # Zustand (auth, notification, theme)
+├── hooks/                  # React Query hooks
+├── components/             # Shared UI, layout, providers
+└── services/               # External API service layer
+```
+
+## Dubbing Workflow
+
+```
+Video input → Language select → Script edit → Processing → Upload
+```
+
+1. **Video input** — paste a YouTube URL or upload a local file. Metadata is registered to a Perso space.
+2. **Language select** — pick the source language (auto-detected) and target languages; toggle lip-sync.
+3. **Script edit** — fine-tune the translated transcript or exclude segments.
+4. **Processing** — kick a Perso job and poll progress in real time.
+5. **Upload** — auto-upload to YouTube with editable title/description/tags/privacy via the upload modal.
+
+## Known Limitations
+
+- YouTube's multi-audio-track API is unavailable — we upload per-language videos as a workaround.
+- Perso `progressReason` values come in both UPPERCASE and PascalCase; always handle both.
+
+## Contributing
+
+1. Fork this repository
+2. Create a feature branch (`git checkout -b feature/awesome`)
+3. Commit (`git commit -m 'feat: add awesome'`)
+4. Push and open a Pull Request
+
+Git flow: `main ← develop ← issue branches`, squash-merge. `main` and `develop` are permanent branches — do not delete.
+
+## Security
+
+**Do not open public issues for vulnerabilities.** Use GitHub Private Vulnerability Reporting. See [.github/SECURITY.md](./.github/SECURITY.md) for details.
+
+## License
+
+This repository is **proprietary**. All rights reserved. No part may be redistributed or reused without prior written permission.
+
+## Acknowledgements
+
+- [Perso.ai](https://perso.ai) — AI dubbing engine
+- [Turso](https://turso.tech) — database
+- [Vercel](https://vercel.com) — deployment platform
+- Sister project [AniVoice](https://github.com/perso-devrel/anivoice) — similar Perso-powered dubbing platform

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,169 @@
+# CreatorDub
+
+[🇰🇷 한국어](./README.md) | [🇺🇸 English](./README.en.md) | [🇯🇵 日本語](./README.ja.md) | [🇨🇳 中文](./README.zh.md)
+
+> **クリエイター向け AI 多言語ダビング & YouTube 自動アップロードプラットフォーム。**
+> 一本の動画をアップロードするだけで、複数言語への AI ダビング、字幕付きの YouTube 自動アップロード、視聴分析までダッシュボードで一気通貫に確認できます。
+
+[Perso.ai](https://developers.perso.ai) API を基盤として動作します。
+
+## 主な機能
+
+- **AI 多言語ダビング** — 5 ステップのウィザードで動画をアップロードすると、元話者のトーンを保ったまま複数言語へ自動ダビングします。
+- **リップシンク** — 翻訳後の音声に合わせて口の動きを調整します（オプション）。
+- **スクリプト編集** — 翻訳結果を文単位で修正し、音声を再生成できます。
+- **YouTube 自動アップロード** — ダビング済み動画をサーバー経由で YouTube Data API v3 に送信し、字幕（SRT）も同時に公開します。
+- **Multi-audio Track 補助** — YouTube のマルチオーディオトラック API が使えない環境でも、言語ごとの動画を体系的に管理できます。
+- **クレジットシステム** — 動画の長さ（分）に基づき、ダビング前に事前チェックし、完了時に消費します。
+- **ダッシュボード & 分析** — 言語別再生数・高評価、月次クレジット使用量、YouTube Analytics 連携を提供します。
+
+## 技術スタック
+
+| 領域 | 技術 |
+| ---- | ---- |
+| フレームワーク | Next.js 16.2.3 (App Router) |
+| ランタイム | React 19, TypeScript 5 |
+| スタイリング | Tailwind CSS v4 |
+| 状態管理 | Zustand 5 |
+| データ取得 | TanStack React Query v5 |
+| バリデーション | Zod v4 |
+| データベース | Turso (libSQL) / `@libsql/client` |
+| ダビングエンジン | Perso.ai API |
+| アップロード / 統計 | YouTube Data API v3 + Analytics API v2 |
+| 認証 | Google OAuth 2.0 + 署名付きセッション Cookie |
+| テスト | Vitest, Playwright, Lighthouse |
+
+> **注意:** 本プロジェクトは Next.js 16 の破壊的変更を前提としています。コードを修正する前に `node_modules/next/dist/docs/` のガイドを必ず参照してください。
+
+## はじめに
+
+### 前提条件
+
+- Node.js 20 以上
+- [Perso.ai](https://developers.perso.ai) API キー
+- Turso データベース
+- OAuth と YouTube Data API を有効化した Google Cloud プロジェクト
+
+### インストール
+
+```bash
+git clone https://github.com/perso-devrel/creatordubbing.git
+cd creatordubbing
+npm install
+```
+
+### 環境変数の設定
+
+`.env.example` をコピーして `.env.local` を作成してください。
+
+```bash
+cp .env.example .env.local
+```
+
+```env
+# Perso.ai
+PERSO_API_KEY=
+PERSO_API_BASE_URL=https://api.perso.ai
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://perso.ai
+
+# Google OAuth
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# セッション Cookie 署名用
+SESSION_SECRET=
+
+# Turso DB
+TURSO_URL=
+TURSO_AUTH_TOKEN=
+```
+
+### 開発サーバー
+
+```bash
+npm run dev         # http://localhost:3000
+```
+
+### テスト & 検証
+
+```bash
+npx tsc --noEmit              # 型チェック
+npm run lint                  # ESLint
+npm run test                  # Vitest (ユニット)
+npm run build                 # 本番ビルド
+npm run test:e2e              # Playwright E2E
+npm run test:lighthouse:gate  # Lighthouse パフォーマンスゲート
+```
+
+## プロジェクト構成
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── (app)/              # 認証が必要なルート (dashboard, dubbing, batch, billing, youtube, uploads, settings)
+│   ├── (marketing)/        # 公開ページ（ランディング等）
+│   ├── api/                # Route Handlers
+│   │   ├── auth/           # ログイン・セッション・トークン同期
+│   │   ├── dashboard/      # mutations（単一エンドポイント）, jobs, summary, credit-usage, language-performance
+│   │   ├── perso/          # Perso.ai プロキシ (spaces, upload, project, queue, progress, download …)
+│   │   └── youtube/        # upload, caption, stats, analytics, videos
+│   └── layout.tsx
+├── features/               # ドメイン別機能
+│   ├── dubbing/            # 5 ステップウィザード、Zustand ストア、型
+│   ├── dashboard/          # チャート・テーブル・サマリーカード
+│   ├── landing/            # ランディングセクション
+│   ├── auth/               # OAuth UI
+│   └── billing/            # クレジット・料金プラン
+├── lib/
+│   ├── db/                 # libSQL クライアント + queries/{users,jobs,youtube,dashboard}
+│   ├── perso/              # persoFetch ラッパー、エラーマッピング、ルートヘルパー
+│   ├── youtube/            # アップロード・字幕・統計・分析
+│   ├── validators/         # Zod スキーマ（discriminated-union 型 mutation）
+│   ├── auth/               # セッション検証
+│   └── env.ts              # 環境変数パース
+├── stores/                 # Zustand (auth, notification, theme)
+├── hooks/                  # React Query フック
+├── components/             # 共通 UI・レイアウト・プロバイダ
+└── services/               # 外部 API サービスレイヤー
+```
+
+## ダビングワークフロー
+
+```
+動画入力 → 言語選択 → スクリプト編集 → 処理 → アップロード
+```
+
+1. **動画入力** — YouTube URL 貼り付けまたはローカルファイルをアップロード。メタデータを Perso space に登録します。
+2. **言語選択** — ソース言語（自動検出）とターゲット言語を複数選択し、リップシンクを切り替えます。
+3. **スクリプト編集** — 翻訳された字幕を文単位で修正、または特定区間を除外します。
+4. **処理** — Perso API でジョブを作成し、リアルタイムに進捗をポーリングします。
+5. **アップロード** — YouTube に自動アップロード（タイトル/説明/タグ/公開設定を編集可能なモーダルを提供）。
+
+## 既知の制約
+
+- YouTube のマルチオーディオトラック API は未対応のため、言語ごとに別動画としてアップロードしています。
+- Perso の `progressReason` は UPPERCASE と PascalCase が混在するため、両方を処理する必要があります。
+
+## コントリビューション
+
+1. リポジトリを Fork
+2. 機能ブランチを作成 (`git checkout -b feature/awesome`)
+3. コミット (`git commit -m 'feat: add awesome'`)
+4. Push して Pull Request を作成
+
+Git フロー: `main ← develop ← issue ブランチ`、squash マージ。`main` と `develop` は永続ブランチで削除禁止です。
+
+## セキュリティ
+
+脆弱性情報を **公開 Issue として投稿しないでください。** GitHub Private Vulnerability Reporting をご利用ください。詳細は [.github/SECURITY.md](./.github/SECURITY.md) を参照してください。
+
+## ライセンス
+
+本リポジトリは **プロプライエタリ**です。すべての権利は著作権者に帰属します。書面による事前許可なく再配布・再利用はできません。
+
+## 謝辞
+
+- [Perso.ai](https://perso.ai) — AI ダビングエンジン
+- [Turso](https://turso.tech) — データベース
+- [Vercel](https://vercel.com) — デプロイプラットフォーム
+- 姉妹プロジェクト [AniVoice](https://github.com/perso-devrel/anivoice) — 同じく Perso ベースのダビングプラットフォーム

--- a/README.md
+++ b/README.md
@@ -1,81 +1,169 @@
 # CreatorDub
 
-AI 기반 영상 더빙 플랫폼. YouTube 영상을 여러 언어로 더빙하고, 더빙 결과를 YouTube에 업로드하며, 시청 분석 데이터를 대시보드에서 확인할 수 있다.
+[🇰🇷 한국어](./README.md) | [🇺🇸 English](./README.en.md) | [🇯🇵 日本語](./README.ja.md) | [🇨🇳 中文](./README.zh.md)
 
-## 스택
+> **YouTube 크리에이터를 위한 AI 다국어 더빙 & 업로드 자동화 플랫폼.**
+> 영상 한 편을 올리면 여러 언어로 더빙하고, 자막과 함께 YouTube에 자동 업로드한 뒤 대시보드에서 시청 분석까지 확인할 수 있습니다.
 
-- **Next.js 16.2.3** (App Router) / React 19 / TypeScript
-- **Tailwind CSS v4** / Zustand / React Query
-- **Turso (libsql)** — DB
-- **Perso.ai API** — 더빙 엔진
-- **YouTube Data API v3** — 업로드, 통계
-- **YouTube Analytics API v2** — 시청 분석
-- **Google OAuth 2.0** — 인증
+[Perso.ai](https://developers.perso.ai) API 기반으로 동작하며, 크리에이터 친화적인 작업 흐름을 제공합니다.
 
-## 환경 변수
+## 주요 기능
 
-`.env.local`에 다음을 설정:
+- **AI 다국어 더빙** — 영상을 5단계 위저드로 업로드하면 원본 화자 톤을 보존한 채 여러 언어로 자동 더빙합니다.
+- **립싱크** — 선택 시 번역된 음성에 맞춰 입 모양을 보정합니다.
+- **스크립트 편집** — 번역 결과를 문장 단위로 수정하고 음성을 재생성할 수 있습니다.
+- **YouTube 자동 업로드** — 더빙된 영상을 서버 경유로 YouTube Data API v3에 업로드하고, 자막(SRT)도 함께 게시합니다.
+- **Multi-audio Track 도우미** — YouTube의 다중 오디오 트랙 미지원 환경에서도 언어별 영상을 체계적으로 관리할 수 있도록 보조합니다.
+- **크레딧 시스템** — 영상 길이(분) 기반으로 크레딧을 사전 검증하고, 완료 시 차감합니다.
+- **대시보드 & 분석** — 언어별 조회수·좋아요, 월별 크레딧 사용, YouTube Analytics 연동 데이터를 제공합니다.
 
+## 기술 스택
+
+| 영역 | 기술 |
+| ---- | ---- |
+| 프레임워크 | Next.js 16.2.3 (App Router) |
+| 런타임 | React 19, TypeScript 5 |
+| 스타일 | Tailwind CSS v4 |
+| 상태 관리 | Zustand 5 |
+| 데이터 페칭 | TanStack React Query v5 |
+| 스키마 검증 | Zod v4 |
+| 데이터베이스 | Turso (libSQL) — `@libsql/client` |
+| 더빙 엔진 | Perso.ai API |
+| 업로드/통계 | YouTube Data API v3 + Analytics API v2 |
+| 인증 | Google OAuth 2.0 + 서버 세션 쿠키 |
+| 테스트 | Vitest, Playwright, Lighthouse |
+
+> **주의:** 이 프로젝트는 Next.js 16의 파괴적 변경(breaking changes)에 기반합니다. 코드 수정 전 반드시 `node_modules/next/dist/docs/` 의 관련 가이드를 참고하세요.
+
+## 시작하기
+
+### 사전 준비
+
+- Node.js 20+
+- [Perso.ai](https://developers.perso.ai) API 키
+- Turso 데이터베이스
+- Google Cloud Console 프로젝트 (OAuth + YouTube Data API 활성화)
+
+### 설치
+
+```bash
+git clone https://github.com/perso-devrel/creatordubbing.git
+cd creatordubbing
+npm install
 ```
+
+### 환경변수 설정
+
+`.env.example` 을 복사하여 `.env.local` 파일을 생성하세요.
+
+```bash
+cp .env.example .env.local
+```
+
+```env
+# Perso.ai
+PERSO_API_KEY=
+PERSO_API_BASE_URL=https://api.perso.ai
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://perso.ai
+
+# Google OAuth
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-NEXT_PUBLIC_PERSO_FILE_BASE_URL=
-PERSO_API_KEY=
-PERSO_API_BASE_URL=
+
+# 세션 (쿠키 서명용)
+SESSION_SECRET=
+
+# Turso DB
 TURSO_URL=
 TURSO_AUTH_TOKEN=
 ```
 
-## 개발 서버
+### 개발 서버
 
 ```bash
-npm install
-npm run dev        # http://localhost:3000
+npm run dev         # http://localhost:3000
 ```
 
-## 테스트
+### 테스트 & 검증
 
 ```bash
 npx tsc --noEmit              # 타입 체크
 npm run lint                  # ESLint
-npm run test                  # Vitest 유닛 테스트
+npm run test                  # Vitest (유닛)
 npm run build                 # 프로덕션 빌드
 npm run test:e2e              # Playwright E2E
 npm run test:lighthouse:gate  # Lighthouse 성능 게이트
 ```
 
-## 디렉토리 구조
+## 프로젝트 구조
 
 ```
 src/
-  app/                    # Next.js App Router
-    (app)/                # 인증 필요 라우트 (dashboard, dubbing, batch, billing, youtube)
-    api/                  # API Route Handlers
-      dashboard/          # 대시보드 데이터 API
-      perso/              # Perso.ai 프록시 API
-      youtube/            # YouTube 업로드/통계/분석 API
-      auth/               # 인증 관련 API
-  features/               # 기능별 컴포넌트
-    dubbing/              # 더빙 워크플로우 (5단계 위저드)
-    dashboard/            # 대시보드 차트 및 요약
-    landing/              # 랜딩 페이지
-    auth/                 # 인증 UI
-    billing/              # 결제/크레딧
-  lib/                    # 서버 유틸
-    db/                   # Turso DB 클라이언트 + 쿼리
-    perso/                # Perso.ai API 헬퍼
-    youtube/              # YouTube API 서버 함수
-    auth/                 # 세션 검증
-    api/                  # 공용 API 응답 헬퍼
-    validators/           # Zod 스키마
-  stores/                 # Zustand 스토어 (auth, notification, theme)
-  hooks/                  # React Query 훅
-  components/             # 공용 UI 컴포넌트
-  proxy.ts                # 인증 미들웨어
+├── app/                    # Next.js App Router
+│   ├── (app)/              # 인증이 필요한 라우트 (dashboard, dubbing, batch, billing, youtube, uploads, settings)
+│   ├── (marketing)/        # 랜딩 등 공개 페이지
+│   ├── api/                # Route Handlers
+│   │   ├── auth/           # 로그인, 세션, 토큰 동기화
+│   │   ├── dashboard/      # mutations(단일 엔드포인트), jobs, summary, credit-usage, language-performance
+│   │   ├── perso/          # Perso.ai 프록시 (spaces, upload, project, queue, progress, download …)
+│   │   └── youtube/        # upload, caption, stats, analytics, videos
+│   └── layout.tsx
+├── features/               # 도메인별 기능 그룹
+│   ├── dubbing/            # 5단계 위저드, Zustand 스토어, 타입
+│   ├── dashboard/          # 차트·테이블·요약 카드
+│   ├── landing/            # 랜딩 섹션
+│   ├── auth/               # OAuth UI
+│   └── billing/            # 크레딧·요금제
+├── lib/
+│   ├── db/                 # libSQL 클라이언트 + queries/{users,jobs,youtube,dashboard}
+│   ├── perso/              # persoFetch 래퍼, 에러 매핑, 라우트 헬퍼
+│   ├── youtube/            # 업로드, 자막, 통계, 분석
+│   ├── validators/         # Zod 스키마 (discriminated union 기반 mutation)
+│   ├── auth/               # 세션 검증
+│   └── env.ts              # 환경변수 파싱
+├── stores/                 # Zustand (auth, notification, theme)
+├── hooks/                  # React Query 훅
+├── components/             # 공용 UI + 레이아웃 + 프로바이더
+└── services/               # 외부 API 서비스 레이어
 ```
+
+## 더빙 워크플로우
+
+```
+영상 입력 → 언어 선택 → 스크립트 편집 → 처리 → 업로드
+```
+
+1. **영상 입력** — YouTube URL 또는 로컬 업로드. 메타데이터를 Perso 공간(space)에 등록.
+2. **언어 선택** — 원본 언어(자동 감지)와 대상 언어 다중 선택, 립싱크 ON/OFF.
+3. **스크립트 편집** — 번역된 자막을 문장 단위로 수정하거나 특정 구간을 제외 처리.
+4. **처리(Processing)** — Perso API 로 더빙 작업을 생성하고 진행률을 폴링합니다.
+5. **업로드** — 완료된 결과를 YouTube 에 자동 업로드 (제목/설명/태그/공개설정 편집 모달 제공).
 
 ## 알려진 제약
 
-- YouTube 다중 오디오 트랙은 API 미지원 — 언어별 별도 영상 업로드 방식 사용
-- Google OAuth implicit flow 사용 중 — authorization code flow 전환 예정
-- `creatordub_session` 쿠키 하드닝 필요
+- YouTube 다중 오디오 트랙 API는 미지원 — 언어별 별도 영상 업로드 방식으로 우회합니다.
+- Perso `progressReason` 값은 UPPERCASE / PascalCase 가 혼재하므로 두 형태 모두 처리해야 합니다.
+
+## 기여하기
+
+1. 저장소 Fork
+2. 기능 브랜치 생성 (`git checkout -b feature/awesome`)
+3. 커밋 (`git commit -m 'feat: add awesome'`)
+4. Push & Pull Request
+
+Git Flow: `main ← develop ← 이슈 브랜치`, squash 머지. `main`/`develop` 은 영구 브랜치이며 삭제 금지입니다.
+
+## 보안
+
+보안 취약점은 **공개 이슈로 보고하지 마세요.** GitHub Private Vulnerability Reporting 을 사용해 주세요. 자세한 절차는 [.github/SECURITY.md](./.github/SECURITY.md) 를 참고하세요.
+
+## 라이선스
+
+이 저장소는 비공개(Proprietary) 입니다. 모든 권리를 저작권자가 보유합니다. 별도 서면 허가 없이 재배포·재사용할 수 없습니다.
+
+## 감사의 말
+
+- [Perso.ai](https://perso.ai) — AI 더빙 엔진
+- [Turso](https://turso.tech) — 데이터베이스
+- [Vercel](https://vercel.com) — 배포 플랫폼
+- 자매 프로젝트 [AniVoice](https://github.com/perso-devrel/anivoice) — 유사한 Perso 기반 더빙 플랫폼

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,169 @@
+# CreatorDub
+
+[🇰🇷 한국어](./README.md) | [🇺🇸 English](./README.en.md) | [🇯🇵 日本語](./README.ja.md) | [🇨🇳 中文](./README.zh.md)
+
+> **面向 YouTube 创作者的 AI 多语言配音与上传自动化平台。**
+> 上传一段视频，CreatorDub 会将其配音为多种语言，连同字幕一起自动发布到 YouTube，并在同一面板中呈现观看数据分析。
+
+基于 [Perso.ai](https://developers.perso.ai) API 构建。
+
+## 核心功能
+
+- **AI 多语言配音** — 通过 5 步向导上传视频，在保留原始说话人音色的前提下自动配音为多种语言。
+- **口型同步** — 可选启用，使嘴型与翻译后的音频匹配。
+- **脚本编辑** — 按句修改译文并重新生成语音。
+- **YouTube 自动上传** — 服务器侧将配音后的视频上传到 YouTube Data API v3，并附带 SRT 字幕发布。
+- **多音轨助手** — 在 YouTube 不支持多音轨 API 的情况下，按语言分别管理视频。
+- **积分系统** — 按视频分钟数预先校验积分，完成时扣减。
+- **数据面板与分析** — 按语言查看播放量 / 点赞，月度积分消耗，集成 YouTube Analytics。
+
+## 技术栈
+
+| 领域 | 技术 |
+| ---- | ---- |
+| 框架 | Next.js 16.2.3 (App Router) |
+| 运行时 | React 19、TypeScript 5 |
+| 样式 | Tailwind CSS v4 |
+| 状态管理 | Zustand 5 |
+| 数据获取 | TanStack React Query v5 |
+| 校验 | Zod v4 |
+| 数据库 | Turso (libSQL) / `@libsql/client` |
+| 配音引擎 | Perso.ai API |
+| 上传 / 统计 | YouTube Data API v3 + Analytics API v2 |
+| 认证 | Google OAuth 2.0 + 签名会话 Cookie |
+| 测试 | Vitest、Playwright、Lighthouse |
+
+> **注意：** 本项目基于 Next.js 16 的破坏性变更。修改代码前请务必阅读 `node_modules/next/dist/docs/` 中的相关指南。
+
+## 快速开始
+
+### 前置条件
+
+- Node.js 20+
+- [Perso.ai](https://developers.perso.ai) API 密钥
+- Turso 数据库
+- 已启用 OAuth 与 YouTube Data API 的 Google Cloud 项目
+
+### 安装
+
+```bash
+git clone https://github.com/perso-devrel/creatordubbing.git
+cd creatordubbing
+npm install
+```
+
+### 环境变量
+
+复制 `.env.example` 为 `.env.local`：
+
+```bash
+cp .env.example .env.local
+```
+
+```env
+# Perso.ai
+PERSO_API_KEY=
+PERSO_API_BASE_URL=https://api.perso.ai
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://perso.ai
+
+# Google OAuth
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# 会话 Cookie 签名密钥
+SESSION_SECRET=
+
+# Turso DB
+TURSO_URL=
+TURSO_AUTH_TOKEN=
+```
+
+### 开发服务器
+
+```bash
+npm run dev         # http://localhost:3000
+```
+
+### 测试与验证
+
+```bash
+npx tsc --noEmit              # 类型检查
+npm run lint                  # ESLint
+npm run test                  # Vitest（单元）
+npm run build                 # 生产构建
+npm run test:e2e              # Playwright E2E
+npm run test:lighthouse:gate  # Lighthouse 性能门禁
+```
+
+## 项目结构
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── (app)/              # 需认证路由 (dashboard, dubbing, batch, billing, youtube, uploads, settings)
+│   ├── (marketing)/        # 公开页面（落地页等）
+│   ├── api/                # Route Handlers
+│   │   ├── auth/           # 登录、会话、令牌同步
+│   │   ├── dashboard/      # mutations（单一端点）、jobs、summary、credit-usage、language-performance
+│   │   ├── perso/          # Perso.ai 代理 (spaces、upload、project、queue、progress、download …)
+│   │   └── youtube/        # upload、caption、stats、analytics、videos
+│   └── layout.tsx
+├── features/               # 按领域组织的功能模块
+│   ├── dubbing/            # 5 步向导、Zustand store、类型定义
+│   ├── dashboard/          # 图表、表格、概览卡片
+│   ├── landing/            # 落地页区块
+│   ├── auth/               # OAuth UI
+│   └── billing/            # 积分与套餐
+├── lib/
+│   ├── db/                 # libSQL 客户端 + queries/{users,jobs,youtube,dashboard}
+│   ├── perso/              # persoFetch 封装、错误映射、路由辅助
+│   ├── youtube/            # 上传、字幕、统计、分析
+│   ├── validators/         # Zod schema（discriminated-union mutation）
+│   ├── auth/               # 会话校验
+│   └── env.ts              # 环境变量解析
+├── stores/                 # Zustand (auth、notification、theme)
+├── hooks/                  # React Query hooks
+├── components/             # 公共 UI、布局、Providers
+└── services/               # 外部 API 服务层
+```
+
+## 配音流程
+
+```
+视频输入 → 语言选择 → 脚本编辑 → 处理 → 上传
+```
+
+1. **视频输入** — 粘贴 YouTube 链接或上传本地文件。元数据注册到 Perso space。
+2. **语言选择** — 选择源语言（自动检测）与多个目标语言，切换口型同步开关。
+3. **脚本编辑** — 按句修改译文，或排除指定片段。
+4. **处理** — 调用 Perso API 创建作业并实时轮询进度。
+5. **上传** — 通过可编辑标题 / 描述 / 标签 / 公开状态的模态框自动上传到 YouTube。
+
+## 已知限制
+
+- YouTube 多音轨 API 不可用 — 通过按语言分别上传视频来规避。
+- Perso 的 `progressReason` 同时存在 UPPERCASE 与 PascalCase 两种写法，需同时处理。
+
+## 贡献指南
+
+1. Fork 本仓库
+2. 创建功能分支 (`git checkout -b feature/awesome`)
+3. 提交 (`git commit -m 'feat: add awesome'`)
+4. Push 并发起 Pull Request
+
+Git 流程：`main ← develop ← issue 分支`，squash 合并。`main` 与 `develop` 为长期分支，禁止删除。
+
+## 安全
+
+**请勿在公开 Issue 中报告漏洞。** 请使用 GitHub Private Vulnerability Reporting。详见 [.github/SECURITY.md](./.github/SECURITY.md)。
+
+## 许可证
+
+本仓库为 **专有 (Proprietary)** 项目，保留一切权利。未经书面授权，禁止再分发或再利用。
+
+## 致谢
+
+- [Perso.ai](https://perso.ai) — AI 配音引擎
+- [Turso](https://turso.tech) — 数据库
+- [Vercel](https://vercel.com) — 部署平台
+- 姊妹项目 [AniVoice](https://github.com/perso-devrel/anivoice) — 同样基于 Perso 的配音平台

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,101 @@
+# Security Audit Report — CreatorDub
+
+- **Scan date**: 2026-04-16
+- **Tool**: `npm audit` (auditReportVersion 2)
+- **Scope**: root `package.json` dependency tree (prod + dev + optional)
+- **Command**: `npm audit --json`
+
+---
+
+## 요약 (Korean Summary)
+
+- **결과**: 현재 의존성 트리에서 알려진 취약점이 **0건** 확인되었습니다.
+- **스캔 범위**: 총 **809개** 패키지 (production 94 / dev 670 / optional 111 / peer 0).
+- **심각도별 건수**: critical 0 · high 0 · moderate 0 · low 0 · info 0.
+- **조치 필요 사항**: 현 시점 즉시 조치 필요한 CVE는 없습니다. Dependabot 일일 스캔과 CI 의 `npm audit --audit-level=high` 게이트로 지속 감시합니다.
+- **권고**:
+  1. `.github/dependabot.yml` 의 일일 업데이트를 활성 상태로 유지합니다.
+  2. PR CI 에서 `npm-audit.yml` 워크플로가 실패하면 병합 전 반드시 해결합니다.
+  3. 매주 월요일 CodeQL 스케줄 스캔 결과를 Security 탭에서 확인합니다.
+  4. 새로운 의존성 추가 시 로컬에서 `npm audit` 재확인.
+  5. 다음 정기 점검 예정일: **2026-05-16** (월 1회 권장).
+
+---
+
+## English Details
+
+### Vulnerability counts
+
+| Severity | Count |
+| -------- | ----- |
+| critical | 0 |
+| high     | 0 |
+| moderate | 0 |
+| low      | 0 |
+| info     | 0 |
+| **total**| **0** |
+
+### Dependency inventory
+
+| Type     | Count |
+| -------- | ----- |
+| prod     | 94 |
+| dev      | 670 |
+| optional | 111 |
+| peer     | 0 |
+| peerOptional | 0 |
+| **total** | **809** |
+
+### High / Critical findings
+
+None. No packages in the dependency tree currently match a known GHSA advisory at HIGH or CRITICAL severity.
+
+Because there are no HIGH or CRITICAL entries, the per-package table (package name, vulnerable version, CVE ID, fix version, affected path) is intentionally empty. Once `npm audit` reports such entries, each will be recorded here with:
+
+- Package name
+- Vulnerable version range
+- CVE / GHSA identifier
+- Patched version
+- Affected dependency path (root → vulnerable package)
+
+### Raw audit output
+
+```json
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 94,
+      "dev": 670,
+      "optional": 111,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 809
+    }
+  }
+}
+```
+
+### Recommended actions
+
+1. **Keep Dependabot daily updates enabled** for the `npm` ecosystem (see `.github/dependabot.yml`). Minor + patch are grouped; majors land as individual PRs for isolated review.
+2. **Enforce `npm audit --audit-level=high`** on every PR via the `npm-audit.yml` workflow — CI must stay green before merge.
+3. **Review weekly CodeQL runs** (`security-extended` + `security-and-quality` queries) under the Security tab every Monday.
+4. **Re-run `npm audit` locally** before opening PRs that touch `package.json` or `package-lock.json`.
+5. **Monthly re-scan**: next scheduled review is **2026-05-16**. Update this document with the new date and any findings.
+6. **Supply-chain hygiene**: prefer packages with active maintenance and provenance-signed releases (`npm --provenance`) when possible.
+
+### Methodology notes
+
+- `npm audit` consults the npm advisory database (GHSA-backed) and reports both direct and transitive vulnerabilities.
+- Results reflect the state of `package-lock.json` at scan time and may change as upstream advisories are published.
+- Absence of findings does **not** imply absence of vulnerabilities — only that none are currently known to the public advisory database.

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,352 @@
+# CreatorDub — Reproducible Build Prompt
+
+> **Purpose.** Hand this file to a capable coding assistant (Claude Opus, GPT-4, etc.) and it should be able to reproduce the CreatorDub project from scratch. Every section is intentionally concrete — follow conventions literally rather than improvising.
+
+---
+
+## 1. Project Vision
+
+**CreatorDub** is an AI multilingual dubbing and YouTube upload automation platform aimed at YouTube creators who want to reach non-native audiences without running a manual translation pipeline.
+
+A creator signs in with Google, pastes a YouTube URL (or uploads a video), picks target languages, optionally edits the translated script, and CreatorDub:
+
+1. Dubs the video into every selected language via [Perso.ai](https://developers.perso.ai).
+2. Optionally applies lip-sync to match the translated audio.
+3. Uploads each dubbed video (plus SRT captions) to YouTube via the Data API v3.
+4. Tracks credits (per-minute, DB-backed) and surfaces per-language analytics in a dashboard.
+
+**Primary users.** Solo / small-team YouTube creators producing long-form or Short videos who want localised uploads.
+
+**Success criteria.**
+
+- A creator can complete the 5-step dubbing wizard end-to-end and see the resulting video live on YouTube without touching the YouTube UI.
+- Credits pre-check prevents over-dubbing; completed jobs deduct minutes atomically.
+- Dashboard charts populate from the same Turso DB that stores job and upload state.
+- Type check (`npx tsc --noEmit`), lint, unit tests, and Playwright E2E all stay green.
+
+---
+
+## 2. Tech Stack
+
+| Area | Choice | Notes |
+| ---- | ------ | ----- |
+| Framework | **Next.js 16.2.3** (App Router) | Breaking changes vs Next 15. Always read the guides in `node_modules/next/dist/docs/` before writing code. |
+| Runtime | React 19 (stable) | Server Components by default; `'use client'` only when needed. |
+| Language | TypeScript 5 | `strict` mode. |
+| Styling | Tailwind CSS v4 (`@tailwindcss/postcss`) | No CSS-in-JS. |
+| State (client) | Zustand 5 | `authStore`, `notificationStore`, `themeStore`, plus feature-local `dubbingStore`. |
+| Data fetching | TanStack React Query v5 | Dashboard, YouTube hooks. |
+| Validation | Zod v4 | Every API mutation goes through a discriminated union. |
+| DB | **Turso (libSQL)** via `@libsql/client@0.17.x` | `db.execute()` for single statements, `db.batch()` for atomic multi-statement. |
+| Dubbing engine | **Perso.ai API** | All requests proxied server-side through `src/lib/perso/client.ts` (injects `XP-API-KEY`). |
+| YouTube | **YouTube Data API v3** + Analytics API v2 | Upload, caption, stats, analytics. |
+| Auth | Google OAuth 2.0 | Signed session cookie (`creatordub_session`), `SESSION_SECRET`. |
+| Testing | Vitest (unit) + Playwright (E2E) + Lighthouse gate | See `npm run` scripts. |
+| Deployment | Vercel | `vercel.json` at root. |
+
+No classes. Plain functions + hooks. No Redux / MobX. No Prisma / Drizzle — raw libSQL queries in `src/lib/db/queries/`.
+
+---
+
+## 3. Architecture
+
+```
+src/
+├── app/                          Next.js App Router — pages + API routes
+│   ├── (app)/                    Route group: pages that require auth
+│   │   ├── dashboard/            Overview charts
+│   │   ├── dubbing/              5-step wizard entry
+│   │   ├── batch/                Batch queue view
+│   │   ├── billing/              Credits & plans
+│   │   ├── youtube/              YouTube upload manager
+│   │   ├── uploads/              Past dubbed outputs
+│   │   ├── settings/             User settings
+│   │   └── layout.tsx            Shared authed layout
+│   ├── (marketing)/              Public pages (landing)
+│   ├── api/
+│   │   ├── auth/                 Google sign-in, session sync, token refresh
+│   │   ├── dashboard/
+│   │   │   ├── mutations/        SINGLE endpoint for all DB writes
+│   │   │   ├── jobs/             GET list of user jobs
+│   │   │   ├── summary/          GET dashboard summary row
+│   │   │   ├── credit-usage/     GET monthly credit usage
+│   │   │   ├── language-performance/ GET aggregated YT perf by language
+│   │   │   └── completed-languages/  GET completed jobs ready to upload
+│   │   ├── perso/                Perso.ai proxy routes
+│   │   │   ├── spaces/           Create / list spaces
+│   │   │   ├── upload/           Upload media
+│   │   │   ├── project/          Kick a dubbing project
+│   │   │   ├── queue/            Submit to queue
+│   │   │   ├── progress/         Poll progress
+│   │   │   ├── download/         Download result
+│   │   │   ├── script/           Script CRUD
+│   │   │   ├── translate/        Translation
+│   │   │   ├── languages/        Supported languages list
+│   │   │   ├── lipsync/          Lip-sync submit
+│   │   │   ├── projects/         List projects
+│   │   │   ├── external/         External URL registration
+│   │   │   └── validate/         Validation helpers
+│   │   └── youtube/
+│   │       ├── upload/           Server-side upload (fetches from Perso CDN → YouTube)
+│   │       ├── caption/          Attach SRT
+│   │       ├── stats/            Views / likes / comments refresh
+│   │       ├── analytics/        YouTube Analytics API v2
+│   │       └── videos/           List user's uploads
+│   ├── global-error.tsx
+│   ├── layout.tsx
+│   └── not-found.tsx
+├── features/                     Domain-grouped UI + logic
+│   ├── dubbing/
+│   │   ├── components/
+│   │   │   ├── DubbingWizard.tsx
+│   │   │   ├── ScriptEditor.tsx
+│   │   │   └── steps/
+│   │   │       ├── VideoInputStep.tsx
+│   │   │       ├── LanguageSelectStep.tsx
+│   │   │       ├── TranslationEditStep.tsx
+│   │   │       ├── ProcessingStep.tsx
+│   │   │       └── UploadStep.tsx
+│   │   ├── hooks/
+│   │   ├── store/dubbingStore.ts  Zustand (wizard state)
+│   │   └── types/
+│   ├── dashboard/                Charts, tables, summary cards
+│   ├── landing/                  Public landing sections
+│   ├── auth/                     OAuth UI
+│   └── billing/                  Credit & plan UI
+├── lib/
+│   ├── db/
+│   │   ├── client.ts             getDb() — libSQL client singleton
+│   │   └── queries/
+│   │       ├── users.ts
+│   │       ├── jobs.ts
+│   │       ├── youtube.ts
+│   │       ├── dashboard.ts
+│   │       └── index.ts
+│   ├── perso/
+│   │   ├── client.ts             persoFetch wrapper (injects XP-API-KEY, strips envelope)
+│   │   ├── errors.ts             PersoError + mapPersoError
+│   │   ├── route-helpers.ts      Request/response shared helpers
+│   │   └── types.ts
+│   ├── youtube/
+│   │   ├── server.ts             Server-side YT client
+│   │   ├── upload.ts             Upload helper
+│   │   ├── stats.ts              Stats refresh
+│   │   ├── analytics.ts          Analytics API
+│   │   └── route-helpers.ts
+│   ├── validators/               Zod schemas (one file per domain)
+│   ├── api/                      Shared API response helpers
+│   ├── api-client.ts             Client-side fetch wrapper
+│   ├── auth/                     Session verification (server only)
+│   ├── env.ts                    Typed env accessor (getServerEnv)
+│   ├── google-auth.ts            Google token verify / refresh
+│   └── logger.ts                 Structured logger
+├── stores/
+│   ├── authStore.ts              Current user, tokens, sign-out
+│   ├── notificationStore.ts      Toast queue
+│   └── themeStore.ts             Light/dark theme
+├── hooks/
+│   ├── useDashboardData.ts       React Query hook
+│   └── useYouTubeData.ts
+├── components/
+│   ├── ui/                       Reusable primitives — Button, Card, Modal, Progress, Badge, Tabs, Toggle, Tooltip, Input, Select
+│   ├── layout/                   Header, Sidebar, Shell
+│   ├── feedback/                 Toast, error boundary helpers
+│   ├── shared/
+│   └── providers/                React Query provider, theme provider
+├── services/                     External-API service layer
+└── utils/                        Pure utility helpers
+
+middleware.ts                     Next.js middleware — auth gate for (app) routes
+next.config.ts                    Next.js config (bundle analyzer, headers)
+vercel.json                       Vercel deployment config
+```
+
+---
+
+## 4. Core Flows
+
+### 4.1 Dubbing Wizard (5 steps)
+
+Managed by `src/features/dubbing/store/dubbingStore.ts` (Zustand). `isSubmitted` guard persists across remounts.
+
+1. **VideoInputStep** — YouTube URL OR local upload. Creates a Perso `space` and registers media, storing `spaceSeq` + `mediaSeq` in the store.
+2. **LanguageSelectStep** — source language auto-detected; user picks target languages and toggles lip-sync.
+3. **TranslationEditStep** — fetch/edit per-language segments; allows excluding segments.
+4. **ProcessingStep** — for each target language: create a Perso project → submit queue → poll `/progress`. Writes `dubbing_jobs` row and one `job_languages` row per language via the `mutations` endpoint.
+5. **UploadStep** — lists completed languages; opens a YouTube upload modal (title / description / tags / privacy editable) and invokes `/api/youtube/upload`.
+
+### 4.2 Perso Integration
+
+- All Perso calls go through `src/lib/perso/client.ts` on the server. The client injects `XP-API-KEY`, normalises the `{ result: ... }` envelope, and throws `PersoError(code, message, status)`.
+- Browser code calls our `/api/perso/*` proxy routes — never Perso directly.
+- Lifecycle: `create space` → `upload media` (or register external URL) → `create project` → `submit queue` → `poll progress` → `download`.
+
+### 4.3 YouTube Upload (CORS workaround)
+
+The browser cannot fetch Perso CDN files and POST them to YouTube directly (CORS). Instead:
+
+```
+Browser → POST /api/youtube/upload { jobLanguageId, title, description, ... }
+   Server → fetch(persoCdnUrl)          // server-side, no CORS
+   Server → YouTube Data API v3 upload  // resumable or multipart
+   Server → write youtube_uploads + update job_languages.youtube_video_id
+```
+
+Captions (SRT) are attached with a follow-up `/api/youtube/caption` call.
+
+### 4.4 Credits
+
+- `users.credits_remaining` stored in minutes.
+- Pre-check before starting a dubbing job.
+- `deductUserMinutes` mutation on job completion; `addCredits` for purchases.
+- All credit movements go through the `/api/dashboard/mutations` endpoint under the `deductUserMinutes` / `addCredits` discriminated-union variants.
+
+---
+
+## 5. Database Schema (Turso / libSQL)
+
+Inferred from `src/lib/db/queries/*.ts`. All timestamps use SQLite `datetime('now')`.
+
+### `users`
+
+| Column | Notes |
+| ------ | ----- |
+| `id` | Primary key (Google user ID) |
+| `email` | |
+| `display_name` | nullable |
+| `photo_url` | nullable |
+| `google_access_token` | nullable |
+| `google_refresh_token` | nullable |
+| `token_expires_at` | ISO timestamp, nullable |
+| `credits_remaining` | integer (minutes) |
+| `updated_at` | `datetime('now')` on upsert/update |
+
+Operations: `upsertUser`, `getUser`, `getUserTokens`, `updateUserTokens`, `updateUserCredits`, `deductUserMinutes` (with `MAX(0, …)`), `addUserCredits`.
+
+### `dubbing_jobs`
+
+| Column | Notes |
+| ------ | ----- |
+| `id` | autoincrement |
+| `user_id` | FK → users.id |
+| `video_title` | |
+| `video_duration_ms` | integer |
+| `video_thumbnail` | |
+| `source_language` | |
+| `media_seq` | Perso media ID |
+| `space_seq` | Perso space ID |
+| `lip_sync_enabled` | 0/1 |
+| `is_short` | 0/1 |
+| `status` | `'processing'`, `'completed'`, etc. |
+| `created_at`, `updated_at` | |
+
+### `job_languages` (one row per target language on a job)
+
+| Column | Notes |
+| ------ | ----- |
+| `id` | autoincrement |
+| `job_id` | FK → dubbing_jobs.id |
+| `language_code` | e.g. `'ja'`, `'en'` |
+| `project_seq` | Perso project ID |
+| `status` | `'processing' | 'completed' | 'failed'` |
+| `progress` | 0–100 |
+| `progress_reason` | free text from Perso |
+| `dubbed_video_url` | nullable |
+| `audio_url` | nullable |
+| `srt_url` | nullable |
+| `youtube_video_id` | nullable (set after YT upload) |
+| `youtube_upload_status` | e.g. `'uploaded'` |
+
+### `youtube_uploads`
+
+| Column | Notes |
+| ------ | ----- |
+| `id` | autoincrement |
+| `user_id` | FK → users.id |
+| `job_language_id` | FK → job_languages.id (nullable) |
+| `youtube_video_id` | |
+| `title` | |
+| `language_code` | |
+| `privacy_status` | `'private' | 'unlisted' | 'public'` |
+| `is_short` | 0/1 |
+| `view_count`, `like_count`, `comment_count` | integers |
+| `last_stats_fetch` | ISO timestamp |
+| `created_at` | |
+
+---
+
+## 6. Critical Conventions (MUST follow)
+
+1. **Atomic writes use `db.batch()`.** Single statements use `db.execute()`. Any multi-statement mutation (e.g. delete job + delete languages) must be a single batch — see `deleteDubbingJob` in `queries/jobs.ts`.
+2. **Mutations funnel through a single endpoint.** Client code never calls per-table mutation routes. It POSTs `{ type, payload }` to `/api/dashboard/mutations`, which validates via `mutationActionSchema` (Zod discriminated union on `type`) and dispatches.
+3. **Ownership verification.** `getUserIdFromAction` / `getJobIdFromAction` in `src/lib/validators/dashboard.ts` tell the mutations route whether to verify ownership directly or query the DB via `verifyJobOwnership()`.
+4. **Server-only modules use `import 'server-only'`.** All files in `src/lib/db/queries/`, `src/lib/perso/client.ts`, and session helpers must include it at the top. Do not import them from client components.
+5. **`'use client'` is opt-in.** Server Components by default. Only mark a file client when it uses hooks, browser APIs, Zustand, or event handlers.
+6. **No classes.** Only functions and hooks. Don't introduce OO.
+7. **Perso envelope.** Responses from Perso look like `{ result: ... }`. `persoFetch` strips this — consumers see the inner payload directly.
+8. **Perso `progressReason` case.** Values arrive as either UPPERCASE (`'COMPLETED'`, `'FAILED'`) or PascalCase (`'Completed'`, `'Failed'`). Always match both — e.g. `if (reason === 'COMPLETED' || reason === 'Completed')`. This is a real gotcha from production logs.
+9. **Modal keyboard handling gotcha.** `src/components/ui/Modal.tsx` uses `useRef` for `handleKeyDown` instead of the handler itself in deps. Inlining would cause focus loss when the handler's identity changes on each render. Keep the `useRef` pattern.
+10. **Zod schema per domain.** `src/lib/validators/{auth,dashboard,dubbing,perso,youtube}.ts`. Every route handler validates query/body against a schema before touching `queries/`.
+11. **YouTube uploads run server-side.** Never let the browser hit `upload.youtube.googleapis.com` directly — CORS fails. Proxy through `/api/youtube/upload`.
+12. **Session cookie is `creatordub_session`.** Signed with `SESSION_SECRET`. `middleware.ts` gates `(app)` routes.
+13. **OAuth tokens are stored per user.** `google_access_token`, `google_refresh_token`, `token_expires_at` on `users`. Refresh via `src/lib/google-auth.ts` before expiry.
+14. **Next.js 16 specifics.** Read `node_modules/next/dist/docs/` before touching routing, caching, or metadata — several APIs moved or changed semantics vs Next 15.
+
+---
+
+## 7. Environment Variables
+
+Copy `.env.example` to `.env.local`. Every variable is required.
+
+| Variable | Scope | Purpose |
+| -------- | ----- | ------- |
+| `PERSO_API_KEY` | server | Injected as `XP-API-KEY` on Perso requests. |
+| `PERSO_API_BASE_URL` | server | Usually `https://api.perso.ai`. |
+| `NEXT_PUBLIC_PERSO_FILE_BASE_URL` | client | Base URL for Perso-hosted files (e.g. `https://perso.ai`). |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | client | Google OAuth client ID. |
+| `GOOGLE_CLIENT_SECRET` | server | Google OAuth client secret. |
+| `SESSION_SECRET` | server | Signs `creatordub_session` cookie. Rotate if compromised. |
+| `TURSO_URL` | server | libSQL URL — `libsql://<db>.turso.io`. |
+| `TURSO_AUTH_TOKEN` | server | libSQL auth token. |
+
+`getServerEnv()` in `src/lib/env.ts` validates these at import time on the server.
+
+---
+
+## 8. Build Verification Commands
+
+Run these before every PR merge. All must pass.
+
+```bash
+npx tsc --noEmit              # TypeScript — zero errors
+npm run lint                  # ESLint (eslint-config-next)
+npm run test                  # Vitest unit tests
+npm run build                 # Production build must succeed
+npm run test:e2e              # Playwright E2E
+npm run test:lighthouse:gate  # Performance gate (parse-a11y-details.mjs, etc.)
+npm run dev                   # Manual smoke at http://localhost:3000
+```
+
+---
+
+## 9. Reference
+
+- **Sister project:** https://github.com/perso-devrel/anivoice — same Perso-powered dubbing architecture, slightly different domain (anime) and stack (Vite + Firebase). Patterns for Perso proxying and space/media/project lifecycle are shared; crib liberally when in doubt.
+- **Next.js 16 docs:** `node_modules/next/dist/docs/` — the source of truth; do not trust pre-Next-16 memory.
+- **Perso.ai developer portal:** https://developers.perso.ai
+- **Security policy:** `.github/SECURITY.md` — private vulnerability reporting only.
+- **Git flow:** `main ← develop ← issue branch`. Squash merge. `main` and `develop` are permanent; never delete.
+
+---
+
+## 10. When in Doubt
+
+- Read the actual source before writing — the codebase is the spec.
+- If you see a deprecation notice from Next.js 16 while editing, heed it.
+- Prefer editing existing files to creating new ones.
+- Never fabricate env vars, table columns, or API routes. Grep first.
+- Put new mutations under `mutationActionSchema`; don't add parallel endpoints.
+- Put new server-only code under `src/lib/**` with `import 'server-only'` at the top.
+- For every UI piece, check `src/components/ui/` first for a reusable primitive.
+
+This document is the contract. Follow it literally and the result will be a working CreatorDub.


### PR DESCRIPTION
## Summary
보안 인프라 + 다국어 문서 일괄 통합.

- 보안: SECURITY.md, Dependabot, CodeQL, npm-audit CI, main 브랜치 보호, CVE 스캔 0건 (PR #59)
- 문서: KR/EN/JA/ZH 4개국어 README + prompt.md (PR #60)

## Merge 전략
- merge commit 사용 (squash 금지) — develop/main 공통 ancestry 유지

## 참조
- 이슈: #57 (security), #58 (docs)
- develop PR: #59, #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)