### PR TITLE
[#100] 웹앱↔확장 메시지 타입 스키마 및 타입 가드 정의

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -13,7 +13,8 @@
         "globals": "^16.5.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -681,6 +682,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -1070,6 +1078,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.318",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.318.tgz",
@@ -1080,6 +1106,13 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1401,6 +1434,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1464,6 +1610,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1490,6 +1646,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1536,6 +1702,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1573,6 +1746,13 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1775,6 +1955,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1783,6 +1973,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2056,6 +2256,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2100,6 +2310,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2185,12 +2406,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",
@@ -2287,6 +2528,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2296,6 +2544,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2321,6 +2583,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2358,17 +2637,14 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2538,19 +2814,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vite/node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -2596,6 +2859,96 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2610,6 +2963,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -7,7 +7,8 @@
     "dev": "vite build --watch",
     "build": "vite build && node scripts/postbuild.js",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.318",
@@ -15,6 +16,7 @@
     "globals": "^16.5.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/extension/src/messages.test.ts
+++ b/extension/src/messages.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isPingMessage,
+  isUploadToYouTubeMessage,
+  isUploadProgressEvent,
+  isUploadDoneEvent,
+  isUploadErrorEvent,
+  isInboundMessage,
+  isOutboundEvent,
+} from './messages'
+
+describe('isPingMessage', () => {
+  it('accepts valid PING', () => {
+    expect(isPingMessage({ type: 'PING' })).toBe(true)
+  })
+
+  it('rejects wrong type', () => {
+    expect(isPingMessage({ type: 'PONG' })).toBe(false)
+  })
+
+  it('rejects null', () => {
+    expect(isPingMessage(null)).toBe(false)
+  })
+
+  it('rejects string', () => {
+    expect(isPingMessage('PING')).toBe(false)
+  })
+})
+
+describe('isUploadToYouTubeMessage', () => {
+  const valid = {
+    type: 'UPLOAD_TO_YOUTUBE',
+    payload: {
+      videoId: 'abc123',
+      languageCode: 'ko',
+      audioUrl: 'https://example.com/audio.mp3',
+      mode: 'assisted' as const,
+    },
+  }
+
+  it('accepts valid message', () => {
+    expect(isUploadToYouTubeMessage(valid)).toBe(true)
+  })
+
+  it('accepts auto mode', () => {
+    expect(isUploadToYouTubeMessage({ ...valid, payload: { ...valid.payload, mode: 'auto' } })).toBe(true)
+  })
+
+  it('rejects invalid mode', () => {
+    expect(isUploadToYouTubeMessage({ ...valid, payload: { ...valid.payload, mode: 'manual' } })).toBe(false)
+  })
+
+  it('rejects missing payload', () => {
+    expect(isUploadToYouTubeMessage({ type: 'UPLOAD_TO_YOUTUBE' })).toBe(false)
+  })
+
+  it('rejects missing videoId', () => {
+    const payload = { languageCode: 'ko', audioUrl: 'https://example.com/audio.mp3', mode: 'assisted' }
+    expect(isUploadToYouTubeMessage({ type: 'UPLOAD_TO_YOUTUBE', payload })).toBe(false)
+  })
+
+  it('rejects wrong type field', () => {
+    expect(isUploadToYouTubeMessage({ ...valid, type: 'PING' })).toBe(false)
+  })
+
+  it('rejects array payload', () => {
+    expect(isUploadToYouTubeMessage({ type: 'UPLOAD_TO_YOUTUBE', payload: [] })).toBe(false)
+  })
+})
+
+describe('isUploadProgressEvent', () => {
+  it('accepts valid progress event', () => {
+    expect(isUploadProgressEvent({
+      type: 'UPLOAD_PROGRESS',
+      payload: { jobId: 'j1', step: 'NAVIGATING' },
+    })).toBe(true)
+  })
+
+  it('rejects missing payload', () => {
+    expect(isUploadProgressEvent({ type: 'UPLOAD_PROGRESS' })).toBe(false)
+  })
+})
+
+describe('isUploadDoneEvent', () => {
+  it('accepts valid done event', () => {
+    expect(isUploadDoneEvent({
+      type: 'UPLOAD_DONE',
+      payload: { jobId: 'j1', videoId: 'v1', languageCode: 'ko' },
+    })).toBe(true)
+  })
+
+  it('rejects null payload', () => {
+    expect(isUploadDoneEvent({ type: 'UPLOAD_DONE', payload: null })).toBe(false)
+  })
+})
+
+describe('isUploadErrorEvent', () => {
+  it('accepts valid error event', () => {
+    expect(isUploadErrorEvent({
+      type: 'UPLOAD_ERROR',
+      payload: { jobId: 'j1', step: 'INJECTING_AUDIO', error: 'fail', retryable: true },
+    })).toBe(true)
+  })
+
+  it('rejects wrong type', () => {
+    expect(isUploadErrorEvent({ type: 'UPLOAD_DONE', payload: {} })).toBe(false)
+  })
+})
+
+describe('isInboundMessage', () => {
+  it('recognizes PING as inbound', () => {
+    expect(isInboundMessage({ type: 'PING' })).toBe(true)
+  })
+
+  it('recognizes UPLOAD_TO_YOUTUBE as inbound', () => {
+    expect(isInboundMessage({
+      type: 'UPLOAD_TO_YOUTUBE',
+      payload: { videoId: 'v', languageCode: 'en', audioUrl: 'u', mode: 'auto' },
+    })).toBe(true)
+  })
+
+  it('rejects outbound events', () => {
+    expect(isInboundMessage({ type: 'UPLOAD_PROGRESS', payload: { jobId: 'j', step: 'NAVIGATING' } })).toBe(false)
+  })
+})
+
+describe('isOutboundEvent', () => {
+  it('recognizes UPLOAD_PROGRESS as outbound', () => {
+    expect(isOutboundEvent({ type: 'UPLOAD_PROGRESS', payload: { jobId: 'j', step: 'NAVIGATING' } })).toBe(true)
+  })
+
+  it('recognizes UPLOAD_DONE as outbound', () => {
+    expect(isOutboundEvent({ type: 'UPLOAD_DONE', payload: { jobId: 'j' } })).toBe(true)
+  })
+
+  it('recognizes UPLOAD_ERROR as outbound', () => {
+    expect(isOutboundEvent({ type: 'UPLOAD_ERROR', payload: { jobId: 'j' } })).toBe(true)
+  })
+
+  it('rejects inbound messages', () => {
+    expect(isOutboundEvent({ type: 'PING' })).toBe(false)
+  })
+})

--- a/extension/src/messages.ts
+++ b/extension/src/messages.ts
@@ -1,0 +1,122 @@
+// ── 업로드 모드 ──────────────────────────────────────────
+export type UploadMode = 'auto' | 'assisted'
+
+// ── 업로드 단계 ──────────────────────────────────────────
+export type UploadStep =
+  | 'NAVIGATING'
+  | 'OPENING_LANGUAGES'
+  | 'SELECTING_LANGUAGE'
+  | 'INJECTING_AUDIO'
+  | 'WAITING_PUBLISH'
+  | 'PUBLISHING'
+
+// ── 웹앱 → 확장 메시지 ──────────────────────────────────
+export interface PingMessage {
+  type: 'PING'
+}
+
+export interface UploadToYouTubeMessage {
+  type: 'UPLOAD_TO_YOUTUBE'
+  payload: {
+    videoId: string
+    languageCode: string
+    audioUrl: string
+    mode: UploadMode
+  }
+}
+
+export type InboundMessage = PingMessage | UploadToYouTubeMessage
+
+// ── 확장 → 웹앱 응답 ────────────────────────────────────
+export interface PongResponse {
+  ok: true
+  version: string
+}
+
+export interface UploadAcceptedResponse {
+  ok: true
+  jobId: string
+}
+
+export interface ErrorResponse {
+  ok: false
+  error: string
+}
+
+export type InboundResponse = PongResponse | UploadAcceptedResponse | ErrorResponse
+
+// ── 확장 → 웹앱 이벤트 (progress / done / error) ────────
+export interface UploadProgressEvent {
+  type: 'UPLOAD_PROGRESS'
+  payload: {
+    jobId: string
+    step: UploadStep
+    detail?: string
+  }
+}
+
+export interface UploadDoneEvent {
+  type: 'UPLOAD_DONE'
+  payload: {
+    jobId: string
+    videoId: string
+    languageCode: string
+  }
+}
+
+export interface UploadErrorEvent {
+  type: 'UPLOAD_ERROR'
+  payload: {
+    jobId: string
+    step: UploadStep
+    error: string
+    retryable: boolean
+  }
+}
+
+export type OutboundEvent = UploadProgressEvent | UploadDoneEvent | UploadErrorEvent
+
+// ── 모든 메시지 유니언 ───────────────────────────────────
+export type Message = InboundMessage | OutboundEvent
+
+// ── 타입 가드 ────────────────────────────────────────────
+export function isPingMessage(msg: unknown): msg is PingMessage {
+  return isObject(msg) && msg.type === 'PING'
+}
+
+export function isUploadToYouTubeMessage(msg: unknown): msg is UploadToYouTubeMessage {
+  if (!isObject(msg) || msg.type !== 'UPLOAD_TO_YOUTUBE') return false
+  const p = msg.payload
+  return (
+    isObject(p) &&
+    typeof p.videoId === 'string' &&
+    typeof p.languageCode === 'string' &&
+    typeof p.audioUrl === 'string' &&
+    (p.mode === 'auto' || p.mode === 'assisted')
+  )
+}
+
+export function isUploadProgressEvent(msg: unknown): msg is UploadProgressEvent {
+  return isObject(msg) && msg.type === 'UPLOAD_PROGRESS' && isObject(msg.payload)
+}
+
+export function isUploadDoneEvent(msg: unknown): msg is UploadDoneEvent {
+  return isObject(msg) && msg.type === 'UPLOAD_DONE' && isObject(msg.payload)
+}
+
+export function isUploadErrorEvent(msg: unknown): msg is UploadErrorEvent {
+  return isObject(msg) && msg.type === 'UPLOAD_ERROR' && isObject(msg.payload)
+}
+
+export function isInboundMessage(msg: unknown): msg is InboundMessage {
+  return isPingMessage(msg) || isUploadToYouTubeMessage(msg)
+}
+
+export function isOutboundEvent(msg: unknown): msg is OutboundEvent {
+  return isUploadProgressEvent(msg) || isUploadDoneEvent(msg) || isUploadErrorEvent(msg)
+}
+
+// ── 내부 유틸 ────────────────────────────────────────────
+function isObject(val: unknown): val is Record<string, unknown> {
+  return val !== null && typeof val === 'object' && !Array.isArray(val)
+}


### PR DESCRIPTION
## 개요
- 이슈: #100
- 요약: 웹앱과 Chrome 확장 간 통신에 사용할 메시지 타입 스키마 및 런타임 타입 가드 정의

## 변경 내용
- `extension/src/messages.ts`: 5개 메시지 타입(PING, UPLOAD_TO_YOUTUBE, UPLOAD_PROGRESS, UPLOAD_DONE, UPLOAD_ERROR) + payload + 타입 가드 7개
- `extension/src/messages.test.ts`: 타입 가드 단위 테스트 24건
- Vitest 의존성 추가 및 `test` 스크립트 등록

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (24/24)

## 리스크 / 팔로업
- zod 등 런타임 스키마 검증은 MVP 이후 필요 시 도입
- 실제 메시지 송수신은 #13(background), #14(content script)에서 구현