### PR TITLE
fix(ci): Dependabot 중복 제거 + CodeQL 매트릭스/v4 업그레이드

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Application dependencies (npm)
+  # npm dependencies — single entry (dependabot rejects overlapping ecosystem+directory+target-branch)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -17,43 +17,19 @@ updates:
       prefix-development: "chore(deps-dev)"
       include: "scope"
     groups:
+      # Group minor+patch version updates together; major updates ship as individual PRs
       npm-minor-and-patch:
         applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
+      # Security updates are grouped across all severities for faster rollout
       npm-security:
         applies-to: security-updates
         update-types:
           - "minor"
           - "patch"
           - "major"
-    ignore:
-      # Major updates handled as individual PRs, never grouped
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-
-  # Major-version updates (npm) — opened as separate, non-grouped PRs
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "Asia/Seoul"
-    target-branch: "develop"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "security"
-      - "major-update"
-    commit-message:
-      prefix: "chore(deps-major)"
-      include: "scope"
-    allow:
-      - dependency-type: "direct"
-    # Only major updates here; grouped config above ignores majors
-    versioning-strategy: "increase"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,21 +31,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # CodeQL analyzes JS + TS in a single pass via 'javascript-typescript'
         language:
-          - javascript
-          - typescript
+          - javascript-typescript
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload audit artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-audit-report
           path: npm-audit.json


### PR DESCRIPTION
## Summary
CI 설정에서 발생한 3가지 경고/오류 수정.

- **Dependabot**: 같은 (npm, /, develop) 조합 엔트리 2개가 있어 `overlapping directories` 에러 → 단일 엔트리로 통합
- **CodeQL matrix**: `javascript` + `typescript` 두 항목이 중복 분석을 유발 → 단일 `javascript-typescript` 로 교체
- **Action 버전**: Node 20 runtime deprecation + CodeQL Action v3 deprecation
  - `actions/checkout@v4` → `@v5`
  - `actions/setup-node@v4` → `@v5`
  - `actions/upload-artifact@v4` → `@v5`
  - `github/codeql-action/init@v3` → `@v4`
  - `github/codeql-action/analyze@v3` → `@v4`

## Test plan
- [ ] 머지 후 CodeQL 다음 실행이 단일 job(`javascript-typescript`)으로 돌고 경고 없음
- [ ] Dependabot 설정 파싱 에러 없음 (Insights > Dependency graph > Dependabot)
- [ ] npm-audit workflow 정상 수행

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)