### PR TITLE
[#106] popup UI 최소 버전 — 상태 표시 및 최근 업로드 로그

### DIFF
--- a/extension/src/popup/index.html
+++ b/extension/src/popup/index.html
@@ -6,19 +6,83 @@
   <title>CreatorDub</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { width: 320px; min-height: 200px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; padding: 16px; background: #fff; color: #1a1a1a; }
-    h1 { font-size: 16px; font-weight: 600; margin-bottom: 12px; }
-    .status { padding: 8px 12px; border-radius: 6px; font-size: 13px; margin-bottom: 8px; }
+    body {
+      width: 340px;
+      min-height: 240px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      padding: 16px;
+      background: #fff;
+      color: #1a1a1a;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+    h1 { font-size: 15px; font-weight: 600; }
+    .version { font-size: 11px; color: #999; }
+
+    .status {
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 13px;
+      margin-bottom: 12px;
+    }
     .status.ok { background: #e8f5e9; color: #2e7d32; }
     .status.warn { background: #fff3e0; color: #e65100; }
-    #log { font-size: 12px; color: #666; margin-top: 12px; }
-    #log li { margin-bottom: 4px; }
+    .status.active { background: #e3f2fd; color: #1565c0; }
+
+    h2 { font-size: 13px; font-weight: 600; color: #555; margin-bottom: 8px; }
+
+    .empty {
+      font-size: 12px;
+      color: #999;
+      text-align: center;
+      padding: 16px 0;
+    }
+
+    .job-list { list-style: none; }
+    .job-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 12px;
+    }
+    .job-item:last-child { border-bottom: none; }
+
+    .job-badge {
+      display: inline-block;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      flex-shrink: 0;
+    }
+    .badge-pending { background: #f5f5f5; color: #757575; }
+    .badge-running { background: #e3f2fd; color: #1565c0; }
+    .badge-done { background: #e8f5e9; color: #2e7d32; }
+    .badge-error { background: #ffebee; color: #c62828; }
+
+    .job-info { flex: 1; min-width: 0; }
+    .job-video { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .job-lang { color: #888; }
+    .job-time { color: #bbb; font-size: 10px; flex-shrink: 0; }
   </style>
 </head>
 <body>
-  <h1>CreatorDub</h1>
+  <header>
+    <h1>CreatorDub</h1>
+    <span id="version" class="version"></span>
+  </header>
   <div id="status" class="status warn">로딩 중…</div>
-  <ul id="log"></ul>
+  <h2>최근 업로드</h2>
+  <div id="jobs-container">
+    <p class="empty">로딩 중…</p>
+  </div>
   <script type="module" src="./main.ts"></script>
 </body>
 </html>

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -1,12 +1,87 @@
-const statusEl = document.getElementById('status')!
+import type { Job } from '../background-types'
+import { STORAGE_KEY } from '../background-types'
 
-async function init() {
+const RECENT_JOB_COUNT = 3
+
+const statusEl = document.getElementById('status')!
+const versionEl = document.getElementById('version')!
+const jobsContainer = document.getElementById('jobs-container')!
+
+function formatTime(timestamp: number): string {
+  const d = new Date(timestamp)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+function badgeClass(status: Job['status']): string {
+  return `badge-${status}`
+}
+
+function statusLabel(status: Job['status']): string {
+  switch (status) {
+    case 'pending': return '대기'
+    case 'running': return '진행'
+    case 'done': return '완료'
+    case 'error': return '오류'
+  }
+}
+
+function renderJobs(jobs: Job[]): void {
+  const recent = jobs
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .slice(0, RECENT_JOB_COUNT)
+
+  if (recent.length === 0) {
+    jobsContainer.innerHTML = '<p class="empty">아직 업로드 기록이 없습니다.</p>'
+    return
+  }
+
+  const ul = document.createElement('ul')
+  ul.className = 'job-list'
+
+  for (const job of recent) {
+    const li = document.createElement('li')
+    li.className = 'job-item'
+    li.innerHTML = `
+      <span class="job-badge ${badgeClass(job.status)}">${statusLabel(job.status)}</span>
+      <span class="job-info">
+        <span class="job-video">${job.videoId}</span>
+        <span class="job-lang">${job.languageCode}</span>
+      </span>
+      <span class="job-time">${formatTime(job.createdAt)}</span>
+    `
+    ul.appendChild(li)
+  }
+
+  jobsContainer.innerHTML = ''
+  jobsContainer.appendChild(ul)
+}
+
+function updateStatus(jobs: Job[]): void {
+  const running = jobs.filter((j) => j.status === 'running')
+  if (running.length > 0) {
+    statusEl.textContent = `${running.length}건 업로드 진행 중`
+    statusEl.className = 'status active'
+  } else {
+    statusEl.textContent = '준비됨'
+    statusEl.className = 'status ok'
+  }
+}
+
+async function init(): Promise<void> {
   const manifest = chrome.runtime.getManifest()
-  statusEl.textContent = `v${manifest.version} — 준비됨`
-  statusEl.className = 'status ok'
+  versionEl.textContent = `v${manifest.version}`
+
+  const { [STORAGE_KEY]: stored } = await chrome.storage.local.get(STORAGE_KEY)
+  const jobs: Job[] = Array.isArray(stored) ? stored : []
+
+  updateStatus(jobs)
+  renderJobs(jobs)
 }
 
 init().catch((err) => {
   statusEl.textContent = `오류: ${err instanceof Error ? err.message : String(err)}`
   statusEl.className = 'status warn'
+  jobsContainer.innerHTML = '<p class="empty">데이터를 불러올 수 없습니다.</p>'
 })


### PR DESCRIPTION
## 개요
- 이슈: #106
- 요약: Chrome 확장 팝업에 현재 상태 및 최근 업로드 작업 3건 표시

## 변경 내용
- `extension/src/popup/index.html`: 레이아��� 개선 — 헤더(버전), 상태 배지, 작업 목록 UI
- `extension/src/popup/main.ts`: storage에서 Job 읽기, 상태별 렌더링 (대기/진행/완료/오류), 빈 상태 처리

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm run build` 통과
- [x] `npm test` 통과 (36/36)

## 리스크 / 팔로업
- 실제 Chrome에서 로드 후 수동 UI 검증 필요
- 설정 페이지, 작업 취소 등 고급 기능은 Phase 5 이후