### PR TITLE
fix(dubbing): ScriptEditor 크래시 / 소스 언어 선택 / Shorts 업로드 옵션

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -17,18 +17,26 @@ import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
 
 type UploadState = 'idle' | 'fetching' | 'uploading' | 'done' | 'error'
 type PrivacyStatus = 'public' | 'unlisted' | 'private'
+type ShortsMode = 'regular' | 'shorts' | 'both'
 
 interface UploadSettings {
   title: string
   description: string
   tags: string
   privacyStatus: PrivacyStatus
+  shortsMode: ShortsMode
 }
 
 const PRIVACY_OPTIONS = [
   { value: 'private', label: '비공개' },
   { value: 'unlisted', label: '일부 공개' },
   { value: 'public', label: '공개' },
+]
+
+const SHORTS_OPTIONS: Array<{ value: ShortsMode; label: string; hint: string }> = [
+  { value: 'regular', label: '일반 영상', hint: '일반 YouTube 영상으로 업로드' },
+  { value: 'shorts', label: 'Shorts', hint: '제목/태그에 #Shorts 추가' },
+  { value: 'both', label: '일반 + Shorts 양쪽', hint: '두 개의 영상으로 각각 업로드' },
 ]
 
 async function fetchCompletedLanguages(uid: string): Promise<CompletedJobLanguage[]> {
@@ -44,6 +52,7 @@ function buildDefaultSettings(item: CompletedJobLanguage, langName: string): Upl
     description: `${item.video_title} - ${langName} dubbed by CreatorDub AI`,
     tags: `CreatorDub, AI dubbing, ${langName}, dubbed`,
     privacyStatus: 'private',
+    shortsMode: 'regular',
   }
 }
 
@@ -95,6 +104,33 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
           onChange={(e) => onChange({ ...settings, privacyStatus: e.target.value as PrivacyStatus })}
           options={PRIVACY_OPTIONS}
         />
+
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+            업로드 형식
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            {SHORTS_OPTIONS.map((opt) => {
+              const active = settings.shortsMode === opt.value
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => onChange({ ...settings, shortsMode: opt.value })}
+                  className={
+                    'rounded-lg border px-3 py-2 text-left transition-colors cursor-pointer ' +
+                    (active
+                      ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/20'
+                      : 'border-surface-200 hover:border-surface-300 dark:border-surface-700 dark:hover:border-surface-600')
+                  }
+                >
+                  <div className="text-sm font-medium text-surface-900 dark:text-white">{opt.label}</div>
+                  <div className="mt-0.5 text-[11px] text-surface-500">{opt.hint}</div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
 
         <div className="flex items-center gap-2 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
           <span className="text-xs text-surface-500">Language: {langName}</span>
@@ -179,73 +215,103 @@ function UploadRow({ item, userId }: UploadRowProps) {
       if (!videoUrl) throw new Error('No dubbed video download link available')
 
       setState('uploading')
-      const tagsArray = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
+      const baseTags = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
 
-      const doUpload = (url: string) => ytUploadVideo({
-        videoUrl: url,
-        title: settings.title,
-        description: settings.description,
-        tags: tagsArray,
-        privacyStatus: settings.privacyStatus,
-        language: item.language_code,
-      })
-
-      let result
-      try {
-        result = await doUpload(videoUrl)
-      } catch (err) {
-        // Retry once with a fresh Perso link — handles expired CDN URLs stored in DB.
-        const msg = err instanceof Error ? err.message : ''
-        const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
-        if (!isFetchFailure || !item.project_seq || !item.space_seq) throw err
-        setState('fetching')
-        const fresh = await refetchFromPerso()
-        if (!fresh.video) throw err
-        videoUrl = fresh.video
-        srtUrl = srtUrl ?? fresh.srt
-        setState('uploading')
-        result = await doUpload(videoUrl)
+      // Build the list of variants to upload (1 for regular/shorts, 2 for both).
+      const variants: Array<{ isShort: boolean; title: string; tags: string[] }> = []
+      if (settings.shortsMode === 'regular' || settings.shortsMode === 'both') {
+        variants.push({ isShort: false, title: settings.title, tags: baseTags })
+      }
+      if (settings.shortsMode === 'shorts' || settings.shortsMode === 'both') {
+        variants.push({
+          isShort: true,
+          title: settings.title.startsWith('#Shorts ') ? settings.title : `#Shorts ${settings.title}`,
+          tags: Array.from(new Set([...baseTags, 'Shorts'])),
+        })
       }
 
-      if (srtUrl) {
+      const doUpload = (url: string, v: (typeof variants)[number]) =>
+        ytUploadVideo({
+          videoUrl: url,
+          title: v.title,
+          description: settings.description,
+          tags: v.tags,
+          privacyStatus: settings.privacyStatus,
+          language: item.language_code,
+        })
+
+      const uploadOnce = async (v: (typeof variants)[number]) => {
         try {
-          const srtRes = await fetch(srtUrl)
-          const srtText = await srtRes.text()
-          await ytUploadCaption({
-            videoId: result.videoId,
-            language: item.language_code,
-            name: `${langName} subtitles`,
-            srtContent: srtText,
-          })
-        } catch {
-          // SRT optional
+          return await doUpload(videoUrl!, v)
+        } catch (err) {
+          // Retry once with a fresh Perso link — handles expired CDN URLs stored in DB.
+          const msg = err instanceof Error ? err.message : ''
+          const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
+          if (!isFetchFailure || !item.project_seq || !item.space_seq) throw err
+          setState('fetching')
+          const fresh = await refetchFromPerso()
+          if (!fresh.video) throw err
+          videoUrl = fresh.video
+          srtUrl = srtUrl ?? fresh.srt
+          setState('uploading')
+          return await doUpload(videoUrl, v)
         }
       }
 
-      setVideoId(result.videoId)
+      const results: Array<{ variant: (typeof variants)[number]; videoId: string }> = []
+      for (const v of variants) {
+        const r = await uploadOnce(v)
+        results.push({ variant: v, videoId: r.videoId })
+
+        if (srtUrl) {
+          try {
+            const srtRes = await fetch(srtUrl)
+            const srtText = await srtRes.text()
+            await ytUploadCaption({
+              videoId: r.videoId,
+              language: item.language_code,
+              name: `${langName} subtitles`,
+              srtContent: srtText,
+            })
+          } catch {
+            // SRT optional
+          }
+        }
+      }
+
+      // Surface the regular (non-short) upload on the row if present, else the first one.
+      const displayed = results.find((r) => !r.variant.isShort) ?? results[0]
+      setVideoId(displayed.videoId)
       setState('done')
 
       const privacyLabel = PRIVACY_OPTIONS.find((o) => o.value === settings.privacyStatus)?.label || settings.privacyStatus
-      addToast({ type: 'success', title: `${langName} upload complete`, message: `Uploaded as ${privacyLabel}` })
+      const modeLabel = settings.shortsMode === 'both' ? '일반 + Shorts' : settings.shortsMode === 'shorts' ? 'Shorts' : '일반'
+      addToast({
+        type: 'success',
+        title: `${langName} upload complete`,
+        message: `${modeLabel} · ${privacyLabel} (${results.length}개 업로드)`,
+      })
 
       await Promise.all([
-        dbMutation({
-          type: 'createYouTubeUpload',
-          payload: {
-            userId,
-            youtubeVideoId: result.videoId,
-            title: settings.title,
-            languageCode: item.language_code,
-            privacyStatus: settings.privacyStatus,
-            isShort: false,
-          },
-        }),
+        ...results.map((r) =>
+          dbMutation({
+            type: 'createYouTubeUpload',
+            payload: {
+              userId,
+              youtubeVideoId: r.videoId,
+              title: r.variant.title,
+              languageCode: item.language_code,
+              privacyStatus: settings.privacyStatus,
+              isShort: r.variant.isShort,
+            },
+          }),
+        ),
         dbMutation({
           type: 'updateJobLanguageYouTube',
           payload: {
             jobId: item.job_id,
             langCode: item.language_code,
-            youtubeVideoId: result.videoId,
+            youtubeVideoId: displayed.videoId,
           },
         }),
       ])

--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -148,41 +148,64 @@ function UploadRow({ item, userId }: UploadRowProps) {
     setModalOpen(false)
     setState('fetching')
     try {
-      let videoUrl = item.dubbed_video_url
-      let srtUrl = item.srt_url
+      const toAbs = (u: string | null | undefined): string | null => {
+        if (!u) return null
+        return u.startsWith('http') ? u : getPersoFileUrl(u)
+      }
 
-      if (!videoUrl && item.project_seq && item.space_seq) {
+      const refetchFromPerso = async (): Promise<{ video: string | null; srt: string | null }> => {
+        if (!item.project_seq || !item.space_seq) return { video: null, srt: null }
         const [dubDl, allDl] = await Promise.all([
           getDownloadLinks(item.project_seq, item.space_seq, 'dubbingVideo'),
           getDownloadLinks(item.project_seq, item.space_seq, 'all'),
         ])
-        videoUrl = dubDl.videoFile?.videoDownloadLink
+        const raw = dubDl.videoFile?.videoDownloadLink
           ?? allDl.videoFile?.videoDownloadLink
           ?? allDl.zippedFileDownloadLink
           ?? null
-        srtUrl = srtUrl ?? allDl.srtFile?.translatedSubtitleDownloadLink ?? null
-
-        if (videoUrl && !videoUrl.startsWith('http')) {
-          videoUrl = getPersoFileUrl(videoUrl)
-        }
-        if (srtUrl && !srtUrl.startsWith('http')) {
-          srtUrl = getPersoFileUrl(srtUrl)
-        }
-        if (!videoUrl) throw new Error('No dubbed video download link available')
+        const rawSrt = allDl.srtFile?.translatedSubtitleDownloadLink ?? null
+        return { video: toAbs(raw), srt: toAbs(rawSrt) }
       }
 
+      // Start from DB URL (normalized). Refetch if missing or later if fetch fails (expired CDN link).
+      let videoUrl = toAbs(item.dubbed_video_url)
+      let srtUrl = toAbs(item.srt_url)
+
+      if (!videoUrl) {
+        const fresh = await refetchFromPerso()
+        videoUrl = fresh.video
+        srtUrl = srtUrl ?? fresh.srt
+      }
       if (!videoUrl) throw new Error('No dubbed video download link available')
 
       setState('uploading')
       const tagsArray = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
-      const result = await ytUploadVideo({
-        videoUrl,
+
+      const doUpload = (url: string) => ytUploadVideo({
+        videoUrl: url,
         title: settings.title,
         description: settings.description,
         tags: tagsArray,
         privacyStatus: settings.privacyStatus,
         language: item.language_code,
       })
+
+      let result
+      try {
+        result = await doUpload(videoUrl)
+      } catch (err) {
+        // Retry once with a fresh Perso link — handles expired CDN URLs stored in DB.
+        const msg = err instanceof Error ? err.message : ''
+        const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
+        if (!isFetchFailure || !item.project_seq || !item.space_seq) throw err
+        setState('fetching')
+        const fresh = await refetchFromPerso()
+        if (!fresh.video) throw err
+        videoUrl = fresh.video
+        srtUrl = srtUrl ?? fresh.srt
+        setState('uploading')
+        result = await doUpload(videoUrl)
+      }
 
       if (srtUrl) {
         try {

--- a/src/features/dubbing/components/DubbingWizard.tsx
+++ b/src/features/dubbing/components/DubbingWizard.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn'
 import { useDubbingStore } from '../store/dubbingStore'
 import { VideoInputStep } from './steps/VideoInputStep'
 import { LanguageSelectStep } from './steps/LanguageSelectStep'
+import { UploadSettingsStep } from './steps/UploadSettingsStep'
 import { TranslationEditStep } from './steps/TranslationEditStep'
 import { ProcessingStep } from './steps/ProcessingStep'
 import { UploadStep } from './steps/UploadStep'
@@ -12,9 +13,10 @@ import { UploadStep } from './steps/UploadStep'
 const steps = [
   { num: 1, label: '영상' },
   { num: 2, label: '언어' },
-  { num: 3, label: '확인' },
-  { num: 4, label: '처리' },
-  { num: 5, label: '결과' },
+  { num: 3, label: '업로드 설정' },
+  { num: 4, label: '확인' },
+  { num: 5, label: '처리' },
+  { num: 6, label: '결과' },
 ] as const
 
 export function DubbingWizard() {
@@ -68,9 +70,10 @@ export function DubbingWizard() {
       <div className="animate-fade-in">
         {currentStep === 1 && <VideoInputStep />}
         {currentStep === 2 && <LanguageSelectStep />}
-        {currentStep === 3 && <TranslationEditStep />}
-        {currentStep === 4 && <ProcessingStep />}
-        {currentStep === 5 && <UploadStep />}
+        {currentStep === 3 && <UploadSettingsStep />}
+        {currentStep === 4 && <TranslationEditStep />}
+        {currentStep === 5 && <ProcessingStep />}
+        {currentStep === 6 && <UploadStep />}
       </div>
     </div>
   )

--- a/src/features/dubbing/components/ScriptEditor.tsx
+++ b/src/features/dubbing/components/ScriptEditor.tsx
@@ -111,7 +111,14 @@ export function ScriptEditor({ langCode, projectSeq, spaceSeq }: ScriptEditorPro
     setOpen(true)
     try {
       const data = await getProjectScript(projectSeq, spaceSeq)
-      setSentences(data)
+      // Perso may return [] directly, or wrap sentences in an object envelope —
+      // normalize so `.map` below can never crash.
+      const list: ScriptSentence[] = Array.isArray(data)
+        ? data
+        : Array.isArray((data as { sentences?: ScriptSentence[] } | null)?.sentences)
+          ? (data as { sentences: ScriptSentence[] }).sentences
+          : []
+      setSentences(list)
     } catch {
       addToast({ type: 'error', title: '스크립트 로드 실패' })
       setOpen(false)
@@ -149,6 +156,11 @@ export function ScriptEditor({ langCode, projectSeq, spaceSeq }: ScriptEditorPro
             번역 텍스트를 수정하고 저장한 뒤 "오디오 재생성"을 클릭하면 해당 문장의 더빙 오디오가 다시 생성됩니다.
             재생성 후에는 영상을 다시 다운로드하거나 YouTube에 다시 업로드하세요.
           </p>
+          {sentences.length === 0 && (
+            <p className="text-sm text-surface-500 py-4 text-center">
+              표시할 스크립트가 없습니다.
+            </p>
+          )}
           {sentences.map((s) => (
             <SentenceRow
               key={s.sentenceSeq}

--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -7,7 +7,16 @@ import { SUPPORTED_LANGUAGES } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 
 export function LanguageSelectStep() {
-  const { selectedLanguages, toggleLanguage, lipSyncEnabled, setLipSync, prevStep, nextStep } = useDubbingStore()
+  const {
+    sourceLanguage,
+    setSourceLanguage,
+    selectedLanguages,
+    toggleLanguage,
+    lipSyncEnabled,
+    setLipSync,
+    prevStep,
+    nextStep,
+  } = useDubbingStore()
 
   const estimatedCredits = selectedLanguages.length * 15 + (lipSyncEnabled ? selectedLanguages.length * 8 : 0)
 
@@ -20,9 +29,30 @@ export function LanguageSelectStep() {
         </p>
       </div>
 
-      {/* Language grid — exclude source language (ko for test video) */}
+      {/* Source language selector */}
+      <Card>
+        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
+          원본 영상 언어
+        </label>
+        <select
+          value={sourceLanguage}
+          onChange={(e) => setSourceLanguage(e.target.value)}
+          className="w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+        >
+          {SUPPORTED_LANGUAGES.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.flag} {lang.name} ({lang.nativeName})
+            </option>
+          ))}
+        </select>
+        <p className="mt-2 text-xs text-surface-500">
+          영상 속 음성의 언어입니다. 잘못 설정하면 전사가 실패할 수 있습니다.
+        </p>
+      </Card>
+
+      {/* Language grid — exclude the current source language */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
-        {SUPPORTED_LANGUAGES.filter((l) => l.code !== 'ko').map((lang) => {
+        {SUPPORTED_LANGUAGES.filter((l) => l.code !== sourceLanguage).map((lang) => {
           const isSelected = selectedLanguages.includes(lang.code)
           return (
             <button

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -71,7 +71,7 @@ export function ProcessingStep() {
   useEffect(() => {
     if (allCompleted) {
       stopPolling()
-      const t = setTimeout(() => setStep(5), 2000)
+      const t = setTimeout(() => setStep(6), 2000)
       return () => clearTimeout(t)
     }
   }, [allCompleted, setStep, stopPolling])

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -8,8 +8,7 @@ import { getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 
 export function TranslationEditStep() {
-  const { selectedLanguages, lipSyncEnabled, setLipSync, videoMeta, prevStep, nextStep } = useDubbingStore()
-  const [sourceLanguage] = useState('ko') // test_video.mp4 is Korean
+  const { sourceLanguage, selectedLanguages, lipSyncEnabled, setLipSync, videoMeta, prevStep, nextStep } = useDubbingStore()
   const [speakers, setSpeakers] = useState(1)
 
   const sourceLang = getLanguageByCode(sourceLanguage)

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
+import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
+import { extractVideoId } from '@/utils/validators'
+import { getLanguageByCode } from '@/utils/languages'
+import { useDubbingStore } from '../../store/dubbingStore'
+import type { PrivacyStatus } from '../../types/dubbing.types'
+
+const PRIVACY_OPTIONS: { value: PrivacyStatus; label: string }[] = [
+  { value: 'private', label: '비공개 (권장)' },
+  { value: 'unlisted', label: '일부 공개' },
+  { value: 'public', label: '공개' },
+]
+
+export function UploadSettingsStep() {
+  const {
+    videoMeta,
+    videoSource,
+    isShort,
+    selectedLanguages,
+    uploadSettings,
+    setUploadSettings,
+    prevStep,
+    nextStep,
+  } = useDubbingStore()
+
+  const originalYouTubeId =
+    videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
+  const originalYouTubeUrl = originalYouTubeId
+    ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
+    : null
+
+  // 처음 진입 시 기본값(제목/설명) 채워 주기 — 비어 있을 때만
+  useEffect(() => {
+    const patch: Partial<typeof uploadSettings> = {}
+    if (!uploadSettings.title && videoMeta?.title) {
+      patch.title = videoMeta.title
+    }
+    if (!uploadSettings.description && videoMeta?.title) {
+      patch.description = `${videoMeta.title} - CreatorDub AI 더빙\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+    }
+    if (Object.keys(patch).length > 0) setUploadSettings(patch)
+  }, [videoMeta?.title, uploadSettings.title, uploadSettings.description, setUploadSettings])
+
+  const firstLangName = useMemo(() => {
+    const first = selectedLanguages[0]
+    if (!first) return null
+    return getLanguageByCode(first)?.name || first
+  }, [selectedLanguages])
+
+  const previewTitle = firstLangName
+    ? `${uploadSettings.uploadAsShort ? '#Shorts ' : ''}[${firstLangName}] ${uploadSettings.title || '(제목 없음)'}`
+    : null
+
+  const previewDescription = (() => {
+    const base = uploadSettings.description || '(설명 없음)'
+    if (uploadSettings.attachOriginalLink && originalYouTubeUrl) {
+      return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
+    }
+    return base
+  })()
+
+  const tagsString = uploadSettings.tags.join(', ')
+
+  const handleTagsChange = (value: string) => {
+    const parsed = value
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    setUploadSettings({ tags: parsed })
+  }
+
+  const canContinue = uploadSettings.title.trim().length > 0
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-surface-900 dark:text-white">업로드 설정</h2>
+        <p className="mt-1 text-surface-500">
+          처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요. 각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.
+        </p>
+      </div>
+
+      <Card>
+        <CardTitle>제목 · 설명 · 태그</CardTitle>
+        <div className="mt-4 space-y-4">
+          <Input
+            label="제목 (공통)"
+            value={uploadSettings.title}
+            onChange={(e) => setUploadSettings({ title: e.target.value })}
+            placeholder="영상 제목"
+          />
+
+          <div className="w-full">
+            <label htmlFor="upload-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+              설명
+            </label>
+            <textarea
+              id="upload-description"
+              rows={4}
+              value={uploadSettings.description}
+              onChange={(e) => setUploadSettings({ description: e.target.value })}
+              placeholder="영상 설명"
+              className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
+            />
+          </div>
+
+          <Input
+            label="태그 (쉼표 구분)"
+            value={tagsString}
+            onChange={(e) => handleTagsChange(e.target.value)}
+            placeholder="CreatorDub, AI더빙, dubbed"
+          />
+
+          <Select
+            label="공개 설정"
+            value={uploadSettings.privacyStatus}
+            onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
+            options={PRIVACY_OPTIONS}
+          />
+          <p className="-mt-2 text-xs text-surface-400">
+            안전을 위해 비공개를 권장합니다. 업로드 후 YouTube Studio에서 변경할 수 있습니다.
+          </p>
+        </div>
+      </Card>
+
+      <Card>
+        <CardTitle>업로드 옵션</CardTitle>
+        <div className="mt-4 space-y-2">
+          <ToggleRow
+            icon={<Upload className="h-4 w-4 text-emerald-500" />}
+            label="완료 즉시 자동 업로드"
+            description="더빙이 완료되면 개입 없이 모든 언어를 자동으로 업로드합니다."
+            active={uploadSettings.autoUpload}
+            activeLabel="ON"
+            inactiveLabel="OFF"
+            onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
+          />
+
+          <ToggleRow
+            icon={<Zap className="h-4 w-4 text-brand-500" />}
+            label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
+            description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
+            active={uploadSettings.uploadAsShort}
+            activeLabel="Shorts ON"
+            inactiveLabel="Shorts OFF"
+            onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
+          />
+
+          {originalYouTubeUrl && (
+            <ToggleRow
+              icon={<Link2 className="h-4 w-4 text-surface-400" />}
+              label="설명란에 원본 YouTube 링크 첨부"
+              description={originalYouTubeUrl}
+              active={uploadSettings.attachOriginalLink}
+              activeLabel="첨부 ON"
+              inactiveLabel="첨부 OFF"
+              onToggle={() => setUploadSettings({ attachOriginalLink: !uploadSettings.attachOriginalLink })}
+            />
+          )}
+        </div>
+      </Card>
+
+      {previewTitle && (
+        <Card className="border-brand-200 bg-brand-50/40 dark:border-brand-800 dark:bg-brand-900/10">
+          <CardTitle>미리보기 ({firstLangName})</CardTitle>
+          <div className="mt-3 space-y-2">
+            <div>
+              <p className="text-xs text-surface-500">제목</p>
+              <p className="mt-0.5 text-sm font-medium text-surface-900 dark:text-white break-all">{previewTitle}</p>
+            </div>
+            <div>
+              <p className="text-xs text-surface-500">설명</p>
+              <p className="mt-0.5 whitespace-pre-line text-sm text-surface-700 dark:text-surface-300">{previewDescription}</p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      <div className="flex justify-between">
+        <Button variant="secondary" onClick={prevStep}>
+          <ArrowLeft className="h-4 w-4" />
+          이전
+        </Button>
+        <Button onClick={nextStep} disabled={!canContinue}>
+          다음: 설정 확인
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface ToggleRowProps {
+  icon: React.ReactNode
+  label: string
+  description?: string
+  active: boolean
+  activeLabel: string
+  inactiveLabel: string
+  onToggle: () => void
+}
+
+function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle }: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+      <div className="flex min-w-0 items-start gap-2">
+        <div className="mt-0.5 flex-shrink-0">{icon}</div>
+        <div className="min-w-0">
+          <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+          {description && (
+            <p className="mt-0.5 truncate text-xs text-surface-400">{description}</p>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
+          active
+            ? 'bg-brand-500 text-white'
+            : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+        }`}
+      >
+        {active ? activeLabel : inactiveLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2, Link2 } from 'lucide-react'
+import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
@@ -10,7 +10,7 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
 import { useAuthStore } from '@/stores/authStore'
-import { ytUploadVideo, ytUploadCaption } from '@/lib/api-client'
+import { ytUploadVideo, ytUploadCaption, getPersoFileUrl } from '@/lib/api-client'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { ScriptEditor } from '../ScriptEditor'
 
@@ -24,7 +24,7 @@ interface LangUploadState {
 }
 
 export function UploadStep() {
-  const { selectedLanguages, videoMeta, videoSource, languageProgress, isShort, dbJobId, spaceSeq, projectMap, reset } = useDubbingStore()
+  const { selectedLanguages, videoMeta, videoSource, languageProgress, dbJobId, spaceSeq, projectMap, uploadSettings, reset } = useDubbingStore()
   const { fetchDownloads } = usePersoFlow()
   const addToast = useNotificationStore((s) => s.addToast)
   const userId = useAuthStore((s) => s.user?.uid)
@@ -37,27 +37,26 @@ export function UploadStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
+  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus } = uploadSettings
+
   const [copiedLang, setCopiedLang] = useState<string | null>(null)
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
-  const [uploadAsShort, setUploadAsShort] = useState(isShort)
-  const [autoUpload, setAutoUpload] = useState(false)
-  // 원본 링크 첨부 — YouTube URL일 때 기본 ON
-  const [attachOriginalLink, setAttachOriginalLink] = useState(!!originalYouTubeUrl)
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoUploadTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
-  // Build description with optional original link
   const buildDescription = useCallback(
     (langName: string) => {
-      const base = `${videoMeta?.title || 'Video'} - ${langName} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+      const base = settingsDescription?.trim()
+        ? settingsDescription
+        : `${videoMeta?.title || 'Video'} - ${langName} 더빙 by CreatorDub AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
       if (attachOriginalLink && originalYouTubeUrl) {
         return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
       }
       return base
     },
-    [videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
+    [settingsDescription, videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
   )
 
   const handleCopy = (langCode: string, text: string) => {
@@ -139,21 +138,28 @@ export function UploadStep() {
     setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 0 } }))
 
     try {
-      // 1. Get dubbed video download link from Perso
+      // 1. Get dubbed video download link from Perso (always fresh — avoids stale DB link)
       const downloads = await fetchDownloads(langCode, 'dubbingVideo')
-      const videoUrl = downloads?.videoFile?.videoDownloadLink
-      if (!videoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
+      if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
       // 2. Upload to YouTube — server fetches video from Perso CDN directly (avoids browser CORS)
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
-      const ytTitle = `${titlePrefix}[${lang.name}] ${videoMeta?.title || 'Dubbed Video'}`
+      const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
+      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const langTags = Array.from(new Set([
+        ...settingsTags,
+        lang.name,
+        ...(uploadAsShort ? ['Shorts'] : []),
+      ]))
       const result = await ytUploadVideo({
         videoUrl,
         title: ytTitle,
         description: buildDescription(lang.name),
-        tags: ['CreatorDub', 'AI더빙', lang.name, 'dubbed', ...(uploadAsShort ? ['Shorts'] : [])],
-        privacyStatus: 'private',
+        tags: langTags,
+        privacyStatus,
         language: langCode,
       })
       setYtUploads((prev) => ({
@@ -195,7 +201,7 @@ export function UploadStep() {
               youtubeVideoId: result.videoId,
               title: ytTitle,
               languageCode: langCode,
-              privacyStatus: 'private',
+              privacyStatus,
               isShort: uploadAsShort,
             },
           })
@@ -210,10 +216,11 @@ export function UploadStep() {
         // DB save best-effort
       }
 
+      const privacyLabel = privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'
       addToast({
         type: 'success',
         title: `${lang.name} YouTube 업로드 완료`,
-        message: `영상 ID: ${result.videoId} (비공개)`,
+        message: `영상 ID: ${result.videoId} (${privacyLabel})`,
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : '업로드 실패'
@@ -223,7 +230,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription])
 
   // Upload ALL completed languages to YouTube (2 concurrent)
   const handleUploadAll = async () => {
@@ -286,68 +293,17 @@ export function UploadStep() {
               더빙된 영상을 YouTube에 새 영상으로 업로드합니다. 안전을 위해 비공개로 업로드되며, 이후 YouTube Studio에서 공개 설정을 변경할 수 있습니다.
             </p>
 
-            {/* Upload options */}
-            <div className="mb-4 space-y-2">
-              {/* Shorts toggle — always visible */}
-              <div className="flex items-center justify-between rounded-lg bg-brand-50 p-3 dark:bg-brand-900/20">
-                <div className="flex items-center gap-2">
-                  {isShort && <Badge variant="brand">Shorts 감지됨</Badge>}
-                  <span className="text-sm text-surface-600 dark:text-surface-400">
-                    {isShort ? '3분 이하 영상 — #Shorts 태그 자동 추가' : 'Shorts로 업로드 (#Shorts 태그 추가)'}
-                  </span>
-                </div>
-                <button
-                  onClick={() => setUploadAsShort(!uploadAsShort)}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                    uploadAsShort
-                      ? 'bg-brand-500 text-white'
-                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                  }`}
-                >
-                  {uploadAsShort ? 'Shorts ON' : 'Shorts OFF'}
-                </button>
-              </div>
-
-              {/* Auto upload toggle */}
-              <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
-                <span className="text-sm text-surface-600 dark:text-surface-400">
-                  완료 즉시 자동 업로드
-                </span>
-                <button
-                  onClick={() => { setAutoUpload(!autoUpload); autoUploadTriggered.current = false }}
-                  className={`rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                    autoUpload
-                      ? 'bg-emerald-500 text-white'
-                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                  }`}
-                >
-                  {autoUpload ? 'ON' : 'OFF'}
-                </button>
-              </div>
-
-              {/* 원본 링크 첨부 — YouTube URL 감지 시만 표시 */}
-              {originalYouTubeUrl && (
-                <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <Link2 className="h-4 w-4 flex-shrink-0 text-surface-400" />
-                    <div className="min-w-0">
-                      <p className="text-sm text-surface-600 dark:text-surface-400">
-                        설명란에 원본 YouTube 링크 첨부
-                      </p>
-                      <p className="truncate text-xs text-surface-400">{originalYouTubeUrl}</p>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => setAttachOriginalLink(!attachOriginalLink)}
-                    className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-                      attachOriginalLink
-                        ? 'bg-brand-500 text-white'
-                        : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
-                    }`}
-                  >
-                    {attachOriginalLink ? '첨부 ON' : '첨부 OFF'}
-                  </button>
-                </div>
+            {/* Upload options summary — read-only, set in Step 3 */}
+            <div className="mb-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 text-xs text-surface-500 space-y-1">
+              <p>
+                자동 업로드: <span className="font-medium text-surface-700 dark:text-surface-300">{autoUpload ? 'ON' : 'OFF'}</span>
+                {' · '}
+                Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
+                {' · '}
+                공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
+              </p>
+              {attachOriginalLink && originalYouTubeUrl && (
+                <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>
               )}
             </div>
 
@@ -589,7 +545,8 @@ export function UploadStep() {
           {completedLangs.map((code) => {
             const lang = getLanguageByCode(code)
             if (!lang) return null
-            const title = `[${lang.name}] ${videoMeta?.title || 'Video Title'}`
+            const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Video Title'
+            const title = `${uploadAsShort ? '#Shorts ' : ''}[${lang.name}] ${baseTitle}`
             const desc = buildDescription(lang.name)
             return (
               <div key={code} className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, ExternalLink, Copy, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
+import { Download, ExternalLink, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
@@ -39,7 +39,6 @@ export function UploadStep() {
 
   const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus } = uploadSettings
 
-  const [copiedLang, setCopiedLang] = useState<string | null>(null)
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
@@ -58,12 +57,6 @@ export function UploadStep() {
     },
     [settingsDescription, videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
   )
-
-  const handleCopy = (langCode: string, text: string) => {
-    navigator.clipboard.writeText(text)
-    setCopiedLang(langCode)
-    setTimeout(() => setCopiedLang(null), 2000)
-  }
 
   const handleNewDubbing = () => reset()
   const handleGoToDashboard = () => { reset(); router.push('/dashboard') }
@@ -536,40 +529,6 @@ export function UploadStep() {
           </Button>
         </Card>
       )}
-
-      {/* Translated metadata */}
-      <Card>
-        <CardTitle>번역된 메타데이터</CardTitle>
-        <p className="text-sm text-surface-500 mb-4">각 언어별 번역된 제목과 설명을 복사하세요.</p>
-        <div className="space-y-3">
-          {completedLangs.map((code) => {
-            const lang = getLanguageByCode(code)
-            if (!lang) return null
-            const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Video Title'
-            const title = `${uploadAsShort ? '#Shorts ' : ''}[${lang.name}] ${baseTitle}`
-            const desc = buildDescription(lang.name)
-            return (
-              <div key={code} className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <span>{lang.flag}</span>
-                    <Badge>{lang.name}</Badge>
-                  </div>
-                  <button
-                    onClick={() => handleCopy(code, `${title}\n\n${desc}`)}
-                    className="flex items-center gap-1 rounded px-2 py-1 text-xs text-brand-500 hover:bg-brand-50 dark:hover:bg-brand-900/20"
-                  >
-                    {copiedLang === code ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-                    {copiedLang === code ? '복사됨' : '복사'}
-                  </button>
-                </div>
-                <p className="text-sm font-medium text-surface-900 dark:text-white">{title}</p>
-                <p className="text-xs text-surface-500 mt-1 whitespace-pre-line">{desc}</p>
-              </div>
-            )
-          })}
-        </div>
-      </Card>
 
       {/* Actions */}
       <div className="flex gap-3 justify-center">

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -64,6 +64,7 @@ async function saveJobToDb(
   selectedLanguages: string[],
   projectMap: Record<string, number>,
   lipSyncEnabled: boolean,
+  sourceLanguage: string,
 ): Promise<number | null> {
   const userId = useAuthStore.getState().user?.uid
   const videoMeta = store.getState().videoMeta
@@ -77,7 +78,7 @@ async function saveJobToDb(
       videoTitle: videoMeta?.title || '',
       videoDurationMs: videoMeta?.durationMs || 0,
       videoThumbnail: videoMeta?.thumbnail || '',
-      sourceLanguage: 'ko',
+      sourceLanguage,
       mediaSeq,
       spaceSeq,
       lipSyncEnabled,
@@ -247,8 +248,9 @@ export function usePersoFlow() {
       duration: 8000,
     })
 
+    const sourceLanguage = store.getState().sourceLanguage
     try {
-      const meta = await getExternalMetadata(spaceSeq!, url, 'ko')
+      const meta = await getExternalMetadata(spaceSeq!, url, sourceLanguage)
       store.getState().setVideoMeta({
         id: url,
         title: meta.originalName || (isYouTube ? 'YouTube Video' : 'External Video'),
@@ -260,7 +262,7 @@ export function usePersoFlow() {
         height: meta.height,
       })
 
-      const result = await uploadExternalVideo(spaceSeq!, url, 'ko')
+      const result = await uploadExternalVideo(spaceSeq!, url, sourceLanguage)
       store.getState().setMediaSeq(result.seq)
 
       addToast({ type: 'success', title: '영상 가져오기 완료' })
@@ -273,7 +275,7 @@ export function usePersoFlow() {
   }, [initSpace, addToast])
 
   const submitDubbing = useCallback(async () => {
-    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled } = store.getState()
+    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, sourceLanguage } = store.getState()
     if (!spaceSeq || !mediaSeq) throw new Error('Missing space or media')
 
     // Credit check before starting
@@ -308,7 +310,7 @@ export function usePersoFlow() {
       const result = await submitTranslation(spaceSeq, {
         mediaSeq,
         isVideoProject: true,
-        sourceLanguageCode: 'ko',
+        sourceLanguageCode: sourceLanguage,
         targetLanguageCodes: selectedLanguages,
         numberOfSpeakers: 1,
         withLipSync: lipSyncEnabled,
@@ -335,7 +337,7 @@ export function usePersoFlow() {
       store.getState().setJobStatus('transcribing')
 
       try {
-        await saveJobToDb(mediaSeq, spaceSeq, selectedLanguages, projectMap, lipSyncEnabled)
+        await saveJobToDb(mediaSeq, spaceSeq, selectedLanguages, projectMap, lipSyncEnabled, sourceLanguage)
       } catch {
         // DB save is best-effort
       }

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -134,10 +134,17 @@ async function pollLanguage(
   if (reason === 'COMPLETED' || reason === 'Completed') {
     try {
       const downloads = await getDownloadLinks(projectSeq, spaceSeq, 'all')
+      // Normalize to absolute URLs — Perso may return relative paths which break
+      // server-side fetch in /api/youtube/upload (requires http-prefixed URLs).
+      const toAbs = (u?: string) => (u ? (u.startsWith('http') ? u : getPersoFileUrl(u)) : undefined)
+      const absVideoUrl = toAbs(downloads.videoFile?.videoDownloadLink)
+      const absAudioUrl = toAbs(downloads.audioFile?.voiceAudioDownloadLink)
+      const absSrtUrl = toAbs(downloads.srtFile?.translatedSubtitleDownloadLink)
+
       store.getState().updateLanguageProgress(langCode, {
-        audioUrl: downloads.audioFile?.voiceAudioDownloadLink,
-        srtUrl: downloads.srtFile?.translatedSubtitleDownloadLink,
-        dubbingVideoUrl: downloads.videoFile?.videoDownloadLink,
+        audioUrl: absAudioUrl,
+        srtUrl: absSrtUrl,
+        dubbingVideoUrl: absVideoUrl,
       })
       if (dbJobId) {
         dbMutation({
@@ -146,9 +153,9 @@ async function pollLanguage(
             jobId: dbJobId,
             langCode,
             urls: {
-              dubbedVideoUrl: downloads.videoFile?.videoDownloadLink,
-              audioUrl: downloads.audioFile?.voiceAudioDownloadLink,
-              srtUrl: downloads.srtFile?.translatedSubtitleDownloadLink,
+              dubbedVideoUrl: absVideoUrl,
+              audioUrl: absAudioUrl,
+              srtUrl: absSrtUrl,
             },
           },
         }).catch(() => { /* completion update is best-effort */ })

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -9,7 +9,18 @@ import type {
   LanguageProgress,
   GlossaryEntry,
   JobStatus,
+  UploadSettings,
 } from '../types/dubbing.types'
+
+const DEFAULT_UPLOAD_SETTINGS: UploadSettings = {
+  autoUpload: true,
+  uploadAsShort: false,
+  attachOriginalLink: true,
+  title: '',
+  description: '',
+  tags: ['CreatorDub', 'AI더빙', 'dubbed'],
+  privacyStatus: 'private',
+}
 
 interface DubbingState {
   // Wizard navigation
@@ -63,6 +74,10 @@ interface DubbingState {
   isShort: boolean
   setIsShort: (v: boolean) => void
 
+  // Upload settings (chosen before dubbing starts)
+  uploadSettings: UploadSettings
+  setUploadSettings: (patch: Partial<UploadSettings>) => void
+
   // Glossary
   glossary: GlossaryEntry[]
   addGlossaryEntry: (entry: GlossaryEntry) => void
@@ -88,6 +103,7 @@ const initialState = {
   jobStatus: 'idle' as JobStatus,
   languageProgress: [] as LanguageProgress[],
   glossary: [] as GlossaryEntry[],
+  uploadSettings: { ...DEFAULT_UPLOAD_SETTINGS } as UploadSettings,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -95,7 +111,7 @@ export const useDubbingStore = create<DubbingState>((set) => ({
 
   setStep: (step) => set({ currentStep: step }),
   setIsSubmitted: (v) => set({ isSubmitted: v }),
-  nextStep: () => set((s) => ({ currentStep: Math.min(5, s.currentStep + 1) as DubbingStep })),
+  nextStep: () => set((s) => ({ currentStep: Math.min(6, s.currentStep + 1) as DubbingStep })),
   prevStep: () => set((s) => ({ currentStep: Math.max(1, s.currentStep - 1) as DubbingStep })),
 
   setSpaceSeq: (seq) => set({ spaceSeq: seq }),
@@ -144,7 +160,14 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     })),
 
   setDbJobId: (id) => set({ dbJobId: id }),
-  setIsShort: (v) => set({ isShort: v }),
+  setIsShort: (v) => set((s) => ({
+    isShort: v,
+    uploadSettings: { ...s.uploadSettings, uploadAsShort: v },
+  })),
+
+  setUploadSettings: (patch) => set((s) => ({
+    uploadSettings: { ...s.uploadSettings, ...patch },
+  })),
 
   addGlossaryEntry: (entry) => set((s) => ({ glossary: [...s.glossary, entry] })),
   removeGlossaryEntry: (id) => set((s) => ({ glossary: s.glossary.filter((e) => e.id !== id) })),

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -46,8 +46,10 @@ interface DubbingState {
   setVideoMeta: (meta: VideoMetadata) => void
 
   // Step 2: Language selection
+  sourceLanguage: string
   selectedLanguages: string[]
   lipSyncEnabled: boolean
+  setSourceLanguage: (code: string) => void
   toggleLanguage: (code: string) => void
   setLipSync: (enabled: boolean) => void
 
@@ -94,6 +96,7 @@ const initialState = {
   mediaSeq: null as number | null,
   videoSource: null as VideoSource | null,
   videoMeta: null as VideoMetadata | null,
+  sourceLanguage: 'ko',
   selectedLanguages: [] as string[],
   lipSyncEnabled: false,
   isShort: false,
@@ -120,6 +123,12 @@ export const useDubbingStore = create<DubbingState>((set) => ({
   setVideoSource: (source) => set({ videoSource: source }),
   setVideoMeta: (meta) => set({ videoMeta: meta }),
 
+  setSourceLanguage: (code) =>
+    set((s) => ({
+      sourceLanguage: code,
+      // Target list must not include the source language
+      selectedLanguages: s.selectedLanguages.filter((l) => l !== code),
+    })),
   toggleLanguage: (code) =>
     set((s) => ({
       selectedLanguages: s.selectedLanguages.includes(code)

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -1,4 +1,16 @@
-export type DubbingStep = 1 | 2 | 3 | 4 | 5
+export type DubbingStep = 1 | 2 | 3 | 4 | 5 | 6
+
+export type PrivacyStatus = 'public' | 'unlisted' | 'private'
+
+export interface UploadSettings {
+  autoUpload: boolean
+  uploadAsShort: boolean
+  attachOriginalLink: boolean
+  title: string
+  description: string
+  tags: string[]
+  privacyStatus: PrivacyStatus
+}
 
 export type JobStatus = 'idle' | 'transcribing' | 'translating' | 'synthesizing' | 'lip-syncing' | 'merging' | 'completed' | 'failed'
 


### PR DESCRIPTION
## Summary
- **ScriptEditor**: Perso가 배열이 아닌 응답을 보내도 `.map` 크래시 없이 빈 상태로 표시 (`o.map is not a function` 버그 수정)
- **UploadStep**: 중복되던 "번역된 메타데이터" 섹션 제거 — Step 3(업로드 설정)에서 이미 입력하므로 결과 화면에서는 불필요
- **LanguageSelectStep**: 원본 언어 드롭다운 추가 + 대상 언어 목록이 선택된 원본을 동적으로 제외
- **소스 언어 스레딩**: `dubbingStore.sourceLanguage` 추가, `usePersoFlow`의 모든 `'ko'` 하드코딩을 스토어 값으로 교체
- **/uploads 업로드 모달**: 일반/Shorts/양쪽 3가지 업로드 형식 선택 — 양쪽 선택 시 하나의 영상을 두 번 업로드(일반 + `#Shorts` 제목)

## Notes
- PR #73 (`feat/pre-dubbing-upload-settings`) 위에 쌓은 브랜치입니다. #73 머지 후 develop에 클린하게 리베이스됩니다.
- 기존 `ScriptEditor` lint 경고/에러는 건드리지 않았고(기존 상태 유지), 내 변경이 새로 만들어낸 lint 이슈는 없습니다.
- `api-client.test.ts`의 타입 에러는 이 PR 이전부터 존재하던 이슈로 별도 PR이 필요합니다.

## Test plan
- [ ] 결과 화면에서 "스크립트 수정" 클릭 — Perso가 어떤 응답을 보내도 크래시 없음
- [ ] 새 더빙 시작 시 Step 2에서 원본 언어를 영어로 선택 → Step 4 요약이 영어로 보임
- [ ] 원본 언어를 바꾸면 대상 언어 그리드에서 해당 언어가 사라지는지
- [ ] /uploads 모달에서 "일반 + Shorts 양쪽" 선택 → 한 언어당 2개 YouTube 영상 생성 확인
- [ ] 기존 "일반 영상" 경로 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)