### PR TITLE
[#136] [phase-6] relayToWebApp 구현 — 웹앱 탭에 실시간 이벤트 전달

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -82,9 +82,26 @@ function waitForTabLoad(tabId: number, callback: () => void): void {
   chrome.tabs.onUpdated.addListener(listener)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function relayToWebApp(event: OutboundEvent): void {
-  // TODO: Phase 4에서 웹앱 탭에 메시지 전달 구현
+const WEBAPP_URL_PATTERNS = [
+  'http://localhost:3000/*',
+  'https://*.creatordub.com/*',
+]
+
+async function relayToWebApp(event: OutboundEvent): Promise<void> {
+  for (const pattern of WEBAPP_URL_PATTERNS) {
+    try {
+      const tabs = await chrome.tabs.query({ url: pattern })
+      for (const tab of tabs) {
+        if (tab.id != null) {
+          chrome.tabs.sendMessage(tab.id, event).catch(() => {
+            // tab may not have a content script listener — ignore
+          })
+        }
+      }
+    } catch {
+      // pattern may not match any tabs — ignore
+    }
+  }
 }
 
 // ── 웹앱 → 확장 외부 메시지 수신 ────────────────────────


### PR DESCRIPTION
## 개요
- 이슈: #136
- 요약: background의 relayToWebApp stub을 실제 구현하여 웹앱에 실시간 이벤트 전달

## 변경 내용
- `extension/src/background.ts`: relayToWebApp — chrome.tabs.query로 웹앱 탭 탐색 후 이벤트 전달
- WEBAPP_URL_PATTERNS: localhost:3000 + *.creatordub.com
- eslint-disable 제거

## 검증
- [x] `npm run typecheck` 통과
- [x] `npm run lint` 통과
- [x] `npm test` 통과 (70/70)

## 리스크 / 팔로업
- 웹앱 측에서 이벤트를 수신하는 리스너는 향후 추가 필요 (현재는 폴링 방식과 병행)