### PR TITLE
release: develop → main — CI 설정 수정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Application dependencies (npm)
+  # npm dependencies — single entry (dependabot rejects overlapping ecosystem+directory+target-branch)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -17,43 +17,19 @@ updates:
       prefix-development: "chore(deps-dev)"
       include: "scope"
     groups:
+      # Group minor+patch version updates together; major updates ship as individual PRs
       npm-minor-and-patch:
         applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
+      # Security updates are grouped across all severities for faster rollout
       npm-security:
         applies-to: security-updates
         update-types:
           - "minor"
           - "patch"
           - "major"
-    ignore:
-      # Major updates handled as individual PRs, never grouped
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-
-  # Major-version updates (npm) — opened as separate, non-grouped PRs
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "Asia/Seoul"
-    target-branch: "develop"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "security"
-      - "major-update"
-    commit-message:
-      prefix: "chore(deps-major)"
-      include: "scope"
-    allow:
-      - dependency-type: "direct"
-    # Only major updates here; grouped config above ignores majors
-    versioning-strategy: "increase"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,21 +31,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # CodeQL analyzes JS + TS in a single pass via 'javascript-typescript'
         language:
-          - javascript
-          - typescript
+          - javascript-typescript
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload audit artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-audit-report
           path: npm-audit.json


### PR DESCRIPTION
## Summary
- Dependabot npm 엔트리 중복 제거
- CodeQL 매트릭스 `javascript-typescript` 단일화
- Actions 버전 업그레이드 (Node 20 runtime/CodeQL v3 deprecation 대응)

## 참조
- 이슈 #62, develop PR #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)