### PR TITLE
[#116] 업로드 자동화 모드 토글 — auto/assisted 전환 + 기본값 설정

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -9,6 +9,7 @@ import { isPingMessage, isUploadToYouTubeMessage } from './messages'
 import type { Job } from './background-types'
 import { STORAGE_KEY } from './background-types'
 import { generateJobId, buildStudioUrl, createJob } from './background-utils'
+import { getUploadMode } from './settings'
 
 // ── Storage helpers ──────────────────────────────────────
 async function saveJob(job: Job): Promise<void> {
@@ -42,7 +43,8 @@ async function handleUpload(
   msg: UploadToYouTubeMessage,
 ): Promise<{ ok: true; jobId: string } | { ok: false; error: string }> {
   const jobId = generateJobId()
-  const job = createJob(jobId, msg.payload)
+  const effectiveMode = msg.payload.mode || await getUploadMode()
+  const job = createJob(jobId, { ...msg.payload, mode: effectiveMode })
 
   try {
     const tab = await chrome.tabs.create({ url: buildStudioUrl(msg.payload.videoId), active: false })
@@ -54,7 +56,7 @@ async function handleUpload(
       waitForTabLoad(tab.id, () => {
         chrome.tabs.sendMessage(tab.id!, {
           type: 'START_UPLOAD',
-          payload: { jobId, ...msg.payload },
+          payload: { jobId, ...msg.payload, mode: effectiveMode },
         })
       })
     }

--- a/extension/src/popup/index.html
+++ b/extension/src/popup/index.html
@@ -33,6 +33,24 @@
     .status.warn { background: #fff3e0; color: #e65100; }
     .status.active { background: #e3f2fd; color: #1565c0; }
 
+    .mode-section { margin-bottom: 12px; }
+    .mode-label {
+      display: flex; align-items: center; gap: 8px; cursor: pointer;
+      font-size: 13px; font-weight: 500;
+    }
+    .mode-label input { display: none; }
+    .toggle-track {
+      position: relative; width: 36px; height: 20px;
+      background: #ccc; border-radius: 10px; transition: background 0.2s;
+    }
+    .toggle-thumb {
+      position: absolute; top: 2px; left: 2px; width: 16px; height: 16px;
+      background: #fff; border-radius: 50%; transition: left 0.2s;
+    }
+    .mode-label input:checked + .toggle-track { background: #4caf50; }
+    .mode-label input:checked + .toggle-track .toggle-thumb { left: 18px; }
+    .mode-desc { font-size: 11px; color: #999; margin-top: 4px; }
+
     h2 { font-size: 13px; font-weight: 600; color: #555; margin-bottom: 8px; }
 
     .empty {
@@ -79,6 +97,15 @@
     <span id="version" class="version"></span>
   </header>
   <div id="status" class="status warn">로딩 중…</div>
+  <div class="mode-section">
+    <label class="mode-label">
+      <span>자동 게시</span>
+      <input type="checkbox" id="mode-toggle" />
+      <span class="toggle-track"><span class="toggle-thumb"></span></span>
+    </label>
+    <p class="mode-desc" id="mode-desc">assisted — 파일 주입까지만 자동</p>
+  </div>
+
   <h2>최근 업로드</h2>
   <div id="jobs-container">
     <p class="empty">로딩 중…</p>

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -1,11 +1,14 @@
 import type { Job } from '../background-types'
 import { STORAGE_KEY } from '../background-types'
+import { getUploadMode, setUploadMode } from '../settings'
 
 const RECENT_JOB_COUNT = 3
 
 const statusEl = document.getElementById('status')!
 const versionEl = document.getElementById('version')!
 const jobsContainer = document.getElementById('jobs-container')!
+const modeToggle = document.getElementById('mode-toggle') as HTMLInputElement
+const modeDesc = document.getElementById('mode-desc')!
 
 function formatTime(timestamp: number): string {
   const d = new Date(timestamp)
@@ -69,9 +72,25 @@ function updateStatus(jobs: Job[]): void {
   }
 }
 
+function updateModeDesc(isAuto: boolean): void {
+  modeDesc.textContent = isAuto
+    ? 'auto — 게시까지 모두 자동'
+    : 'assisted — 파일 주입까지만 자동'
+}
+
 async function init(): Promise<void> {
   const manifest = chrome.runtime.getManifest()
   versionEl.textContent = `v${manifest.version}`
+
+  const currentMode = await getUploadMode()
+  modeToggle.checked = currentMode === 'auto'
+  updateModeDesc(modeToggle.checked)
+
+  modeToggle.addEventListener('change', async () => {
+    const newMode = modeToggle.checked ? 'auto' : 'assisted'
+    await setUploadMode(newMode)
+    updateModeDesc(modeToggle.checked)
+  })
 
   const { [STORAGE_KEY]: stored } = await chrome.storage.local.get(STORAGE_KEY)
   const jobs: Job[] = Array.isArray(stored) ? stored : []

--- a/extension/src/settings.test.ts
+++ b/extension/src/settings.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import type { UploadMode } from './messages'
+
+describe('Settings types', () => {
+  it('UploadMode accepts "auto"', () => {
+    const mode: UploadMode = 'auto'
+    expect(mode).toBe('auto')
+  })
+
+  it('UploadMode accepts "assisted"', () => {
+    const mode: UploadMode = 'assisted'
+    expect(mode).toBe('assisted')
+  })
+
+  it('default mode should be "assisted" per TASK.md', () => {
+    const DEFAULT_MODE: UploadMode = 'assisted'
+    expect(DEFAULT_MODE).toBe('assisted')
+  })
+})

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -1,0 +1,30 @@
+import type { UploadMode } from './messages'
+
+const SETTINGS_KEY = 'creatordub_settings'
+
+export interface Settings {
+  uploadMode: UploadMode
+}
+
+const DEFAULTS: Settings = {
+  uploadMode: 'assisted',
+}
+
+export async function getSettings(): Promise<Settings> {
+  const { [SETTINGS_KEY]: stored } = await chrome.storage.local.get(SETTINGS_KEY)
+  if (stored && typeof stored === 'object') {
+    return { ...DEFAULTS, ...stored }
+  }
+  return { ...DEFAULTS }
+}
+
+export async function getUploadMode(): Promise<UploadMode> {
+  const settings = await getSettings()
+  return settings.uploadMode
+}
+
+export async function setUploadMode(mode: UploadMode): Promise<void> {
+  const settings = await getSettings()
+  settings.uploadMode = mode
+  await chrome.storage.local.set({ [SETTINGS_KEY]: settings })
+}


### PR DESCRIPTION
## 개요
- 이슈: #116
- 요약: auto(게시까지 자동) vs assisted(파일 주입까지만) 모드 전환 + 기본값 assisted

## 변경 내용
- `extension/src/settings.ts`: getUploadMode/setUploadMode — chrome.storage.local 기반
- `extension/src/popup/index.html`: 토글 스위치 UI (CSS 포함)
- `extension/src/popup/main.ts`: 토글 상태 로드/저장 + 설명 텍스트 동적 변경
- `extension/src/background.ts`: 웹앱에서 mode 미지정 시 저장된 모드 fallback
- `extension/src/settings.test.ts`: 타입 검증 3건

## 검증
- [x] `npm run lint` 통과
- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (63/63)
- [x] `npm run build` 통과

## 리스크 / 팔로업
- 웹앱 측 모드 선택 UI는 Phase 4에서 구현
- 실제 Chrome 팝업에서 토글 동작 수동 확인 필요