### PR TITLE
feat(dubbing): 더빙 전 업로드 설정 스텝 + MISSING_VIDEO 버그 수정

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -148,41 +148,64 @@ function UploadRow({ item, userId }: UploadRowProps) {
     setModalOpen(false)
     setState('fetching')
     try {
-      let videoUrl = item.dubbed_video_url
-      let srtUrl = item.srt_url
+      const toAbs = (u: string | null | undefined): string | null => {
+        if (!u) return null
+        return u.startsWith('http') ? u : getPersoFileUrl(u)
+      }
 
-      if (!videoUrl && item.project_seq && item.space_seq) {
+      const refetchFromPerso = async (): Promise<{ video: string | null; srt: string | null }> => {
+        if (!item.project_seq || !item.space_seq) return { video: null, srt: null }
         const [dubDl, allDl] = await Promise.all([
           getDownloadLinks(item.project_seq, item.space_seq, 'dubbingVideo'),
           getDownloadLinks(item.project_seq, item.space_seq, 'all'),
         ])
-        videoUrl = dubDl.videoFile?.videoDownloadLink
+        const raw = dubDl.videoFile?.videoDownloadLink
           ?? allDl.videoFile?.videoDownloadLink
           ?? allDl.zippedFileDownloadLink
           ?? null
-        srtUrl = srtUrl ?? allDl.srtFile?.translatedSubtitleDownloadLink ?? null
-
-        if (videoUrl && !videoUrl.startsWith('http')) {
-          videoUrl = getPersoFileUrl(videoUrl)
-        }
-        if (srtUrl && !srtUrl.startsWith('http')) {
-          srtUrl = getPersoFileUrl(srtUrl)
-        }
-        if (!videoUrl) throw new Error('No dubbed video download link available')
+        const rawSrt = allDl.srtFile?.translatedSubtitleDownloadLink ?? null
+        return { video: toAbs(raw), srt: toAbs(rawSrt) }
       }
 
+      // Start from DB URL (normalized). Refetch if missing or later if fetch fails (expired CDN link).
+      let videoUrl = toAbs(item.dubbed_video_url)
+      let srtUrl = toAbs(item.srt_url)
+
+      if (!videoUrl) {
+        const fresh = await refetchFromPerso()
+        videoUrl = fresh.video
+        srtUrl = srtUrl ?? fresh.srt
+      }
       if (!videoUrl) throw new Error('No dubbed video download link available')
 
       setState('uploading')
       const tagsArray = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
-      const result = await ytUploadVideo({
-        videoUrl,
+
+      const doUpload = (url: string) => ytUploadVideo({
+        videoUrl: url,
         title: settings.title,
         description: settings.description,
         tags: tagsArray,
         privacyStatus: settings.privacyStatus,
         language: item.language_code,
       })
+
+      let result
+      try {
+        result = await doUpload(videoUrl)
+      } catch (err) {
+        // Retry once with a fresh Perso link — handles expired CDN URLs stored in DB.
+        const msg = err instanceof Error ? err.message : ''
+        const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
+        if (!isFetchFailure || !item.project_seq || !item.space_seq) throw err
+        setState('fetching')
+        const fresh = await refetchFromPerso()
+        if (!fresh.video) throw err
+        videoUrl = fresh.video
+        srtUrl = srtUrl ?? fresh.srt
+        setState('uploading')
+        result = await doUpload(videoUrl)
+      }
 
       if (srtUrl) {
         try {

--- a/src/features/dubbing/components/DubbingWizard.tsx
+++ b/src/features/dubbing/components/DubbingWizard.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn'
 import { useDubbingStore } from '../store/dubbingStore'
 import { VideoInputStep } from './steps/VideoInputStep'
 import { LanguageSelectStep } from './steps/LanguageSelectStep'
+import { UploadSettingsStep } from './steps/UploadSettingsStep'
 import { TranslationEditStep } from './steps/TranslationEditStep'
 import { ProcessingStep } from './steps/ProcessingStep'
 import { UploadStep } from './steps/UploadStep'
@@ -12,9 +13,10 @@ import { UploadStep } from './steps/UploadStep'
 const steps = [
   { num: 1, label: '영상' },
   { num: 2, label: '언어' },
-  { num: 3, label: '확인' },
-  { num: 4, label: '처리' },
-  { num: 5, label: '결과' },
+  { num: 3, label: '업로드 설정' },
+  { num: 4, label: '확인' },
+  { num: 5, label: '처리' },
+  { num: 6, label: '결과' },
 ] as const
 
 export function DubbingWizard() {
@@ -68,9 +70,10 @@ export function DubbingWizard() {
       <div className="animate-fade-in">
         {currentStep === 1 && <VideoInputStep />}
         {currentStep === 2 && <LanguageSelectStep />}
-        {currentStep === 3 && <TranslationEditStep />}
-        {currentStep === 4 && <ProcessingStep />}
-        {currentStep === 5 && <UploadStep />}
+        {currentStep === 3 && <UploadSettingsStep />}
+        {currentStep === 4 && <TranslationEditStep />}
+        {currentStep === 5 && <ProcessingStep />}
+        {currentStep === 6 && <UploadStep />}
       </div>
     </div>
   )

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -71,7 +71,7 @@ export function ProcessingStep() {
   useEffect(() => {
     if (allCompleted) {
       stopPolling()
-      const t = setTimeout(() => setStep(5), 2000)
+      const t = setTimeout(() => setStep(6), 2000)
       return () => clearTimeout(t)
     }
   }, [allCompleted, setStep, stopPolling])

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
+import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
+import { extractVideoId } from '@/utils/validators'
+import { getLanguageByCode } from '@/utils/languages'
+import { useDubbingStore } from '../../store/dubbingStore'
+import type { PrivacyStatus } from '../../types/dubbing.types'
+
+const PRIVACY_OPTIONS: { value: PrivacyStatus; label: string }[] = [
+  { value: 'private', label: '비공개 (권장)' },
+  { value: 'unlisted', label: '일부 공개' },
+  { value: 'public', label: '공개' },
+]
+
+export function UploadSettingsStep() {
+  const {
+    videoMeta,
+    videoSource,
+    isShort,
+    selectedLanguages,
+    uploadSettings,
+    setUploadSettings,
+    prevStep,
+    nextStep,
+  } = useDubbingStore()
+
+  const originalYouTubeId =
+    videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
+  const originalYouTubeUrl = originalYouTubeId
+    ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
+    : null
+
+  // 처음 진입 시 기본값(제목/설명) 채워 주기 — 비어 있을 때만
+  useEffect(() => {
+    const patch: Partial<typeof uploadSettings> = {}
+    if (!uploadSettings.title && videoMeta?.title) {
+      patch.title = videoMeta.title
+    }
+    if (!uploadSettings.description && videoMeta?.title) {
+      patch.description = `${videoMeta.title} - CreatorDub AI 더빙\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+    }
+    if (Object.keys(patch).length > 0) setUploadSettings(patch)
+  }, [videoMeta?.title, uploadSettings.title, uploadSettings.description, setUploadSettings])
+
+  const firstLangName = useMemo(() => {
+    const first = selectedLanguages[0]
+    if (!first) return null
+    return getLanguageByCode(first)?.name || first
+  }, [selectedLanguages])
+
+  const previewTitle = firstLangName
+    ? `${uploadSettings.uploadAsShort ? '#Shorts ' : ''}[${firstLangName}] ${uploadSettings.title || '(제목 없음)'}`
+    : null
+
+  const previewDescription = (() => {
+    const base = uploadSettings.description || '(설명 없음)'
+    if (uploadSettings.attachOriginalLink && originalYouTubeUrl) {
+      return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
+    }
+    return base
+  })()
+
+  const tagsString = uploadSettings.tags.join(', ')
+
+  const handleTagsChange = (value: string) => {
+    const parsed = value
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    setUploadSettings({ tags: parsed })
+  }
+
+  const canContinue = uploadSettings.title.trim().length > 0
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-surface-900 dark:text-white">업로드 설정</h2>
+        <p className="mt-1 text-surface-500">
+          처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요. 각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.
+        </p>
+      </div>
+
+      <Card>
+        <CardTitle>제목 · 설명 · 태그</CardTitle>
+        <div className="mt-4 space-y-4">
+          <Input
+            label="제목 (공통)"
+            value={uploadSettings.title}
+            onChange={(e) => setUploadSettings({ title: e.target.value })}
+            placeholder="영상 제목"
+          />
+
+          <div className="w-full">
+            <label htmlFor="upload-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+              설명
+            </label>
+            <textarea
+              id="upload-description"
+              rows={4}
+              value={uploadSettings.description}
+              onChange={(e) => setUploadSettings({ description: e.target.value })}
+              placeholder="영상 설명"
+              className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
+            />
+          </div>
+
+          <Input
+            label="태그 (쉼표 구분)"
+            value={tagsString}
+            onChange={(e) => handleTagsChange(e.target.value)}
+            placeholder="CreatorDub, AI더빙, dubbed"
+          />
+
+          <Select
+            label="공개 설정"
+            value={uploadSettings.privacyStatus}
+            onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
+            options={PRIVACY_OPTIONS}
+          />
+          <p className="-mt-2 text-xs text-surface-400">
+            안전을 위해 비공개를 권장합니다. 업로드 후 YouTube Studio에서 변경할 수 있습니다.
+          </p>
+        </div>
+      </Card>
+
+      <Card>
+        <CardTitle>업로드 옵션</CardTitle>
+        <div className="mt-4 space-y-2">
+          <ToggleRow
+            icon={<Upload className="h-4 w-4 text-emerald-500" />}
+            label="완료 즉시 자동 업로드"
+            description="더빙이 완료되면 개입 없이 모든 언어를 자동으로 업로드합니다."
+            active={uploadSettings.autoUpload}
+            activeLabel="ON"
+            inactiveLabel="OFF"
+            onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
+          />
+
+          <ToggleRow
+            icon={<Zap className="h-4 w-4 text-brand-500" />}
+            label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
+            description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
+            active={uploadSettings.uploadAsShort}
+            activeLabel="Shorts ON"
+            inactiveLabel="Shorts OFF"
+            onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
+          />
+
+          {originalYouTubeUrl && (
+            <ToggleRow
+              icon={<Link2 className="h-4 w-4 text-surface-400" />}
+              label="설명란에 원본 YouTube 링크 첨부"
+              description={originalYouTubeUrl}
+              active={uploadSettings.attachOriginalLink}
+              activeLabel="첨부 ON"
+              inactiveLabel="첨부 OFF"
+              onToggle={() => setUploadSettings({ attachOriginalLink: !uploadSettings.attachOriginalLink })}
+            />
+          )}
+        </div>
+      </Card>
+
+      {previewTitle && (
+        <Card className="border-brand-200 bg-brand-50/40 dark:border-brand-800 dark:bg-brand-900/10">
+          <CardTitle>미리보기 ({firstLangName})</CardTitle>
+          <div className="mt-3 space-y-2">
+            <div>
+              <p className="text-xs text-surface-500">제목</p>
+              <p className="mt-0.5 text-sm font-medium text-surface-900 dark:text-white break-all">{previewTitle}</p>
+            </div>
+            <div>
+              <p className="text-xs text-surface-500">설명</p>
+              <p className="mt-0.5 whitespace-pre-line text-sm text-surface-700 dark:text-surface-300">{previewDescription}</p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      <div className="flex justify-between">
+        <Button variant="secondary" onClick={prevStep}>
+          <ArrowLeft className="h-4 w-4" />
+          이전
+        </Button>
+        <Button onClick={nextStep} disabled={!canContinue}>
+          다음: 설정 확인
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface ToggleRowProps {
+  icon: React.ReactNode
+  label: string
+  description?: string
+  active: boolean
+  activeLabel: string
+  inactiveLabel: string
+  onToggle: () => void
+}
+
+function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle }: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+      <div className="flex min-w-0 items-start gap-2">
+        <div className="mt-0.5 flex-shrink-0">{icon}</div>
+        <div className="min-w-0">
+          <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+          {description && (
+            <p className="mt-0.5 truncate text-xs text-surface-400">{description}</p>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
+          active
+            ? 'bg-brand-500 text-white'
+            : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+        }`}
+      >
+        {active ? activeLabel : inactiveLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2, Link2 } from 'lucide-react'
+import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
@@ -10,7 +10,7 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
 import { useAuthStore } from '@/stores/authStore'
-import { ytUploadVideo, ytUploadCaption } from '@/lib/api-client'
+import { ytUploadVideo, ytUploadCaption, getPersoFileUrl } from '@/lib/api-client'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { ScriptEditor } from '../ScriptEditor'
 
@@ -24,7 +24,7 @@ interface LangUploadState {
 }
 
 export function UploadStep() {
-  const { selectedLanguages, videoMeta, videoSource, languageProgress, isShort, dbJobId, spaceSeq, projectMap, reset } = useDubbingStore()
+  const { selectedLanguages, videoMeta, videoSource, languageProgress, dbJobId, spaceSeq, projectMap, uploadSettings, reset } = useDubbingStore()
   const { fetchDownloads } = usePersoFlow()
   const addToast = useNotificationStore((s) => s.addToast)
   const userId = useAuthStore((s) => s.user?.uid)
@@ -37,27 +37,26 @@ export function UploadStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
+  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus } = uploadSettings
+
   const [copiedLang, setCopiedLang] = useState<string | null>(null)
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
-  const [uploadAsShort, setUploadAsShort] = useState(isShort)
-  const [autoUpload, setAutoUpload] = useState(false)
-  // 원본 링크 첨부 — YouTube URL일 때 기본 ON
-  const [attachOriginalLink, setAttachOriginalLink] = useState(!!originalYouTubeUrl)
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoUploadTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
-  // Build description with optional original link
   const buildDescription = useCallback(
     (langName: string) => {
-      const base = `${videoMeta?.title || 'Video'} - ${langName} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+      const base = settingsDescription?.trim()
+        ? settingsDescription
+        : `${videoMeta?.title || 'Video'} - ${langName} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
       if (attachOriginalLink && originalYouTubeUrl) {
         return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
       }
       return base
     },
-    [videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
+    [settingsDescription, videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
   )
 
   const handleCopy = (langCode: string, text: string) => {
@@ -139,21 +138,28 @@ export function UploadStep() {
     setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 0 } }))
 
     try {
-      // 1. Get dubbed video download link from Perso
+      // 1. Get dubbed video download link from Perso (always fresh — avoids stale DB link)
       const downloads = await fetchDownloads(langCode, 'dubbingVideo')
-      const videoUrl = downloads?.videoFile?.videoDownloadLink
-      if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
+      if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
       // 2. Upload to YouTube — server fetches video from Perso CDN directly (avoids browser CORS)
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
-      const ytTitle = `${titlePrefix}[${lang.name}] ${videoMeta?.title || 'Dubbed Video'}`
+      const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
+      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const langTags = Array.from(new Set([
+        ...settingsTags,
+        lang.name,
+        ...(uploadAsShort ? ['Shorts'] : []),
+      ]))
       const result = await ytUploadVideo({
         videoUrl,
         title: ytTitle,
         description: buildDescription(lang.name),
-        tags: ['CreatorDub', 'AI더빙', lang.name, 'dubbed', ...(uploadAsShort ? ['Shorts'] : [])],
-        privacyStatus: 'private',
+        tags: langTags,
+        privacyStatus,
         language: langCode,
       })
       setYtUploads((prev) => ({
@@ -195,7 +201,7 @@ export function UploadStep() {
               youtubeVideoId: result.videoId,
               title: ytTitle,
               languageCode: langCode,
-              privacyStatus: 'private',
+              privacyStatus,
               isShort: uploadAsShort,
             },
           })
@@ -210,10 +216,11 @@ export function UploadStep() {
         // DB save best-effort
       }
 
+      const privacyLabel = privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'
       addToast({
         type: 'success',
         title: `${lang.name} YouTube 업로드 완료`,
-        message: `영상 ID: ${result.videoId} (비공개)`,
+        message: `영상 ID: ${result.videoId} (${privacyLabel})`,
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : '업로드 실패'
@@ -223,7 +230,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription])
 
   // Upload ALL completed languages to YouTube (2 concurrent)
   const handleUploadAll = async () => {
@@ -286,68 +293,17 @@ export function UploadStep() {
               더빙된 영상을 YouTube에 새 영상으로 업로드합니다. 안전을 위해 비공개로 업로드되며, 이후 YouTube Studio에서 공개 설정을 변경할 수 있습니다.
             </p>
 
-            {/* Upload options */}
-            <div className="mb-4 space-y-2">
-              {/* Shorts toggle — always visible */}
-              <div className="flex items-center justify-between rounded-lg bg-brand-50 p-3 dark:bg-brand-900/20">
-                <div className="flex items-center gap-2">
-                  {isShort && <Badge variant="brand">Shorts 감지됨</Badge>}
-                  <span className="text-sm text-surface-600 dark:text-surface-400">
-                    {isShort ? '3분 이하 영상 — #Shorts 태그 자동 추가' : 'Shorts로 업로드 (#Shorts 태그 추가)'}
-                  </span>
-                </div>
-                <button
-                  onClick={() => setUploadAsShort(!uploadAsShort)}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                    uploadAsShort
-                      ? 'bg-brand-500 text-white'
-                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                  }`}
-                >
-                  {uploadAsShort ? 'Shorts ON' : 'Shorts OFF'}
-                </button>
-              </div>
-
-              {/* Auto upload toggle */}
-              <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
-                <span className="text-sm text-surface-600 dark:text-surface-400">
-                  완료 즉시 자동 업로드
-                </span>
-                <button
-                  onClick={() => { setAutoUpload(!autoUpload); autoUploadTriggered.current = false }}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                    autoUpload
-                      ? 'bg-emerald-500 text-white'
-                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                  }`}
-                >
-                  {autoUpload ? 'ON' : 'OFF'}
-                </button>
-              </div>
-
-              {/* 원본 링크 첨부 — YouTube URL 감지 시만 표시 */}
-              {originalYouTubeUrl && (
-                <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <Link2 className="h-4 w-4 flex-shrink-0 text-surface-400" />
-                    <div className="min-w-0">
-                      <p className="text-sm text-surface-600 dark:text-surface-400">
-                        설명란에 원본 YouTube 링크 첨부
-                      </p>
-                      <p className="truncate text-xs text-surface-400">{originalYouTubeUrl}</p>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => setAttachOriginalLink(!attachOriginalLink)}
-                    className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                      attachOriginalLink
-                        ? 'bg-brand-500 text-white'
-                        : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                    }`}
-                  >
-                    {attachOriginalLink ? '첨부 ON' : '첨부 OFF'}
-                  </button>
-                </div>
+            {/* Upload options summary — read-only, set in Step 3 */}
+            <div className="mb-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 text-xs text-surface-500 space-y-1">
+              <p>
+                자동 업로드: <span className="font-medium text-surface-700 dark:text-surface-300">{autoUpload ? 'ON' : 'OFF'}</span>
+                {' · '}
+                Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
+                {' · '}
+                공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
+              </p>
+              {attachOriginalLink && originalYouTubeUrl && (
+                <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>
               )}
             </div>
 
@@ -589,7 +545,8 @@ export function UploadStep() {
           {completedLangs.map((code) => {
             const lang = getLanguageByCode(code)
             if (!lang) return null
-            const title = `[${lang.name}] ${videoMeta?.title || 'Video Title'}`
+            const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Video Title'
+            const title = `${uploadAsShort ? '#Shorts ' : ''}[${lang.name}] ${baseTitle}`
             const desc = buildDescription(lang.name)
             return (
               <div key={code} className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -134,10 +134,17 @@ async function pollLanguage(
   if (reason === 'COMPLETED' || reason === 'Completed') {
     try {
       const downloads = await getDownloadLinks(projectSeq, spaceSeq, 'all')
+      // Normalize to absolute URLs — Perso may return relative paths which break
+      // server-side fetch in /api/youtube/upload (requires http-prefixed URLs).
+      const toAbs = (u?: string) => (u ? (u.startsWith('http') ? u : getPersoFileUrl(u)) : undefined)
+      const absVideoUrl = toAbs(downloads.videoFile?.videoDownloadLink)
+      const absAudioUrl = toAbs(downloads.audioFile?.voiceAudioDownloadLink)
+      const absSrtUrl = toAbs(downloads.srtFile?.translatedSubtitleDownloadLink)
+
       store.getState().updateLanguageProgress(langCode, {
-        audioUrl: downloads.audioFile?.voiceAudioDownloadLink,
-        srtUrl: downloads.srtFile?.translatedSubtitleDownloadLink,
-        dubbingVideoUrl: downloads.videoFile?.videoDownloadLink,
+        audioUrl: absAudioUrl,
+        srtUrl: absSrtUrl,
+        dubbingVideoUrl: absVideoUrl,
       })
       if (dbJobId) {
         dbMutation({
@@ -146,9 +153,9 @@ async function pollLanguage(
             jobId: dbJobId,
             langCode,
             urls: {
-              dubbedVideoUrl: downloads.videoFile?.videoDownloadLink,
-              audioUrl: downloads.audioFile?.voiceAudioDownloadLink,
-              srtUrl: downloads.srtFile?.translatedSubtitleDownloadLink,
+              dubbedVideoUrl: absVideoUrl,
+              audioUrl: absAudioUrl,
+              srtUrl: absSrtUrl,
             },
           },
         }).catch(() => { /* completion update is best-effort */ })

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -9,7 +9,18 @@ import type {
   LanguageProgress,
   GlossaryEntry,
   JobStatus,
+  UploadSettings,
 } from '../types/dubbing.types'
+
+const DEFAULT_UPLOAD_SETTINGS: UploadSettings = {
+  autoUpload: true,
+  uploadAsShort: false,
+  attachOriginalLink: true,
+  title: '',
+  description: '',
+  tags: ['CreatorDub', 'AI더빙', 'dubbed'],
+  privacyStatus: 'private',
+}
 
 interface DubbingState {
   // Wizard navigation
@@ -63,6 +74,10 @@ interface DubbingState {
   isShort: boolean
   setIsShort: (v: boolean) => void
 
+  // Upload settings (chosen before dubbing starts)
+  uploadSettings: UploadSettings
+  setUploadSettings: (patch: Partial<UploadSettings>) => void
+
   // Glossary
   glossary: GlossaryEntry[]
   addGlossaryEntry: (entry: GlossaryEntry) => void
@@ -88,6 +103,7 @@ const initialState = {
   jobStatus: 'idle' as JobStatus,
   languageProgress: [] as LanguageProgress[],
   glossary: [] as GlossaryEntry[],
+  uploadSettings: { ...DEFAULT_UPLOAD_SETTINGS } as UploadSettings,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -95,7 +111,7 @@ export const useDubbingStore = create<DubbingState>((set) => ({
 
   setStep: (step) => set({ currentStep: step }),
   setIsSubmitted: (v) => set({ isSubmitted: v }),
-  nextStep: () => set((s) => ({ currentStep: Math.min(5, s.currentStep + 1) as DubbingStep })),
+  nextStep: () => set((s) => ({ currentStep: Math.min(6, s.currentStep + 1) as DubbingStep })),
   prevStep: () => set((s) => ({ currentStep: Math.max(1, s.currentStep - 1) as DubbingStep })),
 
   setSpaceSeq: (seq) => set({ spaceSeq: seq }),
@@ -144,7 +160,14 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     })),
 
   setDbJobId: (id) => set({ dbJobId: id }),
-  setIsShort: (v) => set({ isShort: v }),
+  setIsShort: (v) => set((s) => ({
+    isShort: v,
+    uploadSettings: { ...s.uploadSettings, uploadAsShort: v },
+  })),
+
+  setUploadSettings: (patch) => set((s) => ({
+    uploadSettings: { ...s.uploadSettings, ...patch },
+  })),
 
   addGlossaryEntry: (entry) => set((s) => ({ glossary: [...s.glossary, entry] })),
   removeGlossaryEntry: (id) => set((s) => ({ glossary: s.glossary.filter((e) => e.id !== id) })),

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -1,4 +1,16 @@
-export type DubbingStep = 1 | 2 | 3 | 4 | 5
+export type DubbingStep = 1 | 2 | 3 | 4 | 5 | 6
+
+export type PrivacyStatus = 'public' | 'unlisted' | 'private'
+
+export interface UploadSettings {
+  autoUpload: boolean
+  uploadAsShort: boolean
+  attachOriginalLink: boolean
+  title: string
+  description: string
+  tags: string[]
+  privacyStatus: PrivacyStatus
+}
 
 export type JobStatus = 'idle' | 'transcribing' | 'translating' | 'synthesizing' | 'lip-syncing' | 'merging' | 'completed' | 'failed'
 


### PR DESCRIPTION
## Summary

1. **Step 3 '업로드 설정' 추가** — 언어 선택 뒤, 번역 확인 전에 제목/설명/태그/공개설정을 미리 입력받음. 자동 업로드 토글 기본 ON, Shorts/원본 링크 첨부도 여기서 설정. 처리가 끝나면 주욱 진행되어 업로드까지 완료.
2. **\`dubbed_video_url\` 절대 URL 정규화** — \`pollLanguage\`가 DB에 저장할 때 Perso가 상대 경로로 주는 경우가 있어 \`getPersoFileUrl\`로 항상 절대 URL화. 이전에는 상대 경로가 저장되면 \`/uploads\`에서 재시도 시 서버의 \`startsWith('http')\` 체크를 통과 못 해 \`MISSING_VIDEO\` 에러가 발생.
3. **Perso 링크 만료 시 자동 재조회/재시도** — \`/uploads\` 업로드 경로에서 \`VIDEO_FETCH_FAILED\` 또는 fetch 관련 에러면 Perso에서 fresh 링크를 재조회해 한 번 더 시도.

## Steps 구조 변경

| Before | After |
|---|---|
| 1 영상 → 2 언어 → 3 확인 → 4 처리 → 5 결과 | 1 영상 → 2 언어 → **3 업로드 설정** → 4 확인 → 5 처리 → 6 결과 |

\`DubbingStep\` 타입은 \`1\|2\|3\|4\|5\|6\`으로 확장. \`ProcessingStep\`의 \`setStep(5)\`도 \`setStep(6)\`으로 업데이트.

## Files changed
- \`src/features/dubbing/types/dubbing.types.ts\` — DubbingStep 확장, \`UploadSettings\`/\`PrivacyStatus\` 추가
- \`src/features/dubbing/store/dubbingStore.ts\` — \`uploadSettings\` 상태 + \`setUploadSettings\`, \`setIsShort\`가 \`uploadAsShort\`도 반영, \`nextStep\` 상한 6
- \`src/features/dubbing/components/steps/UploadSettingsStep.tsx\` (신규)
- \`src/features/dubbing/components/DubbingWizard.tsx\` — 새 스텝 슬롯
- \`src/features/dubbing/components/steps/UploadStep.tsx\` — 로컬 상태 제거, store에서 설정 읽음. 기존 토글 UI는 요약 표시로 대체
- \`src/features/dubbing/components/steps/ProcessingStep.tsx\` — \`setStep(6)\`
- \`src/features/dubbing/hooks/usePersoFlow.ts\` — 완료 시 URL 정규화 후 DB 저장
- \`src/app/(app)/uploads/page.tsx\` — DB URL 정규화 + fetch 실패 시 Perso 재조회 retry-once

## Test plan
- [ ] 새 더빙: 1→2→3 흐름에서 3단계에 진입되고, 자동 업로드/Shorts/공개설정이 저장/유지되는지
- [ ] 3단계에서 제목 비우면 '다음' 비활성화
- [ ] 미리보기가 첫 번째 선택 언어로 정확히 표시
- [ ] 4(확인) → 5(처리) 진행 후 처리 완료 시점에 \`autoUpload=ON\`이면 결과 화면에서 자동 업로드 트리거
- [ ] 결과 화면에서 설정한 공개 상태/태그/제목/원본 링크 첨부가 YouTube로 정상 반영
- [ ] \`/uploads\`에서 DB에 상대 경로로 저장된 옛 레코드 재업로드 시 MISSING_VIDEO 대신 정상 업로드
- [ ] Perso 만료 링크 시나리오: CDN fetch가 502/실패하면 재조회 후 재시도되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)