### PR TITLE
fix: 영상 입력 탭 순서 변경 - 업로드 우선 배치

### DIFF
--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -112,14 +112,14 @@ export function VideoInputStep() {
 
       <Tabs defaultValue={searchParams.get('url') ? 'url' : 'upload'}>
         <TabsList className="mx-auto w-fit">
-          <TabsTrigger value="url">
-            <span className="flex items-center gap-1.5"><Link2 className="h-4 w-4" /> 영상 URL</span>
-          </TabsTrigger>
           <TabsTrigger value="upload">
             <span className="flex items-center gap-1.5"><Upload className="h-4 w-4" /> 업로드</span>
           </TabsTrigger>
           <TabsTrigger value="channel">
             <span className="flex items-center gap-1.5"><Film className="h-4 w-4" /> 내 영상</span>
+          </TabsTrigger>
+          <TabsTrigger value="url">
+            <span className="flex items-center gap-1.5"><Link2 className="h-4 w-4" /> 영상 URL</span>
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
## Summary
- 영상 입력 단계 탭 순서를 **업로드 → 내 영상 → 영상 URL** 순으로 변경
- 사용 빈도가 높은 업로드 탭을 첫 번째로 배치

Closes #160

## Test plan
- [ ] 영상 입력 페이지에서 탭 순서가 업로드 → 내 영상 → 영상 URL 순인지 확인
- [ ] URL 파라미터가 있을 때 URL 탭이 기본 선택되는 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)