### PR TITLE
[#112] 파일 주입 유틸 — DataTransfer 기반 File input 주입

### DIFF
--- a/extension/src/file-inject.test.ts
+++ b/extension/src/file-inject.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { deriveFilename } from './file-inject'
+
+describe('deriveFilename', () => {
+  it('extracts filename from URL path', () => {
+    expect(deriveFilename('https://example.com/audio/track.mp3', 'audio/mpeg')).toBe('track.mp3')
+  })
+
+  it('extracts filename with nested path', () => {
+    expect(deriveFilename('https://cdn.example.com/a/b/c/voice.wav', 'audio/wav')).toBe('voice.wav')
+  })
+
+  it('falls back to timestamp-based name when URL has no extension', () => {
+    const name = deriveFilename('https://example.com/api/audio/123', 'audio/mpeg')
+    expect(name).toMatch(/^audio_\d+\.mp3$/)
+  })
+
+  it('uses correct extension for wav', () => {
+    const name = deriveFilename('https://example.com/stream', 'audio/wav')
+    expect(name).toMatch(/\.wav$/)
+  })
+
+  it('uses correct extension for flac', () => {
+    const name = deriveFilename('https://example.com/stream', 'audio/flac')
+    expect(name).toMatch(/\.flac$/)
+  })
+
+  it('uses correct extension for ogg', () => {
+    const name = deriveFilename('https://example.com/stream', 'audio/ogg')
+    expect(name).toMatch(/\.ogg$/)
+  })
+
+  it('defaults to mp3 for unknown mime type', () => {
+    const name = deriveFilename('https://example.com/stream', 'application/octet-stream')
+    expect(name).toMatch(/\.mp3$/)
+  })
+
+  it('handles invalid URL gracefully', () => {
+    const name = deriveFilename('not-a-url', 'audio/mpeg')
+    expect(name).toMatch(/^audio_\d+\.mp3$/)
+  })
+})

--- a/extension/src/file-inject.ts
+++ b/extension/src/file-inject.ts
@@ -1,0 +1,45 @@
+export async function fetchAsFile(url: string, filename?: string): Promise<File> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`오디오 파일 다운로드 실패: ${response.status} ${response.statusText}`)
+  }
+
+  const blob = await response.blob()
+  const contentType = blob.type || 'audio/mpeg'
+  const name = filename ?? deriveFilename(url, contentType)
+
+  return new File([blob], name, { type: contentType })
+}
+
+export function deriveFilename(url: string, contentType: string): string {
+  try {
+    const pathname = new URL(url).pathname
+    const basename = pathname.split('/').pop()
+    if (basename && basename.includes('.')) return basename
+  } catch {
+    // invalid URL — use fallback
+  }
+
+  const ext = MIME_TO_EXT[contentType] ?? 'mp3'
+  return `audio_${Date.now()}.${ext}`
+}
+
+const MIME_TO_EXT: Record<string, string> = {
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/flac': 'flac',
+  'audio/aac': 'aac',
+  'audio/ogg': 'ogg',
+  'audio/webm': 'webm',
+}
+
+export function injectFileToInput(input: HTMLInputElement, file: File): void {
+  const dataTransfer = new DataTransfer()
+  dataTransfer.items.add(file)
+  input.files = dataTransfer.files
+
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}

--- a/extension/src/upload-steps.test.ts
+++ b/extension/src/upload-steps.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('./file-inject', () => ({
+  fetchAsFile: vi.fn().mockResolvedValue(new File(['audio'], 'test.mp3', { type: 'audio/mpeg' })),
+  injectFileToInput: vi.fn(),
+}))
+
 import type { DomHelper, UploadContext } from './upload-steps'
 import {
   getStepSequence,
@@ -139,6 +145,7 @@ describe('step sequence execution order', () => {
       'OPENING_LANGUAGES',
       'SELECTING_LANGUAGE',
       'SELECTING_LANGUAGE',
+      'INJECTING_AUDIO',
       'INJECTING_AUDIO',
       'INJECTING_AUDIO',
       'WAITING_PUBLISH',

--- a/extension/src/upload-steps.ts
+++ b/extension/src/upload-steps.ts
@@ -9,6 +9,7 @@ import {
   FILE_INPUT,
   PUBLISH_BUTTON,
 } from './selectors'
+import { fetchAsFile, injectFileToInput } from './file-inject'
 
 // ── DOM 헬퍼 인터페이스 (테스트 시 모킹 가능) ───────────
 export interface DomHelper {
@@ -63,10 +64,13 @@ export async function clickDubAdd(ctx: UploadContext): Promise<void> {
 }
 
 export async function injectAudioFile(ctx: UploadContext): Promise<void> {
-  ctx.reportProgress('INJECTING_AUDIO', '오디오 파일 주입 중')
-  // TODO: Phase 3 #18 — DataTransfer 기반 파일 주입
-  // FILE_INPUT 셀렉터로 input[type="file"] 찾은 뒤 파일 주입
-  await ctx.dom.waitFor(FILE_INPUT)
+  ctx.reportProgress('INJECTING_AUDIO', '오디오 파일 다운로드 중')
+  const file = await fetchAsFile(ctx.audioUrl)
+
+  ctx.reportProgress('INJECTING_AUDIO', '파일 입력 요소에 주입 중')
+  const input = await ctx.dom.waitFor<HTMLInputElement>(FILE_INPUT)
+  injectFileToInput(input, file)
+  await ctx.dom.sleep(1000)
 }
 
 export async function waitForPublishReady(ctx: UploadContext): Promise<void> {


### PR DESCRIPTION
## 개요
- 이슈: #112
- 요약: 오디오 URL에서 파일을 fetch하여 DataTransfer API로 숨겨진 file input에 주입하는 유틸

## 변경 내용
- `extension/src/file-inject.ts`: `fetchAsFile` (URL→Blob→File), `injectFileToInput` (DataTransfer→input.files + change/input 이벤트), `deriveFilename` (URL/MIME→파일명)
- `extension/src/upload-steps.ts`: `injectAudioFile`에 file-inject 연결 (fetch → waitFor → inject)
- `extension/src/file-inject.test.ts`: deriveFilename 단위 테스트 8건
- `extension/src/upload-steps.test.ts`: file-inject 모듈 mock 적용 + 실행 순서 업데이트

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (53/53)

## 리스크 / 팔로업
- DataTransfer API는 일부 브라우저에서 제한 가능 — Chrome 확장 content script에서는 동작함
- 실제 YouTube Studio에서 file input 주입 성공 여부는 수동 검증 필요
- CORS로 오디오 URL fetch 실패 가능 — background에서 fetch 후 전달하는 패턴 고려