### PR TITLE
[#102] background 서비스 워커 기본 로직 — 메시지 수신 및 탭 관리

### DIFF
--- a/extension/src/background-types.ts
+++ b/extension/src/background-types.ts
@@ -1,0 +1,12 @@
+export interface Job {
+  jobId: string
+  videoId: string
+  languageCode: string
+  audioUrl: string
+  mode: 'auto' | 'assisted'
+  tabId: number | null
+  status: 'pending' | 'running' | 'done' | 'error'
+  createdAt: number
+}
+
+export const STORAGE_KEY = 'creatordub_jobs'

--- a/extension/src/background-utils.ts
+++ b/extension/src/background-utils.ts
@@ -1,0 +1,25 @@
+import type { Job } from './background-types'
+
+export function generateJobId(): string {
+  return `job_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function buildStudioUrl(videoId: string): string {
+  return `https://studio.youtube.com/video/${videoId}/translations`
+}
+
+export function createJob(
+  jobId: string,
+  payload: { videoId: string; languageCode: string; audioUrl: string; mode: 'auto' | 'assisted' },
+): Job {
+  return {
+    jobId,
+    videoId: payload.videoId,
+    languageCode: payload.languageCode,
+    audioUrl: payload.audioUrl,
+    mode: payload.mode,
+    tabId: null,
+    status: 'pending',
+    createdAt: Date.now(),
+  }
+}

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { generateJobId, buildStudioUrl, createJob } from './background-utils'
+
+describe('generateJobId', () => {
+  it('starts with "job_" prefix', () => {
+    expect(generateJobId()).toMatch(/^job_/)
+  })
+
+  it('contains a timestamp segment', () => {
+    const before = Date.now()
+    const id = generateJobId()
+    const after = Date.now()
+    const timestamp = Number(id.split('_')[1])
+    expect(timestamp).toBeGreaterThanOrEqual(before)
+    expect(timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('generates unique IDs', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateJobId()))
+    expect(ids.size).toBe(100)
+  })
+})
+
+describe('buildStudioUrl', () => {
+  it('builds correct YouTube Studio translations URL', () => {
+    expect(buildStudioUrl('abc123')).toBe(
+      'https://studio.youtube.com/video/abc123/translations',
+    )
+  })
+
+  it('handles videoId with hyphens and underscores', () => {
+    expect(buildStudioUrl('a-B_c1')).toBe(
+      'https://studio.youtube.com/video/a-B_c1/translations',
+    )
+  })
+})
+
+describe('createJob', () => {
+  it('creates a job with pending status', () => {
+    const job = createJob('job_123', {
+      videoId: 'vid1',
+      languageCode: 'ko',
+      audioUrl: 'https://example.com/audio.mp3',
+      mode: 'assisted',
+    })
+
+    expect(job.jobId).toBe('job_123')
+    expect(job.videoId).toBe('vid1')
+    expect(job.languageCode).toBe('ko')
+    expect(job.mode).toBe('assisted')
+    expect(job.tabId).toBeNull()
+    expect(job.status).toBe('pending')
+    expect(job.createdAt).toBeGreaterThan(0)
+  })
+
+  it('sets auto mode correctly', () => {
+    const job = createJob('job_456', {
+      videoId: 'vid2',
+      languageCode: 'en',
+      audioUrl: 'https://example.com/audio2.mp3',
+      mode: 'auto',
+    })
+    expect(job.mode).toBe('auto')
+  })
+})

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,15 +1,150 @@
+import type {
+  UploadToYouTubeMessage,
+  UploadProgressEvent,
+  UploadDoneEvent,
+  UploadErrorEvent,
+  OutboundEvent,
+} from './messages'
+import { isPingMessage, isUploadToYouTubeMessage } from './messages'
+import type { Job } from './background-types'
+import { STORAGE_KEY } from './background-types'
+import { generateJobId, buildStudioUrl, createJob } from './background-utils'
+
+// ── Storage helpers ──────────────────────────────────────
+async function saveJob(job: Job): Promise<void> {
+  const { [STORAGE_KEY]: existing } = await chrome.storage.local.get(STORAGE_KEY)
+  const jobs: Job[] = Array.isArray(existing) ? existing : []
+  const idx = jobs.findIndex((j) => j.jobId === job.jobId)
+  if (idx >= 0) {
+    jobs[idx] = job
+  } else {
+    jobs.push(job)
+  }
+  await chrome.storage.local.set({ [STORAGE_KEY]: jobs })
+}
+
+async function getJobs(): Promise<Job[]> {
+  const { [STORAGE_KEY]: existing } = await chrome.storage.local.get(STORAGE_KEY)
+  return Array.isArray(existing) ? existing : []
+}
+
+async function updateJobStatus(jobId: string, status: Job['status']): Promise<void> {
+  const jobs = await getJobs()
+  const job = jobs.find((j) => j.jobId === jobId)
+  if (job) {
+    job.status = status
+    await chrome.storage.local.set({ [STORAGE_KEY]: jobs })
+  }
+}
+
+// ── UPLOAD_TO_YOUTUBE 처리 ───────────────────────────────
+async function handleUpload(
+  msg: UploadToYouTubeMessage,
+): Promise<{ ok: true; jobId: string } | { ok: false; error: string }> {
+  const jobId = generateJobId()
+  const job = createJob(jobId, msg.payload)
+
+  try {
+    const tab = await chrome.tabs.create({ url: buildStudioUrl(msg.payload.videoId), active: false })
+    job.tabId = tab.id ?? null
+    job.status = 'running'
+    await saveJob(job)
+
+    if (tab.id != null) {
+      waitForTabLoad(tab.id, () => {
+        chrome.tabs.sendMessage(tab.id!, {
+          type: 'START_UPLOAD',
+          payload: { jobId, ...msg.payload },
+        })
+      })
+    }
+
+    return { ok: true, jobId }
+  } catch (err) {
+    job.status = 'error'
+    await saveJob(job)
+    return { ok: false, error: String(err) }
+  }
+}
+
+function waitForTabLoad(tabId: number, callback: () => void): void {
+  const listener = (
+    updatedTabId: number,
+    changeInfo: chrome.tabs.TabChangeInfo,
+  ) => {
+    if (updatedTabId === tabId && changeInfo.status === 'complete') {
+      chrome.tabs.onUpdated.removeListener(listener)
+      callback()
+    }
+  }
+  chrome.tabs.onUpdated.addListener(listener)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function relayToWebApp(event: OutboundEvent): void {
+  // TODO: Phase 4에서 웹앱 탭에 메시지 전달 구현
+}
+
+// ── 웹앱 → 확장 외부 메시지 수신 ────────────────────────
+chrome.runtime.onMessageExternal.addListener(
+  (message: unknown, _sender, sendResponse) => {
+    if (isPingMessage(message)) {
+      sendResponse({ ok: true, version: chrome.runtime.getManifest().version })
+      return true
+    }
+
+    if (isUploadToYouTubeMessage(message)) {
+      handleUpload(message).then(sendResponse)
+      return true
+    }
+
+    sendResponse({ ok: false, error: 'UNKNOWN_MESSAGE_TYPE' })
+    return true
+  },
+)
+
+// ── content script → background 내부 메시지 (진행 릴레이) ─
+chrome.runtime.onMessage.addListener(
+  (message: unknown, _sender, sendResponse) => {
+    if (isContentProgressMessage(message)) {
+      relayToWebApp(message as OutboundEvent)
+      sendResponse({ ok: true })
+      return true
+    }
+
+    if (isContentDoneMessage(message)) {
+      updateJobStatus(message.payload.jobId, 'done').then(() => {
+        relayToWebApp(message as OutboundEvent)
+        sendResponse({ ok: true })
+      })
+      return true
+    }
+
+    if (isContentErrorMessage(message)) {
+      updateJobStatus(message.payload.jobId, 'error').then(() => {
+        relayToWebApp(message as OutboundEvent)
+        sendResponse({ ok: true })
+      })
+      return true
+    }
+
+    return false
+  },
+)
+
+function isContentProgressMessage(msg: unknown): msg is UploadProgressEvent {
+  return msg !== null && typeof msg === 'object' && (msg as UploadProgressEvent).type === 'UPLOAD_PROGRESS'
+}
+
+function isContentDoneMessage(msg: unknown): msg is UploadDoneEvent {
+  return msg !== null && typeof msg === 'object' && (msg as UploadDoneEvent).type === 'UPLOAD_DONE'
+}
+
+function isContentErrorMessage(msg: unknown): msg is UploadErrorEvent {
+  return msg !== null && typeof msg === 'object' && (msg as UploadErrorEvent).type === 'UPLOAD_ERROR'
+}
+
+// ── 설치 이벤트 ──────────────────────────────────────────
 chrome.runtime.onInstalled.addListener(() => {
   console.log('[CreatorDub] Extension installed')
-})
-
-chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
-  if (message.type === 'PING') {
-    sendResponse({ ok: true, version: chrome.runtime.getManifest().version })
-    return true
-  }
-
-  // TODO: UPLOAD_TO_YOUTUBE 메시지 처리 (Phase 3에서 구현)
-  console.log('[CreatorDub] External message received:', message.type)
-  sendResponse({ ok: false, error: 'NOT_IMPLEMENTED' })
-  return true
 })


### PR DESCRIPTION
## 개요
- 이슈: #102
- 요약: Chrome 확장 background 서비스 워커가 웹앱 메시지를 수신하고 YouTube Studio 탭을 관리하는 기본 로직 구현

## 변경 내용
- `extension/src/background.ts`: 웹앱 PING 응답, UPLOAD_TO_YOUTUBE 처리 (jobId 생성 → 탭 열기 → storage 저장 → content script 전달), content→background 릴레이 구조
- `extension/src/background-types.ts`: Job 인터페이스 + storage key 분리
- `extension/src/background-utils.ts`: 순수 유틸 함수 분리 (generateJobId, buildStudioUrl, createJob)
- `extension/src/background.test.ts`: 순수 함수 단위 테스트 7건

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (31/31 — messages 24 + background 7)

## 리스크 / 팔로업
- `relayToWebApp()` 은 Phase 4에서 구현 (현재 stub)
- 재시도/에러 복구는 Phase 3 #19에서 구현
- Chrome API 통합 테스트는 확장 로드 후 수동 검증 필요