### PR TITLE
[#147] YouTube 이미지 도메인 와일드카드 변경 (i9.ytimg.com 대응)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,8 +39,8 @@ const nextConfig: NextConfig = {
       new URL('https://*.googleusercontent.com/**'),
       new URL('https://perso.ai/**'),
       new URL('https://*.perso.ai/**'),
-      new URL('https://i.ytimg.com/**'),
-      new URL('https://yt3.ggpht.com/**'),
+      new URL('https://*.ytimg.com/**'),
+      new URL('https://*.ggpht.com/**'),
     ],
   },
   async headers() {


### PR DESCRIPTION
## 개요
- 이슈: #147
- 요약: YouTube CDN 숫자 서브도메인(i1~i9.ytimg.com) 대응

## 변경 내용
- `next.config.ts`: `i.ytimg.com` → `*.ytimg.com`, `yt3.ggpht.com` → `*.ggpht.com`

## 검증
- [x] 로컬에서 `i9.ytimg.com` 썸네일 정상 로드 확인 필요