### PR TITLE
[#147] YouTube 썸네일 Image 도메인 등록 + fallback 이미지 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,8 @@ const nextConfig: NextConfig = {
       new URL('https://*.googleusercontent.com/**'),
       new URL('https://perso.ai/**'),
       new URL('https://*.perso.ai/**'),
+      new URL('https://i.ytimg.com/**'),
+      new URL('https://yt3.ggpht.com/**'),
     ],
   },
   async headers() {

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -156,15 +156,13 @@ export default function YouTubeSettingsPage() {
                   className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
                 >
                   <div className="flex items-center gap-3 min-w-0 flex-1">
-                    {video.thumbnail && (
-                      <Image
-                        src={video.thumbnail}
-                        alt={video.title}
-                        width={64}
-                        height={36}
-                        className="rounded object-cover shrink-0"
-                      />
-                    )}
+                    <Image
+                      src={video.thumbnail || '/Youtube_logo.png'}
+                      alt={video.title}
+                      width={64}
+                      height={36}
+                      className="rounded object-cover shrink-0"
+                    />
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
                       <p className="text-xs text-surface-500">


### PR DESCRIPTION
## 개요
- 이슈: #147
- 요약: YouTube 썸네일 400 에러 해소 + 썸네일 없는 영상에 로고 fallback

## 변경 내용
- `next.config.ts`: `i.ytimg.com`, `yt3.ggpht.com` remotePatterns 추가
- `src/app/(app)/youtube/page.tsx`: `video.thumbnail || '/Youtube_logo.png'` fallback

## 검증
- [x] `tsc --noEmit` 통과
- [x] `npm run lint` 통과

## 리스크 / 팔로업
- 없음