### PR TITLE
fix(security): OAuth CSRF + 크레딧 서버 검증 + 에러 누출 차단

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -40,8 +40,7 @@ export async function POST(req: NextRequest) {
     })
 
     if (!tokenRes.ok) {
-      const err = await tokenRes.text()
-      return apiFail('TOKEN_EXCHANGE_FAILED', `Google token exchange failed: ${err}`, 401)
+      return apiFail('TOKEN_EXCHANGE_FAILED', 'Google token exchange failed', 401)
     }
 
     const tokens = (await tokenRes.json()) as {

--- a/src/app/api/dashboard/credit-usage/route.ts
+++ b/src/app/api/dashboard/credit-usage/route.ts
@@ -23,8 +23,7 @@ export async function GET(req: NextRequest) {
   try {
     const data = await getCreditUsageByMonth(auth.session.uid)
     return apiOk(data)
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return apiFail('DB_ERROR', message, 500)
+  } catch {
+    return apiFail('DB_ERROR', 'Failed to load credit usage', 500)
   }
 }

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -92,7 +92,15 @@ export async function POST(req: NextRequest) {
         return apiOk({ jobId, langCode })
       }
       case 'deductUserMinutes': {
-        const { userId, minutes } = action.payload
+        const { userId, jobId: deductJobId, minutes: clientMinutes } = action.payload
+        const deductDb = getDb()
+        const jobRow = await deductDb.execute({
+          sql: 'SELECT video_duration_ms FROM dubbing_jobs WHERE id = ? AND user_id = ?',
+          args: [deductJobId, auth.session.uid],
+        })
+        const durationMs = (jobRow.rows[0]?.video_duration_ms as number) || 0
+        const serverMinutes = Math.max(1, Math.ceil(durationMs / 60_000))
+        const minutes = Math.min(clientMinutes, serverMinutes)
         await deductUserMinutes(userId, minutes)
         return apiOk({ userId, minutes })
       }

--- a/src/app/api/dashboard/summary/route.ts
+++ b/src/app/api/dashboard/summary/route.ts
@@ -23,8 +23,7 @@ export async function GET(req: NextRequest) {
   try {
     const data = await getUserSummary(auth.session.uid)
     return apiOk(data)
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Internal Server Error'
-    return apiFail('DB_ERROR', message, 500)
+  } catch {
+    return apiFail('DB_ERROR', 'Failed to load summary', 500)
   }
 }

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -11,10 +11,11 @@ export default function AuthCallbackPage() {
     const params = new URLSearchParams(window.location.search)
     const code = params.get('code')
     const error = params.get('error')
+    const state = params.get('state')
 
     if (window.opener) {
       window.opener.postMessage(
-        { type: 'google_oauth_callback', code, error },
+        { type: 'google_oauth_callback', code, error, state },
         window.location.origin,
       )
     }

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -170,8 +170,8 @@ async function pollLanguage(
   const userId = useAuthStore.getState().user?.uid
   const durationMs = store.getState().videoMeta?.durationMs || 0
   const minutesUsed = Math.max(1, Math.ceil(durationMs / 60_000))
-  if (userId) {
-    await dbMutation({ type: 'deductUserMinutes', payload: { userId, minutes: minutesUsed } })
+  if (userId && dbJobId) {
+    await dbMutation({ type: 'deductUserMinutes', payload: { userId, minutes: minutesUsed, jobId: dbJobId } })
   }
   if (dbJobId) {
     await dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: anyFailed ? 'failed' : 'completed' } })

--- a/src/lib/auth/token-refresh.ts
+++ b/src/lib/auth/token-refresh.ts
@@ -53,10 +53,10 @@ export async function getOrRefreshAccessToken(
     return tokens.accessToken
   }
 
-  if (!tokens.refreshToken) return tokens.accessToken
+  if (!tokens.refreshToken) return null
 
   const refreshed = await refreshGoogleToken(tokens.refreshToken)
-  if (!refreshed) return tokens.accessToken
+  if (!refreshed) return null
 
   const expiresAt = new Date(
     Date.now() + refreshed.expiresIn * 1000,

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -45,6 +45,9 @@ export async function signInWithGoogle(): Promise<{
       'https://www.googleapis.com/auth/yt-analytics.readonly',
     ].join(' ')
 
+    const stateNonce = crypto.randomUUID()
+    sessionStorage.setItem('oauth_state', stateNonce)
+
     const authUrl =
       `https://accounts.google.com/o/oauth2/v2/auth?` +
       `client_id=${encodeURIComponent(clientId)}` +
@@ -53,7 +56,8 @@ export async function signInWithGoogle(): Promise<{
       `&scope=${encodeURIComponent(scope)}` +
       `&access_type=offline` +
       `&include_granted_scopes=true` +
-      `&prompt=consent`
+      `&prompt=consent` +
+      `&state=${encodeURIComponent(stateNonce)}`
 
     const popup = window.open(authUrl, 'google_auth', 'width=500,height=600')
     if (!popup) {
@@ -69,7 +73,7 @@ export async function signInWithGoogle(): Promise<{
       window.removeEventListener('message', onMessage)
       clearInterval(closedTimer)
 
-      const { code, error } = event.data
+      const { code, error, state: returnedState } = event.data
 
       if (error) {
         reject(new Error(`Google 인증 오류: ${error}`))
@@ -77,6 +81,13 @@ export async function signInWithGoogle(): Promise<{
       }
       if (!code) {
         reject(new Error('인증 코드를 받지 못했습니다.'))
+        return
+      }
+
+      const expectedState = sessionStorage.getItem('oauth_state')
+      sessionStorage.removeItem('oauth_state')
+      if (!expectedState || returnedState !== expectedState) {
+        reject(new Error('OAuth state 불일치 — CSRF 방지를 위해 요청이 거부되었습니다.'))
         return
       }
 

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -98,15 +98,18 @@ const deductUserMinutesSchema = z.object({
   type: z.literal('deductUserMinutes'),
   payload: z.object({
     userId: z.string().min(1),
+    jobId: z.number().int(),
     minutes: z.number().int().positive(),
   }),
 })
+
+const CREDIT_PACK_MAX = 120 // must match max value in CREDIT_PACKS
 
 const addCreditsSchema = z.object({
   type: z.literal('addCredits'),
   payload: z.object({
     userId: z.string().min(1),
-    minutes: z.number().int().positive(),
+    minutes: z.number().int().positive().max(CREDIT_PACK_MAX),
   }),
 })
 
@@ -166,6 +169,8 @@ export function getJobIdFromAction(action: MutationAction): number | null {
     case 'updateJobLanguageYouTube':
       return action.payload.jobId
     case 'deleteDubbingJob':
+      return action.payload.jobId
+    case 'deductUserMinutes':
       return action.payload.jobId
     default:
       return null


### PR DESCRIPTION
## Summary
- **OAuth CSRF 방지**: `state` nonce를 sessionStorage에 생성·저장 → Google redirect에 포함 → callback에서 검증. 불일치 시 인증 거부
- **addCredits 제한**: Zod 스키마에 `max(120)` (CREDIT_PACKS 최대치) 캡 적용. 결제 연동 전까지 무제한 크레딧 추가 방지
- **deductUserMinutes 서버 검증**: `jobId` 필수화 → 서버가 `dubbing_jobs.video_duration_ms`에서 분 계산 → 클라 값보다 큰 차감 불가. 소유권 검증도 추가
- **token-refresh**: 리프레시 실패/refreshToken 없을 때 만료 토큰 대신 `null` 반환 → 세션 복원 로직이 올바르게 re-auth 요청
- **에러 누출 차단**: callback·summary·credit-usage 라우트에서 raw 에러 메시지 대신 제네릭 메시지 반환

## Risk
- OAuth state: 기존 로그인 플로우 전체 회귀 테스트 필요 (popup → callback → postMessage 체인)
- deductUserMinutes: 클라이언트(`usePersoFlow`)가 `jobId` 없이 호출하면 deduct 스킵됨 (의도적 — jobId 없으면 차감 불가)

## Test plan
- [ ] Google 로그인 → 정상 코드+state 받아 세션 생성됨
- [ ] 브라우저 devtools에서 sessionStorage `oauth_state` 확인 → callback 후 삭제됨
- [ ] 결제 페이지 120분 초과 pack 시도 → 서버 400 에러 (현재 UI는 120 max라 트리거 불가하지만 API 직접 호출 시 차단)
- [ ] 더빙 완료 → 크레딧 차감이 영상 길이 기준으로 정상 적용
- [ ] /api/dashboard/summary 에러 시 raw SQL 에러 아닌 제네릭 메시지 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)