### PR TITLE
fix(misc): 외부 업로드 타임아웃 + toast 정리 + BCP-47 자막 코드

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -11,6 +11,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
 import { ytUploadVideo, ytUploadCaption, getDownloadLinks, getPersoFileUrl } from '@/lib/api-client'
+import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { getLanguageByCode } from '@/utils/languages'
 import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
@@ -190,7 +191,7 @@ function UploadRow({ item, userId }: UploadRowProps) {
           const srtText = await srtRes.text()
           await ytUploadCaption({
             videoId: result.videoId,
-            language: item.language_code,
+            language: toBcp47(item.language_code),
             name: `${langName} subtitles`,
             srtContent: srtText,
           })

--- a/src/app/api/perso/external/upload/route.ts
+++ b/src/app/api/perso/external/upload/route.ts
@@ -7,7 +7,7 @@ import type { UploadVideoResponse } from '@/lib/perso/types'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-export const maxDuration = 300
+export const maxDuration = 600
 
 export async function PUT(req: NextRequest) {
   const auth = await requireSession(req)

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -11,6 +11,7 @@ import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
 import { useAuthStore } from '@/stores/authStore'
 import { ytUploadVideo, ytUploadCaption } from '@/lib/api-client'
+import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
 import { ScriptEditor } from '../ScriptEditor'
 
@@ -171,7 +172,7 @@ export function UploadStep() {
           const srtText = await srtResponse.text()
           await ytUploadCaption({
             videoId: result.videoId,
-            language: langCode,
+            language: toBcp47(langCode),
             name: `${lang.name} subtitles`,
             srtContent: srtText,
           })

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -73,9 +73,9 @@ describe('getPersoFileUrl', () => {
 })
 
 describe('ytFetchAnalytics', () => {
-  it('fetches analytics with videoIds and userId', async () => {
+  it('fetches analytics with videoIds', async () => {
     mockFetch.mockResolvedValueOnce(okResponse([{ videoId: 'v1', daily: [], countries: [], totals: {} }]))
-    const result = await ytFetchAnalytics(['v1'], 'user1')
+    const result = await ytFetchAnalytics(['v1'])
     expect(result).toHaveLength(1)
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/youtube/analytics?'),
@@ -83,12 +83,11 @@ describe('ytFetchAnalytics', () => {
     )
     const url = mockFetch.mock.calls[0][0] as string
     expect(url).toContain('videoIds=v1')
-    expect(url).toContain('userId=user1')
   })
 
   it('includes optional date range', async () => {
     mockFetch.mockResolvedValueOnce(okResponse([]))
-    await ytFetchAnalytics(['v1'], 'u1', '2026-01-01', '2026-01-31')
+    await ytFetchAnalytics(['v1'], '2026-01-01', '2026-01-31')
     const url = mockFetch.mock.calls[0][0] as string
     expect(url).toContain('startDate=2026-01-01')
     expect(url).toContain('endDate=2026-01-31')
@@ -96,7 +95,7 @@ describe('ytFetchAnalytics', () => {
 
   it('throws on error response', async () => {
     mockFetch.mockResolvedValueOnce(errorResponse('QUOTA', 'Quota exceeded', 429))
-    await expect(ytFetchAnalytics(['v1'], 'u1')).rejects.toThrow('Quota exceeded')
+    await expect(ytFetchAnalytics(['v1'])).rejects.toThrow('Quota exceeded')
   })
 })
 

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -20,6 +20,7 @@ interface NotificationState {
 }
 
 let toastId = 0
+const timers = new Map<string, ReturnType<typeof setTimeout>>()
 
 export const useNotificationStore = create<NotificationState>((set) => ({
   toasts: [],
@@ -28,11 +29,23 @@ export const useNotificationStore = create<NotificationState>((set) => ({
     set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }))
     const duration = toast.duration ?? 4000
     if (duration > 0) {
-      setTimeout(() => {
-        set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }))
-      }, duration)
+      timers.set(
+        id,
+        setTimeout(() => {
+          timers.delete(id)
+          set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }))
+        }, duration),
+      )
     }
   },
-  removeToast: (id) => set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
-  clearAll: () => set({ toasts: [] }),
+  removeToast: (id) => {
+    const timer = timers.get(id)
+    if (timer) { clearTimeout(timer); timers.delete(id) }
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }))
+  },
+  clearAll: () => {
+    timers.forEach(clearTimeout)
+    timers.clear()
+    set({ toasts: [] })
+  },
 }))

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -23,3 +23,12 @@ export const SUPPORTED_LANGUAGES: Language[] = [
 export function getLanguageByCode(code: string): Language | undefined {
   return SUPPORTED_LANGUAGES.find((l) => l.code === code)
 }
+
+const BCP47_MAP: Record<string, string> = {
+  zh: 'zh-Hans',
+  pt: 'pt-BR',
+}
+
+export function toBcp47(persoCode: string): string {
+  return BCP47_MAP[persoCode] || persoCode
+}


### PR DESCRIPTION
## Summary
- **External upload maxDuration**: `300` → `600`초로 수정, `persoFetch` timeoutMs(600s)와 일치. 기존에는 Next.js가 5분에 route를 강제 종료해서 10분짜리 외부 영상 가져오기가 실패할 수 있었음
- **notificationStore toast 타이머**: `Map`으로 타이머 ID 추적 → `removeToast()`/`clearAll()` 시 `clearTimeout` 호출. 조기 삭제된 toast의 고아 타이머 정리
- **YouTube BCP-47 자막 코드**: `toBcp47()` 유틸 추가. Perso `zh`→YouTube `zh-Hans`, `pt`→`pt-BR` 변환. 자막 업로드가 YouTube에서 잘못 태그되는 문제 방지
- UploadStep + /uploads 모달 모두 `ytUploadCaption` 호출에 `toBcp47()` 적용

## Test plan
- [ ] 10분 이상 외부 영상 URL 가져오기 → 타임아웃 없이 완료
- [ ] toast 여러 개 빠르게 생성 후 clearAll → 콘솔에 orphan update 없음
- [ ] 중국어/포르투갈어 더빙 → YouTube 자막이 올바른 언어로 태그됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)