### PR TITLE
[#114] 에러 핸들링 & 재시도 — 셀렉터 실패 시 최대 3회 지수 백오프

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -4,6 +4,7 @@ import type { SelectorChain } from './selectors'
 import { queryWithFallback } from './selectors'
 import { waitForElement, sleep } from './dom-utils'
 import { getStepSequence } from './upload-steps'
+import { withRetry, buildManualGuideUrl } from './retry'
 
 interface StartUploadPayload {
   jobId: string
@@ -81,12 +82,24 @@ async function executeUpload(payload: StartUploadPayload): Promise<void> {
     ctx.reportProgress('NAVIGATING', 'YouTube Studio 페이지 로드 완료')
 
     for (const step of steps) {
-      await step(ctx)
+      await withRetry(() => step(ctx), {
+        maxAttempts: 3,
+        baseDelayMs: 1000,
+        onRetry: (attempt, err) => {
+          ctx.reportProgress('NAVIGATING', `재시도 ${attempt}/3: ${String(err)}`)
+        },
+      })
     }
 
     sendDoneToBackground(jobId, videoId, languageCode)
   } catch (err) {
-    sendErrorToBackground(jobId, 'NAVIGATING', String(err), true)
+    const guideUrl = buildManualGuideUrl(videoId)
+    sendErrorToBackground(
+      jobId,
+      'NAVIGATING',
+      `자동화 실패 (3회 재시도 후). 수동 진행: ${guideUrl} — ${String(err)}`,
+      false,
+    )
   }
 }
 

--- a/extension/src/retry.test.ts
+++ b/extension/src/retry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { withRetry, buildManualGuideUrl } from './retry'
+
+describe('withRetry', () => {
+  it('returns result on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const result = await withRetry(fn, { maxAttempts: 3, baseDelayMs: 0 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on failure and succeeds on second attempt', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('ok')
+    const result = await withRetry(fn, { maxAttempts: 3, baseDelayMs: 0 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws after maxAttempts exhausted', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('always fails'))
+    await expect(
+      withRetry(fn, { maxAttempts: 3, baseDelayMs: 0 }),
+    ).rejects.toThrow('always fails')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('calls onRetry callback on each retry', async () => {
+    const onRetry = vi.fn()
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValue('ok')
+    await withRetry(fn, { maxAttempts: 3, baseDelayMs: 0, onRetry })
+    expect(onRetry).toHaveBeenCalledTimes(2)
+    expect(onRetry).toHaveBeenCalledWith(1, expect.any(Error))
+    expect(onRetry).toHaveBeenCalledWith(2, expect.any(Error))
+  })
+
+  it('does not call onRetry on first attempt', async () => {
+    const onRetry = vi.fn()
+    const fn = vi.fn().mockResolvedValue('ok')
+    await withRetry(fn, { maxAttempts: 3, baseDelayMs: 0, onRetry })
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+
+  it('respects maxAttempts=1 (no retry)', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('fail'))
+    await expect(
+      withRetry(fn, { maxAttempts: 1, baseDelayMs: 0 }),
+    ).rejects.toThrow('fail')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('buildManualGuideUrl', () => {
+  it('builds correct YouTube Studio translations URL', () => {
+    expect(buildManualGuideUrl('abc123')).toBe(
+      'https://studio.youtube.com/video/abc123/translations',
+    )
+  })
+})

--- a/extension/src/retry.ts
+++ b/extension/src/retry.ts
@@ -1,0 +1,45 @@
+export interface RetryOptions {
+  maxAttempts?: number
+  baseDelayMs?: number
+  onRetry?: (attempt: number, error: unknown) => void
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3
+const DEFAULT_BASE_DELAY_MS = 1000
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    onRetry,
+  } = options
+
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+
+      if (attempt < maxAttempts) {
+        const delay = baseDelayMs * Math.pow(2, attempt - 1)
+        onRetry?.(attempt, err)
+        await sleep(delay)
+      }
+    }
+  }
+
+  throw lastError
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function buildManualGuideUrl(videoId: string): string {
+  return `https://studio.youtube.com/video/${videoId}/translations`
+}


### PR DESCRIPTION
## 개요
- 이슈: #114
- 요약: 업로드 각 단계에 최대 3회 재시도 + 최종 실패 시 수동 가이드 URL 제공

## 변경 내용
- `extension/src/retry.ts`: `withRetry` (지수 백오프, onRetry 콜백) + `buildManualGuideUrl`
- `extension/src/content.ts`: 각 step에 withRetry 적용, 실패 시 retryable=false + 수동 URL
- `extension/src/retry.test.ts`: 단위 테스트 7건

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (60/60)

## 리스크 / 팔로업
- 수동 안내 팝업 UI는 Phase 4 #24에서 구현
- 전체 플로우 재시작은 향후 개선