### PR TITLE
[#86] 테스트 19건 실패 수정 — 환경변수 stub 및 계약 drift 해소

### DIFF
--- a/src/app/api/auth/auth-sync.test.ts
+++ b/src/app/api/auth/auth-sync.test.ts
@@ -7,17 +7,32 @@ vi.mock('@/lib/db/queries', () => ({
 vi.mock('@/lib/auth/session-cookie', () => ({
   SESSION_COOKIE: 'creatordub_session',
   signSessionCookie: vi.fn((uid: string) => `${uid}.fakesig`),
+  verifySessionCookie: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/token-refresh', () => ({
+  getOrRefreshAccessToken: vi.fn(),
 }))
 
 import { POST } from './sync/route'
 import { upsertUser } from '@/lib/db/queries'
 import { NextRequest } from 'next/server'
 
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
 function makeReq(body: unknown) {
   return new NextRequest('http://localhost/api/auth/sync', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+  })
+}
+
+function mockGoogleUserinfo(sub: string, email: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ sub, email }),
   })
 }
 
@@ -55,7 +70,8 @@ describe('POST /api/auth/sync', () => {
   })
 
   it('returns 200 with valid body and sets session cookie', async () => {
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', displayName: 'Test' }))
+    mockGoogleUserinfo('u1', 'a@b.com')
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', displayName: 'Test', accessToken: 'tok-valid' }))
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data.ok).toBe(true)
@@ -65,7 +81,7 @@ describe('POST /api/auth/sync', () => {
       email: 'a@b.com',
       displayName: 'Test',
       photoURL: null,
-      accessToken: null,
+      accessToken: 'tok-valid',
     })
 
     const setCookie = res.headers.getSetCookie()
@@ -73,6 +89,7 @@ describe('POST /api/auth/sync', () => {
   })
 
   it('sets google_access_token cookie when provided', async () => {
+    mockGoogleUserinfo('u1', 'a@b.com')
     const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', accessToken: 'tok123' }))
     expect(res.status).toBe(200)
     const setCookie = res.headers.getSetCookie()
@@ -80,8 +97,9 @@ describe('POST /api/auth/sync', () => {
   })
 
   it('returns 500 on DB error', async () => {
+    mockGoogleUserinfo('u1', 'a@b.com')
     vi.mocked(upsertUser).mockRejectedValueOnce(new Error('DB down'))
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com', accessToken: 'tok-valid' }))
     expect(res.status).toBe(500)
     const data = await res.json()
     expect(data.ok).toBe(false)

--- a/src/app/api/dashboard/dashboard-routes.test.ts
+++ b/src/app/api/dashboard/dashboard-routes.test.ts
@@ -28,6 +28,12 @@ vi.mock('@/lib/db/queries', () => ({
   updateJobLanguageYouTube: vi.fn(),
 }))
 
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({
+    execute: vi.fn(async () => ({ rows: [{ user_id: 'user1' }] })),
+  })),
+}))
+
 vi.mock('@/lib/youtube/server', () => ({
   fetchVideoStatistics: vi.fn(async () => []),
   YouTubeError: class YouTubeError extends Error {
@@ -124,7 +130,7 @@ describe('/api/dashboard/summary', () => {
     const res = await GET(req)
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error.message).toBe('Internal Server Error')
+    expect(body.error.message).toBe('Failed to load summary')
   })
 })
 
@@ -174,7 +180,7 @@ describe('/api/dashboard/jobs', () => {
     const res = await GET(req)
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error.code).toBe('DB_ERROR')
+    expect(body.error.code).toBe('INTERNAL_ERROR')
   })
 
   it('returns generic message when non-Error is thrown', async () => {
@@ -246,7 +252,7 @@ describe('/api/dashboard/credit-usage', () => {
     const res = await GET(req)
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error.message).toBe('Internal Server Error')
+    expect(body.error.message).toBe('Failed to load credit usage')
   })
 })
 
@@ -364,7 +370,7 @@ describe('/api/dashboard/language-performance', () => {
     const res = await GET(req)
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error.code).toBe('DB_ERROR')
+    expect(body.error.code).toBe('INTERNAL_ERROR')
   })
 
   it('returns generic message when non-Error is thrown from outer catch', async () => {
@@ -643,7 +649,7 @@ describe('/api/dashboard/mutations', () => {
     const res = await POST(req)
     expect(res.status).toBe(500)
     const body = await res.json()
-    expect(body.error.code).toBe('DB_ERROR')
+    expect(body.error.code).toBe('INTERNAL_ERROR')
   })
 
   it('returns generic message when non-Error is thrown from DB', async () => {

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -62,7 +62,7 @@ describe('requireSession', () => {
     if (!result.ok) {
       const body = await result.response.json()
       expect(body.error.code).toBe('UNAUTHORIZED')
-      expect(body.error.message).toContain('Invalid or expired')
+      expect(body.error.message).toContain('Missing or expired')
     }
   })
 
@@ -78,20 +78,20 @@ describe('requireSession', () => {
     if (!result.ok) {
       const body = await result.response.json()
       expect(body.error.code).toBe('UNAUTHORIZED')
-      expect(body.error.message).toContain('missing required claims')
+      expect(body.error.message).toContain('Missing or expired')
     }
   })
 
-  it('returns 500 when fetch throws', async () => {
+  it('returns 401 when fetch throws', async () => {
     mockFetch.mockRejectedValueOnce(new Error('network error'))
 
     const req = makeReq({ cookie: 'some-token' })
     const result = await requireSession(req)
     expect(result.ok).toBe(false)
     if (!result.ok) {
-      expect(result.response.status).toBe(500)
+      expect(result.response.status).toBe(401)
       const body = await result.response.json()
-      expect(body.error.code).toBe('AUTH_ERROR')
+      expect(body.error.code).toBe('UNAUTHORIZED')
     }
   })
 

--- a/src/lib/auth/token-refresh.test.ts
+++ b/src/lib/auth/token-refresh.test.ts
@@ -107,14 +107,14 @@ describe('getOrRefreshAccessToken', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('returns existing token when expired but no refresh token', async () => {
+  it('returns null when expired but no refresh token', async () => {
     vi.mocked(getUserTokens).mockResolvedValueOnce({
       accessToken: 'old-at',
       refreshToken: null,
       tokenExpiresAt: '2020-01-01T00:00:00.000Z',
     })
     const result = await getOrRefreshAccessToken('user-1')
-    expect(result).toBe('old-at')
+    expect(result).toBeNull()
   })
 
   it('refreshes and updates DB when token is expired', async () => {
@@ -137,7 +137,7 @@ describe('getOrRefreshAccessToken', () => {
     )
   })
 
-  it('falls back to old token when refresh fails', async () => {
+  it('returns null when refresh fails', async () => {
     vi.mocked(getUserTokens).mockResolvedValueOnce({
       accessToken: 'old-at',
       refreshToken: 'rt-bad',
@@ -146,6 +146,6 @@ describe('getOrRefreshAccessToken', () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
 
     const result = await getOrRefreshAccessToken('user-1')
-    expect(result).toBe('old-at')
+    expect(result).toBeNull()
   })
 })

--- a/src/lib/youtube/route-helpers.test.ts
+++ b/src/lib/youtube/route-helpers.test.ts
@@ -42,7 +42,7 @@ describe('ytFail', () => {
     const res = ytFail(new Error('something broke'))
     const body = await res.json()
     expect(res.status).toBe(500)
-    expect(body.error).toEqual({ code: 'INTERNAL_ERROR', message: 'something broke', details: null })
+    expect(body.error).toEqual({ code: 'INTERNAL_ERROR', message: 'Internal Server Error', details: null })
   })
 
   it('handles non-Error values', async () => {


### PR DESCRIPTION
## 개요
- 이슈: #86
- 요약: Vitest 19건 실패를 모두 수정하여 436/436 테스트 통과 달성

## 변경 내용
- `session.test.ts`: 통합 에러 메시지/상태코드에 맞춰 3건 기대값 수정
- `token-refresh.test.ts`: refresh 불가 시 null 반환 동작에 맞춰 2건 수정
- `auth-sync.test.ts`: Google 토큰 검증 flow에 맞춰 fetch mock + accessToken 추가 (3건)
- `route-helpers.test.ts`: 500 에러 message 마스킹에 맞춰 1건 수정
- `dashboard-routes.test.ts`: apiFailFromError 정규화(INTERNAL_ERROR), 커스텀 catch 메시지, getDb() mock 추가 (10건)

## 검증
- [x] `npm test` — 436 passed, 0 failed
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과

## 리스크 / 팔로업
- 없음. 테스트 기대값만 수정, 구현 코드 변경 없음.