### PR TITLE
[#104] content script 골격 — waitForElement 유틸 및 단계별 핸들러 스텁

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,10 +1,67 @@
-// YouTube Studio content script
-// Phase 3에서 업로드 자동화 로직 구현 예정
+import type { UploadStep } from './messages'
+import type { UploadContext } from './upload-steps'
+import { getStepSequence } from './upload-steps'
+
+interface StartUploadPayload {
+  jobId: string
+  videoId: string
+  languageCode: string
+  audioUrl: string
+  mode: 'auto' | 'assisted'
+}
+
+function isStartUpload(msg: unknown): msg is { type: 'START_UPLOAD'; payload: StartUploadPayload } {
+  return msg !== null && typeof msg === 'object' && (msg as { type: string }).type === 'START_UPLOAD'
+}
+
+function sendProgressToBackground(step: UploadStep, jobId: string, detail?: string): void {
+  chrome.runtime.sendMessage({ type: 'UPLOAD_PROGRESS', payload: { jobId, step, detail } })
+}
+
+function sendDoneToBackground(jobId: string, videoId: string, languageCode: string): void {
+  chrome.runtime.sendMessage({ type: 'UPLOAD_DONE', payload: { jobId, videoId, languageCode } })
+}
+
+function sendErrorToBackground(jobId: string, step: UploadStep, error: string, retryable: boolean): void {
+  chrome.runtime.sendMessage({ type: 'UPLOAD_ERROR', payload: { jobId, step, error, retryable } })
+}
+
+async function executeUpload(payload: StartUploadPayload): Promise<void> {
+  const { jobId, videoId, languageCode, audioUrl, mode } = payload
+
+  const ctx: UploadContext = {
+    jobId,
+    videoId,
+    languageCode,
+    audioUrl,
+    mode,
+    reportProgress: (step, detail) => sendProgressToBackground(step, jobId, detail),
+  }
+
+  const steps = getStepSequence(mode)
+
+  try {
+    ctx.reportProgress('NAVIGATING', 'YouTube Studio 페이지 로드 완료')
+
+    for (const step of steps) {
+      await step(ctx)
+    }
+
+    sendDoneToBackground(jobId, videoId, languageCode)
+  } catch (err) {
+    sendErrorToBackground(jobId, 'NAVIGATING', String(err), true)
+  }
+}
+
+chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
+  if (isStartUpload(message)) {
+    executeUpload(message.payload)
+      .then(() => sendResponse({ ok: true }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }))
+    return true
+  }
+
+  return false
+})
 
 console.log('[CreatorDub] Content script loaded on YouTube Studio')
-
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  console.log('[CreatorDub] Message from background:', message.type)
-  sendResponse({ ok: false, error: 'NOT_IMPLEMENTED' })
-  return true
-})

--- a/extension/src/dom-utils.ts
+++ b/extension/src/dom-utils.ts
@@ -1,0 +1,45 @@
+export interface WaitForElementOptions {
+  timeout?: number
+  root?: ParentNode
+}
+
+const DEFAULT_TIMEOUT = 10_000
+
+export function waitForElement<T extends Element = Element>(
+  selector: string,
+  options: WaitForElementOptions = {},
+): Promise<T> {
+  const { timeout = DEFAULT_TIMEOUT, root = document } = options
+
+  const existing = root.querySelector<T>(selector)
+  if (existing) return Promise.resolve(existing)
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+
+    const observer = new MutationObserver(() => {
+      const el = root.querySelector<T>(selector)
+      if (el) {
+        settled = true
+        observer.disconnect()
+        resolve(el)
+      }
+    })
+
+    observer.observe(root instanceof Node ? root : document, {
+      childList: true,
+      subtree: true,
+    })
+
+    setTimeout(() => {
+      if (!settled) {
+        observer.disconnect()
+        reject(new Error(`waitForElement("${selector}") timed out after ${timeout}ms`))
+      }
+    }, timeout)
+  })
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/extension/src/upload-steps.test.ts
+++ b/extension/src/upload-steps.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { UploadContext } from './upload-steps'
+import { getStepSequence, openLanguagesPage, clickAddLanguage, selectLanguage } from './upload-steps'
+
+function createMockContext(overrides?: Partial<UploadContext>): UploadContext {
+  return {
+    jobId: 'job_test',
+    videoId: 'vid_test',
+    languageCode: 'ko',
+    audioUrl: 'https://example.com/audio.mp3',
+    mode: 'assisted',
+    reportProgress: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('getStepSequence', () => {
+  it('returns 6 steps for assisted mode (no publish)', () => {
+    const steps = getStepSequence('assisted')
+    expect(steps).toHaveLength(6)
+  })
+
+  it('returns 7 steps for auto mode (includes publish)', () => {
+    const steps = getStepSequence('auto')
+    expect(steps).toHaveLength(7)
+  })
+})
+
+describe('step functions report progress', () => {
+  it('openLanguagesPage reports OPENING_LANGUAGES', async () => {
+    const ctx = createMockContext()
+    await openLanguagesPage(ctx)
+    expect(ctx.reportProgress).toHaveBeenCalledWith('OPENING_LANGUAGES', expect.any(String))
+  })
+
+  it('clickAddLanguage reports SELECTING_LANGUAGE', async () => {
+    const ctx = createMockContext()
+    await clickAddLanguage(ctx)
+    expect(ctx.reportProgress).toHaveBeenCalledWith('SELECTING_LANGUAGE', expect.any(String))
+  })
+
+  it('selectLanguage includes language code in detail', async () => {
+    const ctx = createMockContext({ languageCode: 'ja' })
+    await selectLanguage(ctx)
+    expect(ctx.reportProgress).toHaveBeenCalledWith(
+      'SELECTING_LANGUAGE',
+      expect.stringContaining('ja'),
+    )
+  })
+})

--- a/extension/src/upload-steps.ts
+++ b/extension/src/upload-steps.ts
@@ -1,0 +1,66 @@
+import type { UploadStep } from './messages'
+
+export interface UploadContext {
+  jobId: string
+  videoId: string
+  languageCode: string
+  audioUrl: string
+  mode: 'auto' | 'assisted'
+  reportProgress: (step: UploadStep, detail?: string) => void
+}
+
+// ── 각 단계 스텁 — Phase 3에서 실제 구현 ────────────────
+
+export async function openLanguagesPage(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('OPENING_LANGUAGES', '번역 페이지 탐색 중')
+  // TODO: Phase 3 #17 — 번역 페이지 DOM 확인
+}
+
+export async function clickAddLanguage(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('SELECTING_LANGUAGE', '언어 추가 버튼 탐색 중')
+  // TODO: Phase 3 #17 — "언어 추가" 버튼 클릭
+}
+
+export async function selectLanguage(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('SELECTING_LANGUAGE', `${ctx.languageCode} 선택 중`)
+  // TODO: Phase 3 #17 — 드롭다운에서 언어 선택
+}
+
+export async function clickDubAdd(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('INJECTING_AUDIO', '더빙 추가 탐색 중')
+  // TODO: Phase 3 #17 — "��빙 추가" 또는 오디오 트랙 추가 버튼
+}
+
+export async function injectAudioFile(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('INJECTING_AUDIO', '오디오 파일 주입 중')
+  // TODO: Phase 3 #18 — DataTransfer 기반 파일 주입
+}
+
+export async function waitForPublishReady(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('WAITING_PUBLISH', '게시 준비 상태 대기 중')
+  // TODO: Phase 3 #17 — 게시 버튼 활성화 대기
+}
+
+export async function publish(ctx: UploadContext): Promise<void> {
+  ctx.reportProgress('PUBLISHING', '게시 중')
+  // TODO: Phase 3 #20 — auto 모드에서만 실행
+}
+
+export type StepFn = (ctx: UploadContext) => Promise<void>
+
+export function getStepSequence(mode: 'auto' | 'assisted'): StepFn[] {
+  const base: StepFn[] = [
+    openLanguagesPage,
+    clickAddLanguage,
+    selectLanguage,
+    clickDubAdd,
+    injectAudioFile,
+    waitForPublishReady,
+  ]
+
+  if (mode === 'auto') {
+    base.push(publish)
+  }
+
+  return base
+}


### PR DESCRIPTION
## 개요
- 이슈: #104
- 요약: content script의 기본 구조 구현 — DOM 유틸, 업로드 단계 스텁, 메시지 핸들링

## 변경 내용
- `extension/src/dom-utils.ts`: `waitForElement` (MutationObserver 기반) + `sleep` 유틸
- `extension/src/upload-steps.ts`: 7개 업로드 단계 함수 스텁 + `getStepSequence(mode)` — assisted 6단계, auto 7단계(publish 포함)
- `extension/src/content.ts`: background의 `START_UPLOAD` 수신 → 단계 순차 실행 → UPLOAD_DONE/ERROR 전달
- `extension/src/upload-steps.test.ts`: 단위 테스트 5건 (단계 수, 진행 보고)

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (36/36)

## 리스크 / 팔로업
- 각 단계 함수는 스텁 — Phase 3 #16~#20에서 실제 구현
- waitForElement의 DOM 통합 테스트는 확장 로드 후 수동 검증 필요
- 에러 시 현재 단계 추적은 Phase 3 #19에서 개선