### PR TITLE
[#140] [phase-6] 중복 타입가드 제거 — messages.ts 재사용

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,11 +1,15 @@
 import type {
   UploadToYouTubeMessage,
-  UploadProgressEvent,
-  UploadDoneEvent,
-  UploadErrorEvent,
   OutboundEvent,
 } from './messages'
-import { isPingMessage, isUploadToYouTubeMessage } from './messages'
+import {
+  isPingMessage,
+  isUploadToYouTubeMessage,
+  isUploadProgressEvent,
+  isUploadDoneEvent,
+  isUploadErrorEvent,
+  isObject,
+} from './messages'
 import type { Job } from './background-types'
 import { STORAGE_KEY } from './background-types'
 import { generateJobId, buildStudioUrl, createJob } from './background-utils'
@@ -117,7 +121,7 @@ chrome.runtime.onMessageExternal.addListener(
       return true
     }
 
-    if (message !== null && typeof message === 'object' && (message as { type: string }).type === 'GET_JOBS') {
+    if (isObject(message) && message.type === 'GET_JOBS') {
       getJobs().then((jobs) => sendResponse({ ok: true, jobs }))
       return true
     }
@@ -130,23 +134,23 @@ chrome.runtime.onMessageExternal.addListener(
 // ── content script → background 내부 메시지 (진행 릴레이) ─
 chrome.runtime.onMessage.addListener(
   (message: unknown, _sender, sendResponse) => {
-    if (isContentProgressMessage(message)) {
-      relayToWebApp(message as OutboundEvent)
+    if (isUploadProgressEvent(message)) {
+      relayToWebApp(message)
       sendResponse({ ok: true })
       return true
     }
 
-    if (isContentDoneMessage(message)) {
+    if (isUploadDoneEvent(message)) {
       updateJobStatus(message.payload.jobId, 'done').then(() => {
-        relayToWebApp(message as OutboundEvent)
+        relayToWebApp(message)
         sendResponse({ ok: true })
       })
       return true
     }
 
-    if (isContentErrorMessage(message)) {
+    if (isUploadErrorEvent(message)) {
       updateJobStatus(message.payload.jobId, 'error').then(() => {
-        relayToWebApp(message as OutboundEvent)
+        relayToWebApp(message)
         sendResponse({ ok: true })
       })
       return true
@@ -155,18 +159,6 @@ chrome.runtime.onMessage.addListener(
     return false
   },
 )
-
-function isContentProgressMessage(msg: unknown): msg is UploadProgressEvent {
-  return msg !== null && typeof msg === 'object' && (msg as UploadProgressEvent).type === 'UPLOAD_PROGRESS'
-}
-
-function isContentDoneMessage(msg: unknown): msg is UploadDoneEvent {
-  return msg !== null && typeof msg === 'object' && (msg as UploadDoneEvent).type === 'UPLOAD_DONE'
-}
-
-function isContentErrorMessage(msg: unknown): msg is UploadErrorEvent {
-  return msg !== null && typeof msg === 'object' && (msg as UploadErrorEvent).type === 'UPLOAD_ERROR'
-}
 
 // ── 설치 이벤트 ──────────────────────────────────────────
 chrome.runtime.onInstalled.addListener(() => {

--- a/extension/src/messages.ts
+++ b/extension/src/messages.ts
@@ -116,7 +116,7 @@ export function isOutboundEvent(msg: unknown): msg is OutboundEvent {
   return isUploadProgressEvent(msg) || isUploadDoneEvent(msg) || isUploadErrorEvent(msg)
 }
 
-// ── 내부 유틸 ────────────────────────────────────────────
-function isObject(val: unknown): val is Record<string, unknown> {
+// ── 유틸 ─────────────────────────────────────────────────
+export function isObject(val: unknown): val is Record<string, unknown> {
   return val !== null && typeof val === 'object' && !Array.isArray(val)
 }


### PR DESCRIPTION
## 개요
- 이슈: #140
- 요약: background.ts의 인라인 타입가드를 messages.ts의 기존 타입가드로 대체

## 변경 내용
- `messages.ts`: isObject 함수 export
- `background.ts`: isContentProgressMessage/Done/Error 3개 함수 제거 → isUploadProgressEvent/DoneEvent/ErrorEvent 사용. GET_JOBS도 isObject 사용. 불필요한 `as OutboundEvent` 캐스트 제거.

## 검증
- [x] `npm run typecheck` 통과
- [x] `npm run lint` 통과
- [x] `npm test` 통과 (70/70)