### PR TITLE
[#151] 오디오 다운로드 수정 + Multi-Audio 자격 요건 안내 정정

### DIFF
--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -74,8 +74,12 @@ export function UploadStep() {
       const data = await fetchDownloads(langCode, 'voiceAudio')
       const audioUrl = data?.audioFile?.voiceAudioDownloadLink
       if (audioUrl) {
-        // Trigger download in new tab
-        window.open(audioUrl, '_blank')
+        const a = document.createElement('a')
+        a.href = audioUrl
+        a.download = `${lang.name}_${langCode}_audio.wav`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
       }
 
       // 2. Copy language code to clipboard (Studio audio track needs it)
@@ -492,7 +496,7 @@ export function UploadStep() {
             아래 버튼을 누르면 오디오가 다운로드되고 Studio가 팝업으로 열립니다. 언어 코드는 클립보드에 복사됩니다.
           </p>
           <div className="mb-3 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800 dark:bg-amber-900/10 dark:border-amber-800 dark:text-amber-300">
-            Multi-Audio Track 업로드는 YouTube 채널 자격 요건(구독자 1,000명 이상)이 필요합니다.
+            Multi-Audio Track은 YouTube 고급 기능(Advanced Features) 접근 권한이 필요하며, 점진적으로 확대 중입니다.
             {!originalYouTubeId && ' 원본이 YouTube URL이 아니면 Studio 홈으로 이동합니다 — 대상 영상을 직접 선택하세요.'}
           </div>
           <div className="space-y-2">


### PR DESCRIPTION
## 개요
- 이슈: #151
- 요약: 오디오 다운로드 동작 수정 + YouTube 정책 안내 정정

## 변경 내용
- `UploadStep.tsx`: `window.open(audioUrl, '_blank')` → `<a download>` 방식으로 실제 파일 다운로드
- Multi-Audio 안내: "구독자 1,000명 이상" → "고급 기능(Advanced Features) 접근 권한" (YouTube 공식 문서 근거)

## 검증
- [x] `tsc --noEmit` 통과

## 리스크 / 팔로업
- CORS로 인해 cross-origin URL에서는 `download` 속성이 무시될 수 있음 — 같은 도메인이면 정상 동작