### PR TITLE
[#120] 확장 감지 훅 분리 및 설치 가이드 링크 추가

### DIFF
--- a/src/features/dubbing/components/YouTubeExtensionUpload.tsx
+++ b/src/features/dubbing/components/YouTubeExtensionUpload.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
-import { Puzzle, Upload, AlertCircle } from 'lucide-react'
+import { useState, useCallback } from 'react'
+import { Puzzle, Upload, AlertCircle, ExternalLink } from 'lucide-react'
 import { Button, Badge } from '@/components/ui'
 import { getLanguageByCode } from '@/utils/languages'
 import { useNotificationStore } from '@/stores/notificationStore'
-
-const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID || ''
+import { useExtensionDetect, sendToExtension } from '@/hooks/useExtensionDetect'
 
 interface Props {
   videoId: string
@@ -14,58 +13,12 @@ interface Props {
   getAudioUrl: (langCode: string) => Promise<string | undefined>
 }
 
-type ExtensionStatus = 'checking' | 'installed' | 'not-installed'
-
-interface ChromeRuntime {
-  sendMessage: (extensionId: string, message: unknown, callback: (response: unknown) => void) => void
-  lastError?: { message: string }
-}
-
-function getChromeRuntime(): ChromeRuntime | null {
-  if (typeof globalThis !== 'undefined' && 'chrome' in globalThis) {
-    const c = (globalThis as Record<string, unknown>).chrome as { runtime?: ChromeRuntime } | undefined
-    return c?.runtime ?? null
-  }
-  return null
-}
-
-function sendToExtension(message: unknown): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const runtime = getChromeRuntime()
-    if (!EXTENSION_ID || !runtime) {
-      reject(new Error('Chrome 확장 API를 사용할 수 없습니다'))
-      return
-    }
-    runtime.sendMessage(EXTENSION_ID, message, (response: unknown) => {
-      if (runtime.lastError) {
-        reject(new Error(runtime.lastError.message))
-      } else {
-        resolve(response)
-      }
-    })
-  })
-}
+const INSTALL_GUIDE_URL = 'https://github.com/perso-devrel/creatordubbing/blob/main/extension/README.md'
 
 export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }: Props) {
-  const [extensionStatus, setExtensionStatus] = useState<ExtensionStatus>('checking')
+  const { status: extensionStatus, version, recheck } = useExtensionDetect()
   const [uploadingLang, setUploadingLang] = useState<string | null>(null)
   const addToast = useNotificationStore((s) => s.addToast)
-
-  useEffect(() => {
-    async function checkExtension() {
-      if (!EXTENSION_ID) {
-        setExtensionStatus('not-installed')
-        return
-      }
-      try {
-        const response = await sendToExtension({ type: 'PING' }) as { ok?: boolean }
-        setExtensionStatus(response?.ok ? 'installed' : 'not-installed')
-      } catch {
-        setExtensionStatus('not-installed')
-      }
-    }
-    checkExtension()
-  }, [])
 
   const handleExtensionUpload = useCallback(async (langCode: string) => {
     const lang = getLanguageByCode(langCode)
@@ -96,7 +49,7 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
           message: `작업 ID: ${response.jobId}. YouTube Studio에서 자동 진행됩니다.`,
         })
       } else {
-        addToast({ type: 'error', title: `확장 업로드 실패`, message: response.error || '알 수 없는 오류' })
+        addToast({ type: 'error', title: '확장 업로드 실패', message: response.error || '알 수 없는 오류' })
       }
     } catch (err) {
       addToast({ type: 'error', title: '확장 통신 실패', message: err instanceof Error ? err.message : String(err) })
@@ -111,15 +64,22 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
     return (
       <div className="flex items-center gap-3 rounded-lg border border-dashed border-surface-300 p-3 dark:border-surface-700">
         <AlertCircle className="h-5 w-5 flex-shrink-0 text-surface-400" />
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-surface-600 dark:text-surface-400">
             CreatorDub 확장 미설치
           </p>
-          <p className="text-xs text-surface-400">
-            {!EXTENSION_ID
-              ? 'NEXT_PUBLIC_EXTENSION_ID 환경변수가 설정되지 않았습니다.'
-              : 'Chrome 확장을 설치하면 오디오 트랙 업로드를 자동화할 수 있습니다.'}
+          <p className="text-xs text-surface-400 mb-2">
+            Chrome 확장을 설치하면 오디오 트랙 업로드를 자동화할 수 있습니다.
           </p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => window.open(INSTALL_GUIDE_URL, '_blank')}>
+              <ExternalLink className="h-3 w-3" />
+              설치 가이드
+            </Button>
+            <Button variant="ghost" size="sm" onClick={recheck}>
+              다시 감지
+            </Button>
+          </div>
         </div>
       </div>
     )
@@ -132,7 +92,7 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
         <span className="text-sm font-medium text-surface-700 dark:text-surface-300">
           확장 자동 업로드
         </span>
-        <Badge variant="success">연결됨</Badge>
+        <Badge variant="success">연결됨{version ? ` v${version}` : ''}</Badge>
       </div>
       <p className="text-xs text-surface-500 mb-3">
         CreatorDub 확장이 YouTube Studio를 자동으로 열고 오디오 트랙을 추가합니다.

--- a/src/hooks/useExtensionDetect.ts
+++ b/src/hooks/useExtensionDetect.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID || ''
+
+export type ExtensionStatus = 'checking' | 'installed' | 'not-installed'
+
+interface ChromeRuntime {
+  sendMessage: (extensionId: string, message: unknown, callback: (response: unknown) => void) => void
+  lastError?: { message: string }
+}
+
+function getChromeRuntime(): ChromeRuntime | null {
+  if (typeof globalThis !== 'undefined' && 'chrome' in globalThis) {
+    const c = (globalThis as Record<string, unknown>).chrome as { runtime?: ChromeRuntime } | undefined
+    return c?.runtime ?? null
+  }
+  return null
+}
+
+export function sendToExtension(message: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const runtime = getChromeRuntime()
+    if (!EXTENSION_ID || !runtime) {
+      reject(new Error('Chrome 확장 API를 사용할 수 없습니다'))
+      return
+    }
+    runtime.sendMessage(EXTENSION_ID, message, (response: unknown) => {
+      if (runtime.lastError) {
+        reject(new Error(runtime.lastError.message))
+      } else {
+        resolve(response)
+      }
+    })
+  })
+}
+
+export function getExtensionId(): string {
+  return EXTENSION_ID
+}
+
+async function detectExtension(): Promise<{ status: ExtensionStatus; version: string | null }> {
+  if (!EXTENSION_ID) {
+    return { status: 'not-installed', version: null }
+  }
+  try {
+    const response = await sendToExtension({ type: 'PING' }) as { ok?: boolean; version?: string }
+    if (response?.ok) {
+      return { status: 'installed', version: response.version ?? null }
+    }
+    return { status: 'not-installed', version: null }
+  } catch {
+    return { status: 'not-installed', version: null }
+  }
+}
+
+export function useExtensionDetect() {
+  const [status, setStatus] = useState<ExtensionStatus>('checking')
+  const [version, setVersion] = useState<string | null>(null)
+
+  const recheck = useCallback(() => {
+    setStatus('checking')
+    detectExtension().then((result) => {
+      setStatus(result.status)
+      setVersion(result.version)
+    })
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    detectExtension().then((result) => {
+      if (!cancelled) {
+        setStatus(result.status)
+        setVersion(result.version)
+      }
+    })
+    return () => { cancelled = true }
+  }, [])
+
+  return { status, version, recheck, extensionId: EXTENSION_ID }
+}


### PR DESCRIPTION
## 개요
- 이슈: #120
- 요약: 재사용 가능한 useExtensionDetect 훅 + 미설치 시 설치 가이드 링크

## 변경 내용
- `src/hooks/useExtensionDetect.ts`: PING 감지 + 버전 읽기 + recheck + sendToExtension 유틸 export
- `src/features/dubbing/components/YouTubeExtensionUpload.tsx`: 훅 사용으로 리팩터, 설치 가이드 버튼 + 다시 감지 버튼, 연결 시 버전 표시

## 검증
- [x] `tsc --noEmit` 통과
- [x] `npm run lint` 통과

## 리스크 / 팔로업
- 실제 Chrome 웹 스토어 URL은 배포 후 교체 필요 (현재 GitHub README 링크)