### PR TITLE
feat: 결과물 모드 통합 + 자막 편집기 + 백그라운드 업로드 큐 (develop → main)

### DIFF
--- a/extension/src/background-types.ts
+++ b/extension/src/background-types.ts
@@ -6,6 +6,8 @@ export interface Job {
   mode: 'auto' | 'assisted'
   tabId: number | null
   status: 'pending' | 'running' | 'done' | 'error'
+  step?: string
+  error?: string
   createdAt: number
 }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -33,11 +33,17 @@ async function getJobs(): Promise<Job[]> {
   return Array.isArray(existing) ? existing : []
 }
 
-async function updateJobStatus(jobId: string, status: Job['status']): Promise<void> {
+async function updateJobStatus(
+  jobId: string,
+  status: Job['status'],
+  extra?: { step?: string; error?: string },
+): Promise<void> {
   const jobs = await getJobs()
   const job = jobs.find((j) => j.jobId === jobId)
   if (job) {
     job.status = status
+    if (extra?.step) job.step = extra.step
+    if (extra?.error) job.error = extra.error
     await chrome.storage.local.set({ [STORAGE_KEY]: jobs })
   }
 }
@@ -113,21 +119,21 @@ chrome.runtime.onMessageExternal.addListener(
   (message: unknown, _sender, sendResponse) => {
     if (isPingMessage(message)) {
       sendResponse({ ok: true, version: chrome.runtime.getManifest().version })
-      return true
+      return false
     }
 
     if (isUploadToYouTubeMessage(message)) {
-      handleUpload(message).then(sendResponse)
+      handleUpload(message).then(sendResponse).catch(() => sendResponse({ ok: false, error: 'upload failed' }))
       return true
     }
 
     if (isObject(message) && message.type === 'GET_JOBS') {
-      getJobs().then((jobs) => sendResponse({ ok: true, jobs }))
+      getJobs().then((jobs) => sendResponse({ ok: true, jobs })).catch(() => sendResponse({ ok: true, jobs: [] }))
       return true
     }
 
     sendResponse({ ok: false, error: 'UNKNOWN_MESSAGE_TYPE' })
-    return true
+    return false
   },
 )
 
@@ -135,25 +141,27 @@ chrome.runtime.onMessageExternal.addListener(
 chrome.runtime.onMessage.addListener(
   (message: unknown, _sender, sendResponse) => {
     if (isUploadProgressEvent(message)) {
-      relayToWebApp(message)
       sendResponse({ ok: true })
-      return true
+      updateJobStatus(message.payload.jobId, 'running', {
+        step: message.payload.step,
+      }).then(() => relayToWebApp(message)).catch(() => {})
+      return false
     }
 
     if (isUploadDoneEvent(message)) {
-      updateJobStatus(message.payload.jobId, 'done').then(() => {
-        relayToWebApp(message)
-        sendResponse({ ok: true })
-      })
-      return true
+      sendResponse({ ok: true })
+      updateJobStatus(message.payload.jobId, 'done', { step: 'COMPLETED' })
+        .then(() => relayToWebApp(message)).catch(() => {})
+      return false
     }
 
     if (isUploadErrorEvent(message)) {
-      updateJobStatus(message.payload.jobId, 'error').then(() => {
-        relayToWebApp(message)
-        sendResponse({ ok: true })
-      })
-      return true
+      sendResponse({ ok: true })
+      updateJobStatus(message.payload.jobId, 'error', {
+        step: message.payload.step,
+        error: message.payload.error,
+      }).then(() => relayToWebApp(message)).catch(() => {})
+      return false
     }
 
     return false

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -2,7 +2,15 @@ import type { Job } from '../background-types'
 import { STORAGE_KEY } from '../background-types'
 import { getUploadMode, setUploadMode } from '../settings'
 
-const RECENT_JOB_COUNT = 3
+const RECENT_JOB_COUNT = 5
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + '…' : s
+}
 
 const statusEl = document.getElementById('status')!
 const versionEl = document.getElementById('version')!
@@ -46,11 +54,14 @@ function renderJobs(jobs: Job[]): void {
   for (const job of recent) {
     const li = document.createElement('li')
     li.className = 'job-item'
+    const stepInfo = job.step ? ` · ${job.step}` : ''
+    const errorInfo = job.error ? `<span class="job-error" title="${escapeHtml(job.error)}">${truncate(job.error, 40)}</span>` : ''
     li.innerHTML = `
-      <span class="job-badge ${badgeClass(job.status)}">${statusLabel(job.status)}</span>
+      <span class="job-badge ${badgeClass(job.status)}">${statusLabel(job.status)}${stepInfo}</span>
       <span class="job-info">
         <span class="job-video">${job.videoId}</span>
         <span class="job-lang">${job.languageCode}</span>
+        ${errorInfo}
       </span>
       <span class="job-time">${formatTime(job.createdAt)}</span>
     `

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -7,7 +7,7 @@ export interface Settings {
 }
 
 const DEFAULTS: Settings = {
-  uploadMode: 'assisted',
+  uploadMode: 'auto',
 }
 
 export async function getSettings(): Promise<Settings> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "creatordub-next",
       "version": "0.1.0",
       "dependencies": {
-        "@libsql/client": "^0.17.2",
-        "@tanstack/react-query": "^5.99.2",
+        "@libsql/client": "^0.17.3",
+        "@tanstack/react-query": "^5.100.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.8.0",
+        "lucide-react": "^1.9.0",
         "next": "16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -1316,22 +1316,22 @@
       }
     },
     "node_modules/@libsql/client": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.2.tgz",
-      "integrity": "sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.3.tgz",
+      "integrity": "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==",
       "license": "MIT",
       "dependencies": {
-        "@libsql/core": "^0.17.2",
-        "@libsql/hrana-client": "^0.9.0",
+        "@libsql/core": "^0.17.3",
+        "@libsql/hrana-client": "^0.10.0",
         "js-base64": "^3.7.5",
         "libsql": "^0.5.28",
         "promise-limit": "^2.7.0"
       }
     },
     "node_modules/@libsql/core": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.2.tgz",
-      "integrity": "sha512-L8qv12HZ/jRBcETVR3rscP0uHNxh+K3EABSde6scCw7zfOdiLqO3MAkJaeE1WovPsjXzsN/JBoZED4+7EZVT3g==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.3.tgz",
+      "integrity": "sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg==",
       "license": "MIT",
       "dependencies": {
         "js-base64": "^3.7.5"
@@ -1364,15 +1364,13 @@
       ]
     },
     "node_modules/@libsql/hrana-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.9.0.tgz",
-      "integrity": "sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
       "license": "MIT",
       "dependencies": {
         "@libsql/isomorphic-ws": "^0.1.5",
-        "cross-fetch": "^4.0.0",
-        "js-base64": "^3.7.5",
-        "node-fetch": "^3.3.2"
+        "js-base64": "^3.7.5"
       }
     },
     "node_modules/@libsql/isomorphic-ws": {
@@ -3198,9 +3196,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
-      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.1.tgz",
+      "integrity": "sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3208,12 +3206,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
-      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.1.tgz",
+      "integrity": "sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.99.2"
+        "@tanstack/query-core": "5.100.1"
       },
       "funding": {
         "type": "github",
@@ -5050,35 +5048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5249,15 +5218,6 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -6437,29 +6397,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6538,18 +6475,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded-parse": {
@@ -8324,9 +8249,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
-      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.9.0.tgz",
+      "integrity": "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8630,26 +8555,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -8667,24 +8572,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -10600,12 +10487,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -11158,27 +11039,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.1",
@@ -11238,16 +11104,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@libsql/client": "^0.17.2",
-    "@tanstack/react-query": "^5.99.2",
+    "@libsql/client": "^0.17.3",
+    "@tanstack/react-query": "^5.100.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.8.0",
+    "lucide-react": "^1.9.0",
     "next": "16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/src/app/api/cron/process-uploads/route.ts
+++ b/src/app/api/cron/process-uploads/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from 'next/server'
+import { getPendingUploads, updateQueueItemStatus } from '@/lib/db/queries/upload-queue'
+import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
+import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
+import { uploadVideoToYouTube } from '@/lib/youtube/upload'
+import { apiOk, apiFail } from '@/lib/api/response'
+import { logger } from '@/lib/logger'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+export async function GET(req: NextRequest) {
+  const secret = req.headers.get('authorization')?.replace('Bearer ', '')
+  const expected = process.env.CRON_SECRET
+  if (expected && secret !== expected) {
+    return apiFail('UNAUTHORIZED', 'Invalid cron secret', 401)
+  }
+
+  const items = await getPendingUploads(3)
+  if (items.length === 0) {
+    return apiOk({ processed: 0, message: 'No pending uploads' })
+  }
+
+  const results: { id: number; status: string; videoId?: string; error?: string }[] = []
+
+  for (const item of items) {
+    await updateQueueItemStatus(item.id, 'processing')
+
+    try {
+      const accessToken = await getOrRefreshAccessToken(item.userId)
+      if (!accessToken) {
+        await updateQueueItemStatus(item.id, 'failed', { error: 'No valid access token — user may need to re-login' })
+        results.push({ id: item.id, status: 'failed', error: 'no_token' })
+        continue
+      }
+
+      // Fetch video from source URL
+      const allowed = ['.blob.core.windows.net', '.perso.ai', 'perso.ai']
+      const urlHost = new URL(item.videoUrl).hostname
+      const isAllowed = allowed.some((d) => urlHost === d || urlHost.endsWith(d))
+      if (!isAllowed) {
+        await updateQueueItemStatus(item.id, 'failed', { error: 'Video URL domain not allowed' })
+        results.push({ id: item.id, status: 'failed', error: 'invalid_domain' })
+        continue
+      }
+
+      const videoRes = await fetch(item.videoUrl)
+      if (!videoRes.ok) {
+        await updateQueueItemStatus(item.id, 'failed', { error: `Failed to fetch video: ${videoRes.status}` })
+        results.push({ id: item.id, status: 'failed', error: 'fetch_failed' })
+        continue
+      }
+      const videoBlob = await videoRes.blob()
+
+      const result = await uploadVideoToYouTube({
+        accessToken,
+        videoBlob,
+        title: item.title,
+        description: item.description,
+        tags: item.tags ? item.tags.split(',') : [],
+        privacyStatus: item.privacyStatus as 'public' | 'unlisted' | 'private',
+        language: item.language || undefined,
+      })
+
+      await updateQueueItemStatus(item.id, 'done', { youtubeVideoId: result.videoId })
+
+      // Update DB records
+      try {
+        await createYouTubeUpload({
+          userId: item.userId,
+          youtubeVideoId: result.videoId,
+          title: item.title,
+          languageCode: item.langCode,
+          privacyStatus: item.privacyStatus,
+          isShort: item.isShort,
+        })
+        await updateJobLanguageYouTube(item.jobId, item.langCode, result.videoId)
+      } catch {
+        // DB update is best-effort
+      }
+
+      results.push({ id: item.id, status: 'done', videoId: result.videoId })
+      logger.info('queue upload success', { queueId: item.id, videoId: result.videoId })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      await updateQueueItemStatus(item.id, 'failed', { error: msg })
+      results.push({ id: item.id, status: 'failed', error: msg })
+      logger.error('queue upload failed', { queueId: item.id, error: msg })
+    }
+  }
+
+  return apiOk({ processed: results.length, results })
+}

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -11,6 +11,7 @@ import {
   deductUserMinutes,
   addUserCredits,
   deleteDubbingJob,
+  createUploadQueueItem,
 } from '@/lib/db/queries'
 import { requireSession } from '@/lib/auth/session'
 import { mutationActionSchema, getUserIdFromAction, getJobIdFromAction } from '@/lib/validators/dashboard'
@@ -114,6 +115,10 @@ export async function POST(req: NextRequest) {
         const { userId, minutes } = action.payload
         await addUserCredits(userId, minutes)
         return apiOk({ userId, minutes })
+      }
+      case 'queueYouTubeUpload': {
+        const id = await createUploadQueueItem(action.payload)
+        return apiOk({ queueId: id })
       }
       case 'deleteDubbingJob': {
         const { jobId } = action.payload

--- a/src/features/dubbing/components/DubbingWizard.tsx
+++ b/src/features/dubbing/components/DubbingWizard.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn'
 import { useDubbingStore } from '../store/dubbingStore'
 import { VideoInputStep } from './steps/VideoInputStep'
 import { LanguageSelectStep } from './steps/LanguageSelectStep'
+import { OutputModeStep } from './steps/OutputModeStep'
 import { UploadSettingsStep } from './steps/UploadSettingsStep'
 import { TranslationEditStep } from './steps/TranslationEditStep'
 import { ProcessingStep } from './steps/ProcessingStep'
@@ -13,10 +14,11 @@ import { UploadStep } from './steps/UploadStep'
 const steps = [
   { num: 1, label: '영상' },
   { num: 2, label: '언어' },
-  { num: 3, label: '업로드 설정' },
-  { num: 4, label: '확인' },
-  { num: 5, label: '처리' },
-  { num: 6, label: '결과' },
+  { num: 3, label: '결과물' },
+  { num: 4, label: '업로드 설정' },
+  { num: 5, label: '확인' },
+  { num: 6, label: '처리' },
+  { num: 7, label: '결과' },
 ] as const
 
 export function DubbingWizard() {
@@ -70,10 +72,11 @@ export function DubbingWizard() {
       <div className="animate-fade-in">
         {currentStep === 1 && <VideoInputStep />}
         {currentStep === 2 && <LanguageSelectStep />}
-        {currentStep === 3 && <UploadSettingsStep />}
-        {currentStep === 4 && <TranslationEditStep />}
-        {currentStep === 5 && <ProcessingStep />}
-        {currentStep === 6 && <UploadStep />}
+        {currentStep === 3 && <OutputModeStep />}
+        {currentStep === 4 && <UploadSettingsStep />}
+        {currentStep === 5 && <TranslationEditStep />}
+        {currentStep === 6 && <ProcessingStep />}
+        {currentStep === 7 && <UploadStep />}
       </div>
     </div>
   )

--- a/src/features/dubbing/components/SubtitleEditor.tsx
+++ b/src/features/dubbing/components/SubtitleEditor.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { ChevronDown, ChevronUp, Download, Eye, EyeOff, Save, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui'
+import { getLanguageByCode } from '@/utils/languages'
+import { useNotificationStore } from '@/stores/notificationStore'
+import { getProjectScript, updateSentenceTranslation } from '@/lib/api-client'
+import { toSRT } from '@/utils/srt'
+import type { ScriptSentence } from '@/lib/perso/types'
+
+function formatMs(ms: number): string {
+  const h = Math.floor(ms / 3600000)
+  const m = Math.floor((ms % 3600000) / 60000)
+  const s = Math.floor((ms % 60000) / 1000)
+  const remainder = ms % 1000
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(remainder).padStart(3, '0')}`
+}
+
+function parseTimeToMs(timeStr: string): number | null {
+  const match = timeStr.match(/^(\d{1,2}):(\d{2}):(\d{2}),(\d{3})$/)
+  if (!match) return null
+  const [, h, m, s, ms] = match
+  return Number(h) * 3600000 + Number(m) * 60000 + Number(s) * 1000 + Number(ms)
+}
+
+interface EditableSentence extends ScriptSentence {
+  editedTranslatedText: string
+  editedStartMs: number
+  editedEndMs: number
+}
+
+interface SubtitleRowProps {
+  sentence: EditableSentence
+  projectSeq: number
+  onUpdate: (sentenceSeq: number, patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'editedStartMs' | 'editedEndMs'>>) => void
+}
+
+function SubtitleRow({ sentence, projectSeq, onUpdate }: SubtitleRowProps) {
+  const addToast = useNotificationStore((s) => s.addToast)
+  const [saving, setSaving] = useState(false)
+  const [startTimeStr, setStartTimeStr] = useState(formatMs(sentence.editedStartMs))
+  const [endTimeStr, setEndTimeStr] = useState(formatMs(sentence.editedEndMs))
+
+  const textDirty = sentence.editedTranslatedText !== sentence.translatedText
+
+  const handleSaveText = useCallback(async () => {
+    setSaving(true)
+    try {
+      await updateSentenceTranslation(projectSeq, sentence.sentenceSeq, sentence.editedTranslatedText)
+      addToast({ type: 'success', title: '저장됨', message: '번역이 업데이트되었습니다.' })
+    } catch {
+      addToast({ type: 'error', title: '저장 실패' })
+    } finally {
+      setSaving(false)
+    }
+  }, [projectSeq, sentence.sentenceSeq, sentence.editedTranslatedText, addToast])
+
+  const handleStartTimeBlur = useCallback(() => {
+    const ms = parseTimeToMs(startTimeStr)
+    if (ms !== null) {
+      onUpdate(sentence.sentenceSeq, { editedStartMs: ms })
+    } else {
+      setStartTimeStr(formatMs(sentence.editedStartMs))
+    }
+  }, [startTimeStr, sentence.sentenceSeq, sentence.editedStartMs, onUpdate])
+
+  const handleEndTimeBlur = useCallback(() => {
+    const ms = parseTimeToMs(endTimeStr)
+    if (ms !== null) {
+      onUpdate(sentence.sentenceSeq, { editedEndMs: ms })
+    } else {
+      setEndTimeStr(formatMs(sentence.editedEndMs))
+    }
+  }, [endTimeStr, sentence.sentenceSeq, sentence.editedEndMs, onUpdate])
+
+  return (
+    <div className="rounded-lg border border-surface-200 p-3 space-y-2 dark:border-surface-800">
+      <div className="flex items-center gap-2 text-xs">
+        <input
+          type="text"
+          value={startTimeStr}
+          onChange={(e) => setStartTimeStr(e.target.value)}
+          onBlur={handleStartTimeBlur}
+          className="w-28 rounded border border-surface-300 bg-white px-2 py-0.5 text-xs font-mono text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+        />
+        <span className="text-surface-400">&rarr;</span>
+        <input
+          type="text"
+          value={endTimeStr}
+          onChange={(e) => setEndTimeStr(e.target.value)}
+          onBlur={handleEndTimeBlur}
+          className="w-28 rounded border border-surface-300 bg-white px-2 py-0.5 text-xs font-mono text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+        />
+        {sentence.speakerLabel && (
+          <span className="rounded bg-surface-100 px-1.5 py-0.5 text-surface-400 dark:bg-surface-800">{sentence.speakerLabel}</span>
+        )}
+      </div>
+      <p className="text-xs text-surface-500 italic">&ldquo;{sentence.originalText}&rdquo;</p>
+      <textarea
+        value={sentence.editedTranslatedText}
+        onChange={(e) => onUpdate(sentence.sentenceSeq, { editedTranslatedText: e.target.value })}
+        rows={2}
+        className="w-full resize-none rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+      />
+      {textDirty && (
+        <div className="flex justify-end">
+          <Button size="sm" variant="outline" onClick={handleSaveText} loading={saving}>
+            <Save className="h-3.5 w-3.5" />
+            서버에 저장
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface SubtitleEditorProps {
+  langCode: string
+  projectSeq: number
+  spaceSeq: number
+}
+
+export function SubtitleEditor({ langCode, projectSeq, spaceSeq }: SubtitleEditorProps) {
+  const addToast = useNotificationStore((s) => s.addToast)
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [sentences, setSentences] = useState<EditableSentence[] | null>(null)
+  const [showPreview, setShowPreview] = useState(false)
+
+  const lang = getLanguageByCode(langCode)
+
+  const loadScript = useCallback(async () => {
+    if (sentences) { setOpen((v) => !v); return }
+    setLoading(true)
+    setOpen(true)
+    try {
+      const data = await getProjectScript(projectSeq, spaceSeq)
+      const list: ScriptSentence[] = Array.isArray(data) ? data : []
+      setSentences(list.map((s) => ({
+        ...s,
+        editedTranslatedText: s.translatedText,
+        editedStartMs: s.startMs,
+        editedEndMs: s.endMs,
+      })))
+    } catch {
+      addToast({ type: 'error', title: '스크립트 로드 실패' })
+      setOpen(false)
+    } finally {
+      setLoading(false)
+    }
+  }, [sentences, projectSeq, spaceSeq, addToast])
+
+  const handleUpdate = useCallback((sentenceSeq: number, patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'editedStartMs' | 'editedEndMs'>>) => {
+    setSentences((prev) =>
+      prev?.map((s) => s.sentenceSeq === sentenceSeq ? { ...s, ...patch } : s) ?? null
+    )
+  }, [])
+
+  const handleDownloadSRT = useCallback(() => {
+    if (!sentences) return
+    const srtContent = toSRT(sentences.map((s) => ({
+      startMs: s.editedStartMs,
+      endMs: s.editedEndMs,
+      translatedText: s.editedTranslatedText,
+    })))
+    const blob = new Blob([srtContent], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${lang?.name || langCode}_${langCode}.srt`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, [sentences, lang, langCode])
+
+  const srtPreview = sentences
+    ? toSRT(sentences.map((s) => ({
+        startMs: s.editedStartMs,
+        endMs: s.editedEndMs,
+        translatedText: s.editedTranslatedText,
+      })))
+    : ''
+
+  return (
+    <div className="rounded-lg border border-surface-200 dark:border-surface-800">
+      <button
+        onClick={loadScript}
+        className="flex w-full items-center justify-between p-3 text-left hover:bg-surface-50 dark:hover:bg-surface-800/50 transition-colors cursor-pointer rounded-lg"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-lg">{lang?.flag}</span>
+          <span className="text-sm font-medium text-surface-900 dark:text-white">{lang?.name} 자막</span>
+        </div>
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin text-surface-400" />
+        ) : open ? (
+          <ChevronUp className="h-4 w-4 text-surface-400" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-surface-400" />
+        )}
+      </button>
+
+      {open && sentences && (
+        <div className="border-t border-surface-200 p-3 space-y-3 dark:border-surface-800">
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={handleDownloadSRT}>
+              <Download className="h-3.5 w-3.5" />
+              SRT 다운로드
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setShowPreview((v) => !v)}>
+              {showPreview ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+              SRT 미리보기
+            </Button>
+          </div>
+
+          {showPreview && (
+            <textarea
+              readOnly
+              value={srtPreview}
+              rows={12}
+              className="w-full resize-y rounded-md border border-surface-300 bg-surface-50 px-3 py-2 font-mono text-xs text-surface-700 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+            />
+          )}
+
+          <div className="max-h-96 overflow-y-auto space-y-2">
+            <p className="text-xs text-surface-400 mb-3">
+              타이밍과 번역 텍스트를 수정한 뒤 SRT를 다운로드하세요. 타이밍 변경은 SRT 내보내기에만 반영됩니다.
+              번역 텍스트는 &ldquo;서버에 저장&rdquo; 버튼으로 서버에 반영할 수 있습니다.
+            </p>
+            {sentences.length === 0 && (
+              <p className="text-sm text-surface-500 py-4 text-center">
+                표시할 자막이 없습니다.
+              </p>
+            )}
+            {sentences.map((s) => (
+              <SubtitleRow
+                key={s.sentenceSeq}
+                sentence={s}
+                projectSeq={projectSeq}
+                onUpdate={handleUpdate}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/dubbing/components/YouTubeExtensionUpload.tsx
+++ b/src/features/dubbing/components/YouTubeExtensionUpload.tsx
@@ -11,6 +11,7 @@ interface Props {
   videoId: string
   completedLangs: string[]
   getAudioUrl: (langCode: string) => Promise<string | undefined>
+  autoTrigger?: boolean
 }
 
 const INSTALL_GUIDE_URL = 'https://github.com/perso-devrel/creatordubbing/blob/main/extension/README.md'
@@ -23,12 +24,15 @@ interface ExtJob {
   videoId: string
   languageCode: string
   status: JobStatus
+  step?: string
+  error?: string
 }
 
 interface LangJobState {
   jobId: string
   status: JobStatus
   step?: string
+  error?: string
 }
 
 const STEP_LABELS: Record<string, string> = {
@@ -38,13 +42,15 @@ const STEP_LABELS: Record<string, string> = {
   INJECTING_AUDIO: '오디오 주입 중',
   WAITING_PUBLISH: '게시 대기',
   PUBLISHING: '게시 중',
+  COMPLETED: '완료',
 }
 
-export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }: Props) {
+export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl, autoTrigger = false }: Props) {
   const { status: extensionStatus, version, recheck } = useExtensionDetect()
   const [uploadingLang, setUploadingLang] = useState<string | null>(null)
   const [langJobs, setLangJobs] = useState<Record<string, LangJobState>>({})
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const autoTriggered = useRef(false)
   const addToast = useNotificationStore((s) => s.addToast)
 
   const pollJobs = useCallback(async () => {
@@ -58,6 +64,8 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
           updated[job.languageCode] = {
             jobId: job.jobId,
             status: job.status,
+            step: job.step,
+            error: job.error,
           }
         }
       }
@@ -122,6 +130,23 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
     }
   }, [videoId, getAudioUrl, addToast])
 
+  // Auto-trigger: sequentially upload all languages without user clicking
+  useEffect(() => {
+    if (!autoTrigger || autoTriggered.current) return
+    if (extensionStatus !== 'installed') return
+    if (completedLangs.length === 0) return
+    autoTriggered.current = true
+
+    const runAll = async () => {
+      for (const code of completedLangs) {
+        if (langJobs[code]?.status === 'done') continue
+        await handleExtensionUpload(code)
+      }
+    }
+    runAll()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoTrigger, extensionStatus, completedLangs.length])
+
   if (extensionStatus === 'checking') return null
 
   if (extensionStatus === 'not-installed') {
@@ -184,7 +209,15 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl }:
                   <p className="text-xs text-emerald-600">업로드 완료</p>
                 )}
                 {job?.status === 'error' && (
-                  <p className="text-xs text-red-500">자동 업로드 실패 — 아래에서 수동 진행</p>
+                  <div>
+                    <p className="text-xs text-red-500">자동 업로드 실패</p>
+                    {job.error && (
+                      <p className="text-[10px] text-red-400 mt-0.5 break-all">{job.error}</p>
+                    )}
+                    {job.step && (
+                      <p className="text-[10px] text-red-400">실패 단계: {STEP_LABELS[job.step] || job.step}</p>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect } from 'react'
+import { ArrowLeft, ArrowRight, Film, Music, Download, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui'
+import { cn } from '@/utils/cn'
+import { useDubbingStore } from '../../store/dubbingStore'
+import type { DeliverableMode, VideoSourceType } from '../../types/dubbing.types'
+
+interface DeliverableOption {
+  value: DeliverableMode
+  icon: typeof Film
+  title: string
+  description: string
+}
+
+function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
+  const options: DeliverableOption[] = [
+    {
+      value: 'newDubbedVideos',
+      icon: Film,
+      title: '새 더빙 영상 업로드',
+      description: '더빙된 영상을 언어별 새 YouTube 영상으로 업로드합니다.',
+    },
+  ]
+
+  if (sourceType === 'channel') {
+    options.push({
+      value: 'originalWithMultiAudio',
+      icon: Music,
+      title: '기존 영상에 오디오 트랙 추가',
+      description: '내 YouTube 영상에 더빙 오디오를 멀티 트랙으로 자동 추가합니다.',
+    })
+  } else if (sourceType === 'upload') {
+    options.push({
+      value: 'originalWithMultiAudio',
+      icon: Music,
+      title: '원본 업로드 + 오디오 트랙 추가',
+      description: '원본 영상을 YouTube에 업로드한 뒤, 더빙 오디오를 멀티 트랙으로 자동 추가합니다.',
+    })
+  }
+
+  options.push({
+    value: 'downloadOnly',
+    icon: Download,
+    title: '다운로드만',
+    description: '더빙 파일을 다운로드만 합니다. YouTube에 업로드하지 않습니다.',
+  })
+
+  return options
+}
+
+export function OutputModeStep() {
+  const { deliverableMode, setDeliverableMode, videoSource, prevStep, nextStep } = useDubbingStore()
+  const sourceType = videoSource?.type ?? 'upload'
+  const options = getAvailableOptions(sourceType)
+  const isExternalUrl = videoSource?.type === 'url'
+
+  useEffect(() => {
+    if (!options.some((o) => o.value === deliverableMode)) {
+      setDeliverableMode('newDubbedVideos')
+    }
+  }, [sourceType, options, deliverableMode, setDeliverableMode])
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-surface-900 dark:text-white">결과물 선택</h2>
+        <p className="mt-1 text-surface-500">
+          더빙 결과물을 어떻게 활용할지 선택하세요.
+        </p>
+      </div>
+
+      {isExternalUrl && (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/10">
+          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-amber-900 dark:text-amber-300">저작권 안내</p>
+            <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+              타인의 영상을 무단으로 재업로드하면 저작권 위반이 될 수 있습니다. 저작권을 지켜주세요.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className={cn('grid gap-4', options.length === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2')}>
+        {options.map(({ value, icon: Icon, title, description }) => {
+          const selected = deliverableMode === value
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setDeliverableMode(value)}
+              className={cn(
+                'flex flex-col items-center gap-4 rounded-xl border-2 p-6 text-center transition-all cursor-pointer',
+                selected
+                  ? 'border-brand-500 bg-brand-50 shadow-lg shadow-brand-500/10 dark:bg-brand-900/10'
+                  : 'border-surface-200 bg-white hover:border-surface-300 dark:border-surface-700 dark:bg-surface-800 dark:hover:border-surface-600',
+              )}
+            >
+              <div
+                className={cn(
+                  'flex h-14 w-14 items-center justify-center rounded-full',
+                  selected
+                    ? 'bg-brand-500 text-white'
+                    : 'bg-surface-100 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
+                )}
+              >
+                <Icon className="h-7 w-7" />
+              </div>
+              <div>
+                <p className={cn(
+                  'text-lg font-semibold',
+                  selected ? 'text-brand-700 dark:text-brand-300' : 'text-surface-900 dark:text-white',
+                )}>
+                  {title}
+                </p>
+                <p className="mt-2 text-sm text-surface-500">{description}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="secondary" onClick={prevStep}>
+          <ArrowLeft className="h-4 w-4" />
+          이전
+        </Button>
+        <Button onClick={nextStep}>
+          {deliverableMode === 'downloadOnly' ? '다음: 설정 확인' : '다음: 업로드 설정'}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { ArrowLeft, ArrowRight, Film, Music, Download, AlertTriangle } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Film, Subtitles, Download, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { useDubbingStore } from '../../store/dubbingStore'
@@ -27,16 +27,16 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
   if (sourceType === 'channel') {
     options.push({
       value: 'originalWithMultiAudio',
-      icon: Music,
-      title: '기존 영상에 오디오 트랙 추가',
-      description: '내 YouTube 영상에 더빙 오디오를 멀티 트랙으로 자동 추가합니다.',
+      icon: Subtitles,
+      title: '기존 영상에 자막 추가',
+      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다. 오디오 트랙도 선택 가능합니다.',
     })
   } else if (sourceType === 'upload') {
     options.push({
       value: 'originalWithMultiAudio',
-      icon: Music,
-      title: '원본 업로드 + 오디오 트랙 추가',
-      description: '원본 영상을 YouTube에 업로드한 뒤, 더빙 오디오를 멀티 트랙으로 자동 추가합니다.',
+      icon: Subtitles,
+      title: '원본 업로드 + 자막 추가',
+      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다. 오디오 트랙도 선택 가능합니다.',
     })
   }
 

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Loader2, CheckCircle2, AlertCircle, XCircle } from 'lucide-react'
 import { Card, Progress, Badge, Button } from '@/components/ui'
 import { cn } from '@/utils/cn'
@@ -45,10 +45,12 @@ export function ProcessingStep() {
   const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted } = useDubbingStore()
   const { submitDubbing, startPolling, stopPolling, cancelAll } = usePersoFlow()
   const [cancelling, setCancelling] = useState(false)
+  const submittedRef = useRef(isSubmitted)
 
-  // Submit dubbing and start polling on mount
+  // Submit dubbing and start polling on mount — ref guard prevents double-fire in Strict Mode
   useEffect(() => {
-    if (isSubmitted) return
+    if (submittedRef.current) return
+    submittedRef.current = true
     setIsSubmitted(true)
 
     const run = async () => {
@@ -62,8 +64,8 @@ export function ProcessingStep() {
     run()
 
     return () => stopPolling()
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount; callbacks are stable enough
-  }, [isSubmitted])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once on mount
+  }, [])
 
   // Auto-advance when all complete
   const allCompleted = languageProgress.length > 0 && languageProgress.every(
@@ -73,7 +75,7 @@ export function ProcessingStep() {
   useEffect(() => {
     if (allCompleted) {
       stopPolling()
-      const t = setTimeout(() => setStep(6), 2000)
+      const t = setTimeout(() => setStep(7), 2000)
       return () => clearTimeout(t)
     }
   }, [allCompleted, setStep, stopPolling])

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -8,7 +8,7 @@ import { getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 
 export function TranslationEditStep() {
-  const { sourceLanguage, selectedLanguages, lipSyncEnabled, setLipSync, videoMeta, prevStep, nextStep } = useDubbingStore()
+  const { sourceLanguage, selectedLanguages, lipSyncEnabled, setLipSync, videoMeta, deliverableMode, uploadSettings, prevStep, nextStep } = useDubbingStore()
   const [speakers, setSpeakers] = useState(1)
 
   const sourceLang = getLanguageByCode(sourceLanguage)
@@ -89,6 +89,27 @@ export function TranslationEditStep() {
               <p className="text-xs text-surface-400 mt-0.5">더빙 오디오에 맞춰 입 모양을 조절합니다</p>
             </div>
             <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
+          </div>
+
+          {/* Deliverable mode */}
+          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+            <span className="text-sm text-surface-600 dark:text-surface-400">결과물 모드</span>
+            <span className="text-sm font-medium text-surface-900 dark:text-white">
+              {deliverableMode === 'newDubbedVideos' ? '새 더빙 영상 업로드'
+                : deliverableMode === 'originalWithMultiAudio' ? '멀티 오디오 트랙 추가'
+                : '다운로드만'}
+            </span>
+          </div>
+
+          {/* Auto upload */}
+          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+            <span className="text-sm text-surface-600 dark:text-surface-400">자동 업로드</span>
+            <span className={cn(
+              'text-sm font-medium',
+              uploadSettings.autoUpload ? 'text-emerald-600 dark:text-emerald-400' : 'text-surface-500',
+            )}>
+              {uploadSettings.autoUpload ? 'ON' : 'OFF'}
+            </span>
           </div>
         </div>
       </Card>

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -96,7 +96,7 @@ export function TranslationEditStep() {
             <span className="text-sm text-surface-600 dark:text-surface-400">결과물 모드</span>
             <span className="text-sm font-medium text-surface-900 dark:text-white">
               {deliverableMode === 'newDubbedVideos' ? '새 더빙 영상 업로드'
-                : deliverableMode === 'originalWithMultiAudio' ? '멀티 오디오 트랙 추가'
+                : deliverableMode === 'originalWithMultiAudio' ? '원본 영상에 자막 추가'
                 : '다운로드만'}
             </span>
           </div>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo } from 'react'
 import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
-import { cn } from '@/utils/cn'
 import { extractVideoId } from '@/utils/validators'
 import { getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo } from 'react'
 import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
+import { cn } from '@/utils/cn'
 import { extractVideoId } from '@/utils/validators'
 import { getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
@@ -20,6 +21,7 @@ export function UploadSettingsStep() {
     videoSource,
     isShort,
     selectedLanguages,
+    deliverableMode,
     uploadSettings,
     setUploadSettings,
     prevStep,
@@ -32,7 +34,6 @@ export function UploadSettingsStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
-  // 처음 진입 시 기본값(제목/설명) 채워 주기 — 비어 있을 때만
   useEffect(() => {
     const patch: Partial<typeof uploadSettings> = {}
     if (!uploadSettings.title && videoMeta?.title) {
@@ -50,9 +51,9 @@ export function UploadSettingsStep() {
     return getLanguageByCode(first)?.name || first
   }, [selectedLanguages])
 
-  const previewTitle = firstLangName
+  const previewTitle = firstLangName && deliverableMode === 'newDubbedVideos'
     ? `${uploadSettings.uploadAsShort ? '#Shorts ' : ''}[${firstLangName}] ${uploadSettings.title || '(제목 없음)'}`
-    : null
+    : uploadSettings.title || '(제목 없음)'
 
   const previewDescription = (() => {
     const base = uploadSettings.description || '(설명 없음)'
@@ -72,84 +73,139 @@ export function UploadSettingsStep() {
     setUploadSettings({ tags: parsed })
   }
 
-  const canContinue = uploadSettings.title.trim().length > 0
+  const canContinue =
+    deliverableMode === 'originalWithMultiAudio'
+      ? true
+      : uploadSettings.title.trim().length > 0
+
+  const isMultiAudio = deliverableMode === 'originalWithMultiAudio'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="text-center">
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">업로드 설정</h2>
         <p className="mt-1 text-surface-500">
-          처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요. 각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.
+          {isMultiAudio
+            ? '원본 영상에 오디오 트랙을 추가합니다. 기본 설정을 확인하세요.'
+            : '처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요.'}
         </p>
       </div>
 
-      <Card>
-        <CardTitle>제목 · 설명 · 태그</CardTitle>
-        <div className="mt-4 space-y-4">
-          <Input
-            label="제목 (공통)"
-            value={uploadSettings.title}
-            onChange={(e) => setUploadSettings({ title: e.target.value })}
-            placeholder="영상 제목"
-          />
+      {/* Title/Desc/Tags — only for newDubbedVideos or originalWithMultiAudio(upload) */}
+      {deliverableMode === 'newDubbedVideos' && (
+        <Card>
+          <CardTitle>제목 · 설명 · 태그</CardTitle>
+          <p className="mt-1 mb-4 text-xs text-surface-500">각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.</p>
+          <div className="space-y-4">
+            <Input
+              label="제목 (공통)"
+              value={uploadSettings.title}
+              onChange={(e) => setUploadSettings({ title: e.target.value })}
+              placeholder="영상 제목"
+            />
 
-          <div className="w-full">
-            <label htmlFor="upload-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
-              설명
-            </label>
-            <textarea
-              id="upload-description"
-              rows={4}
-              value={uploadSettings.description}
-              onChange={(e) => setUploadSettings({ description: e.target.value })}
-              placeholder="영상 설명"
-              className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
+            <div className="w-full">
+              <label htmlFor="upload-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+                설명
+              </label>
+              <textarea
+                id="upload-description"
+                rows={4}
+                value={uploadSettings.description}
+                onChange={(e) => setUploadSettings({ description: e.target.value })}
+                placeholder="영상 설명"
+                className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
+              />
+            </div>
+
+            <Input
+              label="태그 (쉼표 구분)"
+              value={tagsString}
+              onChange={(e) => handleTagsChange(e.target.value)}
+              placeholder="CreatorDub, AI더빙, dubbed"
+            />
+
+            <Select
+              label="공개 설정"
+              value={uploadSettings.privacyStatus}
+              onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
+              options={PRIVACY_OPTIONS}
+            />
+            <p className="-mt-2 text-xs text-surface-400">
+              안전을 위해 비공개를 권장합니다. 업로드 후 YouTube Studio에서 변경할 수 있습니다.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {/* Multi-audio: show privacy for original upload if source is file upload */}
+      {isMultiAudio && videoSource?.type === 'upload' && (
+        <Card>
+          <CardTitle>원본 영상 업로드 설정</CardTitle>
+          <p className="mt-1 mb-4 text-xs text-surface-500">
+            원본 영상이 YouTube에 먼저 업로드된 후, 더빙 오디오 트랙이 자동 추가됩니다.
+          </p>
+          <div className="space-y-4">
+            <Input
+              label="제목"
+              value={uploadSettings.title}
+              onChange={(e) => setUploadSettings({ title: e.target.value })}
+              placeholder="영상 제목"
+            />
+
+            <div className="w-full">
+              <label htmlFor="upload-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+                설명
+              </label>
+              <textarea
+                id="upload-description"
+                rows={3}
+                value={uploadSettings.description}
+                onChange={(e) => setUploadSettings({ description: e.target.value })}
+                placeholder="영상 설명"
+                className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
+              />
+            </div>
+
+            <Select
+              label="공개 설정"
+              value={uploadSettings.privacyStatus}
+              onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
+              options={PRIVACY_OPTIONS}
             />
           </div>
+        </Card>
+      )}
 
-          <Input
-            label="태그 (쉼표 구분)"
-            value={tagsString}
-            onChange={(e) => handleTagsChange(e.target.value)}
-            placeholder="CreatorDub, AI더빙, dubbed"
-          />
-
-          <Select
-            label="공개 설정"
-            value={uploadSettings.privacyStatus}
-            onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
-            options={PRIVACY_OPTIONS}
-          />
-          <p className="-mt-2 text-xs text-surface-400">
-            안전을 위해 비공개를 권장합니다. 업로드 후 YouTube Studio에서 변경할 수 있습니다.
-          </p>
-        </div>
-      </Card>
-
+      {/* Upload options — for both newDubbedVideos and originalWithMultiAudio */}
       <Card>
         <CardTitle>업로드 옵션</CardTitle>
         <div className="mt-4 space-y-2">
           <ToggleRow
             icon={<Upload className="h-4 w-4 text-emerald-500" />}
             label="완료 즉시 자동 업로드"
-            description="더빙이 완료되면 개입 없이 모든 언어를 자동으로 업로드합니다."
+            description={isMultiAudio
+              ? '더빙 완료 시 자동으로 오디오 트랙을 추가합니다.'
+              : '더빙이 완료되면 개입 없이 모든 언어를 자동으로 업로드합니다.'}
             active={uploadSettings.autoUpload}
             activeLabel="ON"
             inactiveLabel="OFF"
             onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
           />
 
-          <ToggleRow
-            icon={<Zap className="h-4 w-4 text-brand-500" />}
-            label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
-            description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
-            active={uploadSettings.uploadAsShort}
-            activeLabel="Shorts ON"
-            inactiveLabel="Shorts OFF"
-            onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
-          />
+          {deliverableMode === 'newDubbedVideos' && (
+            <ToggleRow
+              icon={<Zap className="h-4 w-4 text-brand-500" />}
+              label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
+              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
+              active={uploadSettings.uploadAsShort}
+              activeLabel="Shorts ON"
+              inactiveLabel="Shorts OFF"
+              onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
+            />
+          )}
 
-          {originalYouTubeUrl && (
+          {originalYouTubeUrl && deliverableMode === 'newDubbedVideos' && (
             <ToggleRow
               icon={<Link2 className="h-4 w-4 text-surface-400" />}
               label="설명란에 원본 YouTube 링크 첨부"
@@ -163,7 +219,8 @@ export function UploadSettingsStep() {
         </div>
       </Card>
 
-      {previewTitle && (
+      {/* Preview — only for newDubbedVideos */}
+      {deliverableMode === 'newDubbedVideos' && firstLangName && (
         <Card className="border-brand-200 bg-brand-50/40 dark:border-brand-800 dark:bg-brand-900/10">
           <CardTitle>미리보기 ({firstLangName})</CardTitle>
           <div className="mt-3 space-y-2">

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -48,6 +48,7 @@ export function UploadStep() {
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
+  const [captionUploads, setCaptionUploads] = useState<Record<string, UploadStatus>>({})
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoUploadTriggered = useRef(false)
   const autoChainTriggered = useRef(false)
@@ -380,8 +381,46 @@ export function UploadStep() {
     }
   }, [completedLangs, ytUploads, queueYouTubeUpload])
 
+  // ─── Caption upload to YouTube ───────────────────────────────────────
+  const uploadCaptions = useCallback(async (targetVideoId: string, langs: string[]) => {
+    for (const langCode of langs) {
+      const lang = getLanguageByCode(langCode)
+      if (!lang) continue
+      const pSeq = projectMap[langCode]
+      if (!pSeq || !spaceSeq) continue
+
+      setCaptionUploads((prev) => ({ ...prev, [langCode]: 'uploading' }))
+      try {
+        const data = await getProjectScript(pSeq, spaceSeq)
+        const list = Array.isArray(data) ? data : []
+        if (list.length === 0) {
+          setCaptionUploads((prev) => ({ ...prev, [langCode]: 'error' }))
+          continue
+        }
+        const srtContent = toSRT(list)
+        await ytUploadCaption({
+          videoId: targetVideoId,
+          language: toBcp47(langCode),
+          name: `${lang.name} subtitles`,
+          srtContent,
+        })
+        setCaptionUploads((prev) => ({ ...prev, [langCode]: 'done' }))
+        addToast({ type: 'success', title: `${lang.name} 자막 업로드 완료` })
+      } catch (err) {
+        setCaptionUploads((prev) => ({ ...prev, [langCode]: 'error' }))
+        const msg = err instanceof Error ? err.message : '자막 업로드 실패'
+        addToast({ type: 'error', title: `${lang.name} 자막 업로드 실패`, message: msg })
+      }
+    }
+  }, [projectMap, spaceSeq, addToast])
+
+  const handleUploadCaptionsToVideo = useCallback(async (targetVideoId: string) => {
+    const pending = completedLangs.filter((code) => captionUploads[code] !== 'done')
+    await uploadCaptions(targetVideoId, pending)
+  }, [completedLangs, captionUploads, uploadCaptions])
+
   // ─── Auto-chain: originalWithMultiAudio ──────────────────────────────
-  // 1. Upload original (if file upload) → 2. Auto-trigger extension for audio tracks
+  // 1. Upload original (if file upload) → 2. Auto-upload captions → 3. Extension for audio tracks
   useEffect(() => {
     if (deliverableMode !== 'originalWithMultiAudio') return
     if (!autoUpload || !isAuthenticated) return
@@ -398,8 +437,9 @@ export function UploadStep() {
         targetVideoId = await uploadOriginalToYouTube()
       }
 
-      // Extension auto-upload is handled by YouTubeExtensionUpload component
-      // which is rendered with the resolved videoId
+      if (targetVideoId) {
+        await uploadCaptions(targetVideoId, completedLangs)
+      }
     }
 
     chain()
@@ -503,6 +543,69 @@ export function UploadStep() {
                   영상 보기
                 </a>
               </div>
+            </Card>
+          )}
+
+          {/* Caption auto-upload */}
+          {multiAudioVideoId && (
+            <Card className="border-emerald-200 dark:border-emerald-800">
+              <div className="flex items-center justify-between mb-4">
+                <CardTitle>자막(SRT) 업로드</CardTitle>
+                {isAuthenticated ? (
+                  <Badge variant="success">인증됨</Badge>
+                ) : (
+                  <Badge variant="warning">로그인 필요</Badge>
+                )}
+              </div>
+              <p className="mb-4 text-sm text-surface-500">
+                번역된 자막을 원본 영상에 자동으로 업로드합니다.
+              </p>
+              <div className="space-y-2">
+                {completedLangs.map((code) => {
+                  const lang = getLanguageByCode(code)
+                  if (!lang) return null
+                  const status = captionUploads[code]
+                  return (
+                    <div key={code} className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span className="text-lg">{lang.flag}</span>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                          {status === 'uploading' && <p className="text-xs text-brand-500">업로드 중...</p>}
+                          {status === 'done' && <p className="text-xs text-emerald-600">자막 업로드 완료</p>}
+                          {status === 'error' && <p className="text-xs text-red-500">업로드 실패</p>}
+                        </div>
+                      </div>
+                      {status === 'done' ? (
+                        <Badge variant="success">완료</Badge>
+                      ) : status === 'uploading' ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-brand-500" />
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => uploadCaptions(multiAudioVideoId, [code])}
+                          disabled={!isAuthenticated}
+                        >
+                          <Upload className="h-3.5 w-3.5" />
+                          {status === 'error' ? '재시도' : '업로드'}
+                        </Button>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+              {completedLangs.length > 1 && (
+                <Button
+                  className="mt-3 w-full"
+                  variant="secondary"
+                  onClick={() => handleUploadCaptionsToVideo(multiAudioVideoId)}
+                  disabled={!isAuthenticated || completedLangs.every((c) => captionUploads[c] === 'done')}
+                >
+                  <Upload className="h-4 w-4" />
+                  전체 자막 업로드
+                </Button>
+              )}
             </Card>
           )}
 
@@ -705,6 +808,45 @@ export function UploadStep() {
               YouTube에 로그인하면 더빙된 영상을 자동으로 채널에 업로드할 수 있습니다.
             </p>
           )}
+        </Card>
+      )}
+
+      {/* ─── Caption upload to original video (URL source) ─── */}
+      {deliverableMode === 'newDubbedVideos' && originalYouTubeId && completedLangs.length > 0 && isAuthenticated && (
+        <Card>
+          <CardTitle>원본 영상에 자막 추가</CardTitle>
+          <p className="mb-4 mt-1 text-sm text-surface-500">
+            번역된 자막(SRT)을 원본 YouTube 영상에 업로드합니다.
+          </p>
+          <div className="space-y-2">
+            {completedLangs.map((code) => {
+              const lang = getLanguageByCode(code)
+              if (!lang) return null
+              const status = captionUploads[code]
+              return (
+                <div key={code} className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+                  <div className="flex items-center gap-3">
+                    <span className="text-lg">{lang.flag}</span>
+                    <div>
+                      <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                      {status === 'done' && <p className="text-xs text-emerald-600">자막 업로드 완료</p>}
+                      {status === 'error' && <p className="text-xs text-red-500">업로드 실패</p>}
+                    </div>
+                  </div>
+                  {status === 'done' ? (
+                    <Badge variant="success">완료</Badge>
+                  ) : status === 'uploading' ? (
+                    <Loader2 className="h-4 w-4 animate-spin text-brand-500" />
+                  ) : (
+                    <Button variant="outline" size="sm" onClick={() => uploadCaptions(originalYouTubeId, [code])}>
+                      <Upload className="h-3.5 w-3.5" />
+                      자막 업로드
+                    </Button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
         </Card>
       )}
 

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -26,15 +26,18 @@ interface LangUploadState {
 }
 
 export function UploadStep() {
-  const { selectedLanguages, videoMeta, videoSource, languageProgress, dbJobId, spaceSeq, projectMap, uploadSettings, reset } = useDubbingStore()
+  const {
+    selectedLanguages, videoMeta, videoSource, languageProgress, dbJobId,
+    spaceSeq, projectMap, uploadSettings, deliverableMode, originalVideoUrl, reset,
+  } = useDubbingStore()
   const { fetchDownloads } = usePersoFlow()
   const addToast = useNotificationStore((s) => s.addToast)
   const userId = useAuthStore((s) => s.user?.uid)
   const router = useRouter()
 
-  // Original YouTube link detection (for auto-attach)
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
+  const channelVideoId = videoSource?.type === 'channel' ? videoSource.videoId : null
   const originalYouTubeUrl = originalYouTubeId
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
@@ -45,7 +48,19 @@ export function UploadStep() {
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoUploadTriggered = useRef(false)
+  const autoChainTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  // Original video upload state (for upload + originalWithMultiAudio)
+  const [originalUploadState, setOriginalUploadState] = useState<{
+    status: 'idle' | 'uploading' | 'done' | 'skipped'
+    videoId?: string
+    error?: string
+  }>({ status: videoSource?.type === 'channel' ? 'skipped' : 'idle' })
+
+  // Resolve the target videoId for multi-audio
+  const multiAudioVideoId =
+    originalUploadState.videoId || channelVideoId || null
 
   const buildDescription = useCallback(
     (langName: string) => {
@@ -63,16 +78,43 @@ export function UploadStep() {
   const handleNewDubbing = () => reset()
   const handleGoToDashboard = () => { reset(); router.push('/dashboard') }
 
-  // Audio + Studio helper — downloads audio and opens Studio in popup
-  // (iframe embed is blocked by YouTube's X-Frame-Options: DENY, so we use a popup)
-  const handleAudioToStudio = useCallback(async (langCode: string) => {
+  // ─── Original video upload (for upload + originalWithMultiAudio) ──────
+  const uploadOriginalToYouTube = useCallback(async () => {
+    if (!isAuthenticated || !originalVideoUrl) return null
+
+    setOriginalUploadState({ status: 'uploading' })
+    try {
+      const result = await ytUploadVideo({
+        videoUrl: originalVideoUrl,
+        title: settingsTitle?.trim() || videoMeta?.title || 'Original Video',
+        description: settingsDescription || '',
+        tags: settingsTags,
+        privacyStatus,
+      })
+      setOriginalUploadState({ status: 'done', videoId: result.videoId })
+      addToast({
+        type: 'success',
+        title: '원본 영상 YouTube 업로드 완료',
+        message: `영상 ID: ${result.videoId}`,
+      })
+      return result.videoId
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '원본 업로드 실패'
+      setOriginalUploadState({ status: 'idle', error: msg })
+      addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
+      return null
+    }
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast])
+
+  // ─── Audio → Studio helper ──────────────────────────────────────────
+  const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {
     const lang = getLanguageByCode(langCode)
     if (!lang) return
     setStudioOpenedLang(langCode)
     try {
-      // 1. Fetch audio download link
       const data = await fetchDownloads(langCode, 'voiceAudio')
-      const audioUrl = data?.audioFile?.voiceAudioDownloadLink
+      const rawAudioUrl = data?.audioFile?.voiceAudioDownloadLink
+      const audioUrl = rawAudioUrl ? (rawAudioUrl.startsWith('http') ? rawAudioUrl : getPersoFileUrl(rawAudioUrl)) : undefined
       if (audioUrl) {
         const a = document.createElement('a')
         a.href = audioUrl
@@ -82,16 +124,13 @@ export function UploadStep() {
         document.body.removeChild(a)
       }
 
-      // 2. Copy language code to clipboard (Studio audio track needs it)
       try {
         await navigator.clipboard.writeText(langCode)
-      } catch {
-        // Clipboard may fail on insecure contexts — ignore
-      }
+      } catch { /* ignore */ }
 
-      // 3. Open Studio in popup — deep-link to original video's audio page if available
-      const studioUrl = originalYouTubeId
-        ? `https://studio.youtube.com/video/${originalYouTubeId}/translations/audio`
+      const vid = targetVideoId || originalYouTubeId
+      const studioUrl = vid
+        ? `https://studio.youtube.com/video/${vid}/translations/audio`
         : 'https://studio.youtube.com'
       window.open(studioUrl, 'yt-studio', 'width=1400,height=900,noopener')
 
@@ -105,6 +144,7 @@ export function UploadStep() {
     }
   }, [fetchDownloads, originalYouTubeId, addToast])
 
+  // ─── File download ──────────────────────────────────────────────────
   const handleDownload = useCallback(async (langCode: string, type: 'video' | 'voiceAudio' | 'translatedSubtitle') => {
     setLoadingDownload(`${langCode}-${type}`)
     try {
@@ -112,19 +152,29 @@ export function UploadStep() {
       const data = await fetchDownloads(langCode, target as 'all')
       if (!data) return
 
-      let url: string | undefined
-      if (type === 'video' && data.videoFile?.videoDownloadLink) url = data.videoFile.videoDownloadLink
-      else if (type === 'voiceAudio' && data.audioFile?.voiceAudioDownloadLink) url = data.audioFile.voiceAudioDownloadLink
-      else if (type === 'translatedSubtitle' && data.srtFile?.translatedSubtitleDownloadLink) url = data.srtFile.translatedSubtitleDownloadLink
-      else if (data.zippedFileDownloadLink) url = data.zippedFileDownloadLink
+      let rawUrl: string | undefined
+      if (type === 'video' && data.videoFile?.videoDownloadLink) rawUrl = data.videoFile.videoDownloadLink
+      else if (type === 'voiceAudio' && data.audioFile?.voiceAudioDownloadLink) rawUrl = data.audioFile.voiceAudioDownloadLink
+      else if (type === 'translatedSubtitle' && data.srtFile?.translatedSubtitleDownloadLink) rawUrl = data.srtFile.translatedSubtitleDownloadLink
+      else if (data.zippedFileDownloadLink) rawUrl = data.zippedFileDownloadLink
 
-      if (url) window.open(url, '_blank')
+      if (rawUrl) {
+        const fullUrl = rawUrl.startsWith('http') ? rawUrl : getPersoFileUrl(rawUrl)
+        const ext = type === 'video' ? 'mp4' : type === 'voiceAudio' ? 'wav' : 'srt'
+        const lang = getLanguageByCode(langCode)
+        const a = document.createElement('a')
+        a.href = fullUrl
+        a.download = `${lang?.name || langCode}_${langCode}.${ext}`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+      }
     } finally {
       setLoadingDownload(null)
     }
   }, [fetchDownloads])
 
-  // Upload dubbed video to YouTube
+  // ─── Upload dubbed video to YouTube (newDubbedVideos mode) ──────────
   const handleYouTubeUpload = useCallback(async (langCode: string) => {
     if (!isAuthenticated) {
       addToast({ type: 'error', title: 'YouTube에 먼저 로그인해주세요' })
@@ -137,13 +187,11 @@ export function UploadStep() {
     setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 0 } }))
 
     try {
-      // 1. Get dubbed video download link from Perso (always fresh — avoids stale DB link)
       const downloads = await fetchDownloads(langCode, 'dubbingVideo')
       const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
       if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
       const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
-      // 2. Upload to YouTube — server fetches video from Perso CDN directly (avoids browser CORS)
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
@@ -161,12 +209,9 @@ export function UploadStep() {
         privacyStatus,
         language: langCode,
       })
-      setYtUploads((prev) => ({
-        ...prev,
-        [langCode]: { status: 'uploading', progress: 90 },
-      }))
+      setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 90 } }))
 
-      // 4. Try uploading SRT caption
+      // Upload SRT caption
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 92 } }))
       try {
         const srtDownloads = await fetchDownloads(langCode, 'translatedSubtitle')
@@ -181,16 +226,13 @@ export function UploadStep() {
             srtContent: srtText,
           })
         }
-      } catch {
-        // Caption upload is optional, don't fail the whole process
-      }
+      } catch { /* caption upload is optional */ }
 
       setYtUploads((prev) => ({
         ...prev,
         [langCode]: { status: 'done', progress: 100, videoId: result.videoId },
       }))
 
-      // Save to DB
       try {
         if (userId) {
           await dbMutation({
@@ -211,9 +253,7 @@ export function UploadStep() {
             })
           }
         }
-      } catch {
-        // DB save best-effort
-      }
+      } catch { /* DB save best-effort */ }
 
       const privacyLabel = privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'
       addToast({
@@ -230,6 +270,65 @@ export function UploadStep() {
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
   }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription])
+
+  // ─── Queue upload (background — survives tab close) ─────────────────
+  const queueYouTubeUpload = useCallback(async (langCode: string) => {
+    if (!userId || !dbJobId) return
+
+    const lang = getLanguageByCode(langCode)
+    if (!lang) return
+
+    setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 10 } }))
+
+    try {
+      const downloads = await fetchDownloads(langCode, 'dubbingVideo')
+      const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
+      if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
+      const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
+
+      const titlePrefix = uploadAsShort ? '#Shorts ' : ''
+      const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
+      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const langTags = Array.from(new Set([
+        ...settingsTags,
+        lang.name,
+        ...(uploadAsShort ? ['Shorts'] : []),
+      ]))
+
+      await dbMutation({
+        type: 'queueYouTubeUpload',
+        payload: {
+          userId,
+          jobId: dbJobId,
+          langCode,
+          videoUrl,
+          title: ytTitle,
+          description: buildDescription(lang.name),
+          tags: langTags,
+          privacyStatus,
+          language: langCode,
+          isShort: uploadAsShort,
+        },
+      })
+
+      setYtUploads((prev) => ({
+        ...prev,
+        [langCode]: { status: 'done', progress: 100 },
+      }))
+      addToast({
+        type: 'success',
+        title: `${lang.name} 업로드 예약됨`,
+        message: '서버에서 백그라운드로 업로드합니다. 탭을 닫아도 됩니다.',
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '큐 등록 실패'
+      setYtUploads((prev) => ({
+        ...prev,
+        [langCode]: { status: 'error', progress: 0, error: msg },
+      }))
+      addToast({ type: 'error', title: `${lang?.name} 큐 등록 실패`, message: msg })
+    }
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsTags, privacyStatus, buildDescription])
 
   const completedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
@@ -252,12 +351,47 @@ export function UploadStep() {
     }
   }, [completedLangs, ytUploads, handleYouTubeUpload])
 
+  const handleQueueAll = useCallback(async () => {
+    const pending = completedLangs.filter((code) => ytUploads[code]?.status !== 'done')
+    for (const code of pending) {
+      await queueYouTubeUpload(code)
+    }
+  }, [completedLangs, ytUploads, queueYouTubeUpload])
+
+  // ─── Auto-chain: originalWithMultiAudio ──────────────────────────────
+  // 1. Upload original (if file upload) → 2. Auto-trigger extension for audio tracks
   useEffect(() => {
+    if (deliverableMode !== 'originalWithMultiAudio') return
+    if (!autoUpload || !isAuthenticated) return
+    if (completedLangs.length === 0) return
+    if (autoChainTriggered.current) return
+    autoChainTriggered.current = true
+
+    const chain = async () => {
+      let targetVideoId: string | undefined | null
+
+      if (videoSource?.type === 'channel' && channelVideoId) {
+        targetVideoId = channelVideoId
+      } else if (videoSource?.type === 'upload' && originalVideoUrl) {
+        targetVideoId = await uploadOriginalToYouTube()
+      }
+
+      // Extension auto-upload is handled by YouTubeExtensionUpload component
+      // which is rendered with the resolved videoId
+    }
+
+    chain()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deliverableMode, autoUpload, isAuthenticated, completedLangs.length])
+
+  // ─── Auto-upload: newDubbedVideos ────────────────────────────────────
+  useEffect(() => {
+    if (deliverableMode !== 'newDubbedVideos') return
     if (autoUpload && isAuthenticated && completedLangs.length > 0 && !autoUploadTriggered.current && !anyUploading) {
       autoUploadTriggered.current = true
       handleUploadAll()
     }
-  }, [autoUpload, isAuthenticated, completedLangs.length, anyUploading, handleUploadAll])
+  }, [deliverableMode, autoUpload, isAuthenticated, completedLangs.length, anyUploading, handleUploadAll])
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -269,133 +403,290 @@ export function UploadStep() {
           {failedLangs.length > 0 ? '더빙 부분 완료' : '더빙된 영상이 준비되었습니다!'}
         </h2>
         <p className="mt-1 text-surface-500">
-          {completedLangs.length} / {selectedLanguages.length}개 언어 완료. 다운로드하거나 YouTube에 업로드하세요.
+          {completedLangs.length} / {selectedLanguages.length}개 언어 완료.
+          {deliverableMode === 'downloadOnly'
+            ? ' 파일을 다운로드하세요.'
+            : deliverableMode === 'originalWithMultiAudio'
+              ? ' 원본 영상에 오디오 트랙을 추가합니다.'
+              : ' 다운로드하거나 YouTube에 업로드하세요.'}
         </p>
       </div>
 
-      {/* YouTube Auto Upload */}
-      <Card className="border-brand-200 dark:border-brand-800">
-        <div className="flex items-center justify-between mb-4">
-          <CardTitle>YouTube 자동 업로드</CardTitle>
-          {isAuthenticated ? (
-            <Badge variant="success">인증됨</Badge>
-          ) : (
-            <Badge variant="warning">Google 로그인 시 자동 인증</Badge>
-          )}
-        </div>
-
-        {isAuthenticated ? (
-          <>
-            <p className="text-sm text-surface-500 mb-4">
-              더빙된 영상을 YouTube에 새 영상으로 업로드합니다. 안전을 위해 비공개로 업로드되며, 이후 YouTube Studio에서 공개 설정을 변경할 수 있습니다.
-            </p>
-
-            {/* Upload options summary — read-only, set in Step 3 */}
-            <div className="mb-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 text-xs text-surface-500 space-y-1">
-              <p>
-                자동 업로드: <span className="font-medium text-surface-700 dark:text-surface-300">{autoUpload ? 'ON' : 'OFF'}</span>
-                {' · '}
-                Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
-                {' · '}
-                공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
-              </p>
-              {attachOriginalLink && originalYouTubeUrl && (
-                <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>
-              )}
-            </div>
-
-            {/* Upload info */}
-            <div className="mb-4 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
-              <div className="flex items-center gap-2 mb-2">
-                <Upload className="h-4 w-4 text-surface-400" />
-                <span className="text-sm font-medium text-surface-700 dark:text-surface-300">더빙 영상을 새 영상으로 업로드</span>
-              </div>
-              <p className="text-xs text-surface-500">
-                각 언어별 더빙된 영상이 별도의 새 영상으로 YouTube에 업로드됩니다. 원본 영상은 변경되지 않습니다.
-              </p>
-              <div className="flex items-center gap-2 mt-2">
-                <Volume2 className="h-4 w-4 text-surface-400" />
-                <span className="text-xs text-surface-500">
-                  오디오만 필요하면 아래 다운로드에서 Audio를 받아 YouTube Studio에서 수동 추가하세요.
-                </span>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              {completedLangs.map((code) => {
-                const lang = getLanguageByCode(code)
-                if (!lang) return null
-                const state = ytUploads[code]
-
-                return (
-                  <div
-                    key={code}
-                    className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800"
-                  >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <span className="text-lg">{lang.flag}</span>
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
-                        {state?.status === 'uploading' && (
-                          <Progress value={state.progress} size="sm" className="mt-1 w-32" />
-                        )}
-                        {state?.status === 'done' && state.videoId && (
-                          <p className="text-xs text-emerald-600">
-                            업로드 완료 — <a
-                              href={`https://youtube.com/watch?v=${state.videoId}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="underline"
-                            >영상 보기</a>
-                          </p>
-                        )}
-                        {state?.status === 'error' && (
-                          <p className="text-xs text-red-500">{state.error}</p>
-                        )}
-                      </div>
-                    </div>
-
-                    {state?.status === 'done' ? (
-                      <Badge variant="success">완료</Badge>
-                    ) : state?.status === 'uploading' ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-brand-500" />
-                    ) : (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleYouTubeUpload(code)}
-                        disabled={anyUploading}
-                      >
-                        <Upload className="h-3.5 w-3.5" />
-                        업로드
-                      </Button>
-                    )}
+      {/* ─── originalWithMultiAudio: Original upload + extension auto ─── */}
+      {deliverableMode === 'originalWithMultiAudio' && completedLangs.length > 0 && (
+        <>
+          {/* Original upload status (file upload only) */}
+          {videoSource?.type === 'upload' && (
+            <Card>
+              <CardTitle>원본 영상 YouTube 업로드</CardTitle>
+              <div className="mt-3">
+                {originalUploadState.status === 'idle' && (
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm text-surface-500">
+                      원본 영상을 YouTube에 업로드해야 오디오 트랙을 추가할 수 있습니다.
+                    </p>
+                    <Button
+                      size="sm"
+                      onClick={uploadOriginalToYouTube}
+                      disabled={!isAuthenticated}
+                    >
+                      <Upload className="h-4 w-4" />
+                      원본 업로드
+                    </Button>
                   </div>
-                )
-              })}
-            </div>
+                )}
+                {originalUploadState.status === 'uploading' && (
+                  <div className="flex items-center gap-3">
+                    <Loader2 className="h-5 w-5 animate-spin text-brand-500" />
+                    <p className="text-sm text-surface-600 dark:text-surface-400">원본 영상 업로드 중...</p>
+                  </div>
+                )}
+                {originalUploadState.status === 'done' && originalUploadState.videoId && (
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Check className="h-5 w-5 text-emerald-500" />
+                      <p className="text-sm text-emerald-700 dark:text-emerald-400">
+                        업로드 완료 — <a
+                          href={`https://youtube.com/watch?v=${originalUploadState.videoId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline"
+                        >영상 보기</a>
+                      </p>
+                    </div>
+                    <Badge variant="success">완료</Badge>
+                  </div>
+                )}
+                {originalUploadState.error && (
+                  <p className="text-xs text-red-500 mt-1">{originalUploadState.error}</p>
+                )}
+              </div>
+            </Card>
+          )}
 
-            {completedLangs.length > 1 && (
-              <Button
-                className="mt-3 w-full"
-                onClick={handleUploadAll}
-                disabled={anyUploading}
-                loading={anyUploading}
-              >
-                <Upload className="h-4 w-4" />
-                전체 YouTube 업로드
-              </Button>
-            )}
-          </>
-        ) : (
-          <p className="text-sm text-surface-500">
-            YouTube에 로그인하면 더빙된 영상을 자동으로 채널에 업로드할 수 있습니다.
-            자막(SRT)도 함께 업로드됩니다.
+          {/* Channel source — already on YouTube */}
+          {videoSource?.type === 'channel' && channelVideoId && (
+            <Card>
+              <div className="flex items-center gap-2">
+                <Check className="h-5 w-5 text-emerald-500" />
+                <p className="text-sm text-surface-700 dark:text-surface-300">
+                  기존 YouTube 영상에 오디오 트랙을 추가합니다.
+                </p>
+                <a
+                  href={`https://youtube.com/watch?v=${channelVideoId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-brand-500 underline"
+                >
+                  영상 보기
+                </a>
+              </div>
+            </Card>
+          )}
+
+          {/* Extension auto-upload for multi-audio */}
+          {multiAudioVideoId && (
+            <Card className="border-brand-200 dark:border-brand-800">
+              <CardTitle>멀티 오디오 트랙 추가</CardTitle>
+              <p className="mb-4 mt-1 text-sm text-surface-500">
+                더빙된 오디오를 원본 영상에 멀티 트랙으로 추가합니다.
+              </p>
+              <YouTubeExtensionUpload
+                videoId={multiAudioVideoId}
+                completedLangs={completedLangs}
+                autoTrigger={autoUpload}
+                getAudioUrl={async (langCode) => {
+                  const data = await fetchDownloads(langCode, 'voiceAudio')
+                  const raw = data?.audioFile?.voiceAudioDownloadLink
+                  return raw ? (raw.startsWith('http') ? raw : getPersoFileUrl(raw)) : undefined
+                }}
+              />
+
+              {/* Manual fallback */}
+              <div className="mt-4 border-t border-surface-200 pt-4 dark:border-surface-700">
+                <p className="text-xs text-surface-500 mb-3">
+                  확장 프로그램 없이 수동으로 진행하려면 아래 버튼을 사용하세요.
+                </p>
+                <div className="space-y-2">
+                  {completedLangs.map((code) => {
+                    const lang = getLanguageByCode(code)
+                    if (!lang) return null
+                    const opening = studioOpenedLang === code
+                    return (
+                      <div key={code} className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+                        <div className="flex items-center gap-3">
+                          <span className="text-lg">{lang.flag}</span>
+                          <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                        </div>
+                        <Button variant="outline" size="sm" onClick={() => handleAudioToStudio(code, multiAudioVideoId)} loading={opening}>
+                          <Volume2 className="h-3.5 w-3.5" />
+                          오디오 + Studio
+                        </Button>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            </Card>
+          )}
+        </>
+      )}
+
+      {/* ─── Audio preview for manual mode ─── */}
+      {!autoUpload && completedLangs.length > 0 && (
+        <Card>
+          <CardTitle>오디오 미리듣기</CardTitle>
+          <p className="mb-4 mt-1 text-xs text-surface-500">
+            업로드 전에 더빙된 오디오를 확인하세요.
           </p>
-        )}
-      </Card>
+          <div className="space-y-3">
+            {completedLangs.map((code) => {
+              const lang = getLanguageByCode(code)
+              const lp = languageProgress.find((p) => p.langCode === code)
+              if (!lang || !lp?.audioUrl) return null
+              return (
+                <div key={code} className="flex items-center gap-3 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+                  <span className="text-lg">{lang.flag}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-surface-900 dark:text-white mb-1">{lang.name}</p>
+                    <audio controls preload="none" className="w-full h-8" src={lp.audioUrl}>
+                      <track kind="captions" />
+                    </audio>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </Card>
+      )}
 
-      {/* Download section */}
+      {/* ─── newDubbedVideos: YouTube Auto Upload ─── */}
+      {deliverableMode === 'newDubbedVideos' && (
+        <Card className="border-brand-200 dark:border-brand-800">
+          <div className="flex items-center justify-between mb-4">
+            <CardTitle>YouTube 업로드</CardTitle>
+            {isAuthenticated ? (
+              <Badge variant="success">인증됨</Badge>
+            ) : (
+              <Badge variant="warning">Google 로그인 시 자동 인증</Badge>
+            )}
+          </div>
+
+          {isAuthenticated ? (
+            <>
+              <p className="text-sm text-surface-500 mb-4">
+                더빙된 영상을 YouTube에 새 영상으로 업로드합니다.
+              </p>
+
+              <div className="mb-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 text-xs text-surface-500 space-y-1">
+                <p>
+                  자동 업로드: <span className="font-medium text-surface-700 dark:text-surface-300">{autoUpload ? 'ON' : 'OFF'}</span>
+                  {' · '}
+                  Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
+                  {' · '}
+                  공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
+                </p>
+                {attachOriginalLink && originalYouTubeUrl && (
+                  <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                {completedLangs.map((code) => {
+                  const lang = getLanguageByCode(code)
+                  if (!lang) return null
+                  const state = ytUploads[code]
+
+                  return (
+                    <div
+                      key={code}
+                      className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span className="text-lg">{lang.flag}</span>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                          {state?.status === 'uploading' && (
+                            <Progress value={state.progress} size="sm" className="mt-1 w-32" />
+                          )}
+                          {state?.status === 'done' && state.videoId && (
+                            <p className="text-xs text-emerald-600">
+                              업로드 완료 — <a
+                                href={`https://youtube.com/watch?v=${state.videoId}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline"
+                              >영상 보기</a>
+                            </p>
+                          )}
+                          {state?.status === 'error' && (
+                            <p className="text-xs text-red-500">{state.error}</p>
+                          )}
+                        </div>
+                      </div>
+
+                      {state?.status === 'done' ? (
+                        <Badge variant="success">완료</Badge>
+                      ) : state?.status === 'uploading' ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-brand-500" />
+                      ) : (
+                        <div className="flex gap-1">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleYouTubeUpload(code)}
+                            disabled={anyUploading}
+                          >
+                            <Upload className="h-3.5 w-3.5" />
+                            즉시
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => queueYouTubeUpload(code)}
+                            disabled={anyUploading}
+                          >
+                            예약
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+
+              {completedLangs.length > 1 && (
+                <div className="mt-3 flex gap-2">
+                  <Button
+                    className="flex-1"
+                    onClick={handleUploadAll}
+                    disabled={anyUploading}
+                    loading={anyUploading}
+                  >
+                    <Upload className="h-4 w-4" />
+                    즉시 업로드
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    className="flex-1"
+                    onClick={handleQueueAll}
+                    disabled={anyUploading}
+                  >
+                    <Upload className="h-4 w-4" />
+                    예약 (탭 닫아도 OK)
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-surface-500">
+              YouTube에 로그인하면 더빙된 영상을 자동으로 채널에 업로드할 수 있습니다.
+            </p>
+          )}
+        </Card>
+      )}
+
+      {/* ─── Download section ─── */}
       {completedLangs.length > 0 && (
         <Card>
           <CardTitle>더빙 파일 다운로드</CardTitle>
@@ -413,14 +704,18 @@ export function UploadStep() {
                     <span className="text-lg">{lang.flag}</span>
                     <div>
                       <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
-                      <p className="text-xs text-surface-400">Video + Audio + SRT</p>
+                      <p className="text-xs text-surface-400">
+                        {deliverableMode === 'originalWithMultiAudio' ? 'Audio + SRT' : 'Video + Audio + SRT'}
+                      </p>
                     </div>
                   </div>
                   <div className="flex gap-2">
-                    <Button variant="outline" size="sm" onClick={() => handleDownload(code, 'video')}
-                      loading={loadingDownload === `${code}-video`}>
-                      <Download className="h-3.5 w-3.5" /> Video
-                    </Button>
+                    {deliverableMode !== 'originalWithMultiAudio' && (
+                      <Button variant="outline" size="sm" onClick={() => handleDownload(code, 'video')}
+                        loading={loadingDownload === `${code}-video`}>
+                        <Download className="h-3.5 w-3.5" /> Video
+                      </Button>
+                    )}
                     <Button variant="outline" size="sm" onClick={() => handleDownload(code, 'voiceAudio')}
                       loading={loadingDownload === `${code}-voiceAudio`}>
                       <Download className="h-3.5 w-3.5" /> Audio
@@ -437,7 +732,7 @@ export function UploadStep() {
         </Card>
       )}
 
-      {/* Failed languages */}
+      {/* ─── Failed languages ─── */}
       {failedLangs.length > 0 && (
         <Card className="border-red-200 dark:border-red-800">
           <CardTitle>실패한 언어</CardTitle>
@@ -453,7 +748,7 @@ export function UploadStep() {
         </Card>
       )}
 
-      {/* Script editor — fix translation mistakes */}
+      {/* ─── Script editor ─── */}
       {completedLangs.length > 0 && spaceSeq && (
         <Card>
           <CardTitle>스크립트 수정</CardTitle>
@@ -473,82 +768,7 @@ export function UploadStep() {
         </Card>
       )}
 
-      {/* YouTube Multi-Audio Track — extension auto + manual fallback */}
-      {completedLangs.length > 0 && (
-        <Card>
-          <CardTitle>원본 영상에 오디오 트랙 추가 (Multi-Audio)</CardTitle>
-
-          {/* Chrome Extension auto upload */}
-          {originalYouTubeId && (
-            <div className="mb-4">
-              <YouTubeExtensionUpload
-                videoId={originalYouTubeId}
-                completedLangs={completedLangs}
-                getAudioUrl={async (langCode) => {
-                  const data = await fetchDownloads(langCode, 'voiceAudio')
-                  return data?.audioFile?.voiceAudioDownloadLink
-                }}
-              />
-            </div>
-          )}
-          <p className="text-xs text-surface-500 mb-3">
-            하나의 영상에 여러 오디오 트랙을 붙이려면 YouTube Studio에서 수동 적용이 필요합니다.
-            아래 버튼을 누르면 오디오가 다운로드되고 Studio가 팝업으로 열립니다. 언어 코드는 클립보드에 복사됩니다.
-          </p>
-          <div className="mb-3 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-800 dark:bg-amber-900/10 dark:border-amber-800 dark:text-amber-300">
-            Multi-Audio Track은 YouTube 고급 기능(Advanced Features) 접근 권한이 필요하며, 점진적으로 확대 중입니다.
-            {!originalYouTubeId && ' 원본이 YouTube URL이 아니면 Studio 홈으로 이동합니다 — 대상 영상을 직접 선택하세요.'}
-          </div>
-          <div className="space-y-2">
-            {completedLangs.map((code) => {
-              const lang = getLanguageByCode(code)
-              if (!lang) return null
-              const opening = studioOpenedLang === code
-              return (
-                <div
-                  key={code}
-                  className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800"
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="text-lg">{lang.flag}</span>
-                    <div>
-                      <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
-                      <p className="text-xs text-surface-400">오디오 다운로드 + Studio 팝업</p>
-                    </div>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleAudioToStudio(code)}
-                    loading={opening}
-                  >
-                    <Volume2 className="h-3.5 w-3.5" />
-                    오디오 + Studio
-                  </Button>
-                </div>
-              )
-            })}
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="mt-3"
-            onClick={() =>
-              window.open(
-                originalYouTubeId
-                  ? `https://studio.youtube.com/video/${originalYouTubeId}/translations/audio`
-                  : 'https://studio.youtube.com',
-                '_blank',
-              )
-            }
-          >
-            <ExternalLink className="h-4 w-4" />
-            Studio만 열기
-          </Button>
-        </Card>
-      )}
-
-      {/* Actions */}
+      {/* ─── Actions ─── */}
       <div className="flex gap-3 justify-center">
         <Button variant="secondary" onClick={handleNewDubbing}>
           <RotateCcw className="h-4 w-4" /> 새 더빙

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -49,6 +49,7 @@ export function UploadStep() {
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
   const [captionUploads, setCaptionUploads] = useState<Record<string, UploadStatus>>({})
+  const [audioTrackEnabled, setAudioTrackEnabled] = useState(false)
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoUploadTriggered = useRef(false)
   const autoChainTriggered = useRef(false)
@@ -609,49 +610,74 @@ export function UploadStep() {
             </Card>
           )}
 
-          {/* Extension auto-upload for multi-audio */}
+          {/* Audio track toggle + extension upload */}
           {multiAudioVideoId && (
-            <Card className="border-brand-200 dark:border-brand-800">
-              <CardTitle>멀티 오디오 트랙 추가</CardTitle>
-              <p className="mb-4 mt-1 text-sm text-surface-500">
-                더빙된 오디오를 원본 영상에 멀티 트랙으로 추가합니다.
-              </p>
-              <YouTubeExtensionUpload
-                videoId={multiAudioVideoId}
-                completedLangs={completedLangs}
-                autoTrigger={autoUpload}
-                getAudioUrl={async (langCode) => {
-                  const data = await fetchDownloads(langCode, 'voiceAudio')
-                  const raw = data?.audioFile?.voiceAudioDownloadLink
-                  return raw ? (raw.startsWith('http') ? raw : getPersoFileUrl(raw)) : undefined
-                }}
-              />
-
-              {/* Manual fallback */}
-              <div className="mt-4 border-t border-surface-200 pt-4 dark:border-surface-700">
-                <p className="text-xs text-surface-500 mb-3">
-                  확장 프로그램 없이 수동으로 진행하려면 아래 버튼을 사용하세요.
-                </p>
-                <div className="space-y-2">
-                  {completedLangs.map((code) => {
-                    const lang = getLanguageByCode(code)
-                    if (!lang) return null
-                    const opening = studioOpenedLang === code
-                    return (
-                      <div key={code} className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
-                        <div className="flex items-center gap-3">
-                          <span className="text-lg">{lang.flag}</span>
-                          <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
-                        </div>
-                        <Button variant="outline" size="sm" onClick={() => handleAudioToStudio(code, multiAudioVideoId)} loading={opening}>
-                          <Volume2 className="h-3.5 w-3.5" />
-                          오디오 + Studio
-                        </Button>
-                      </div>
-                    )
-                  })}
+            <Card className="border-surface-200 dark:border-surface-700">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>멀티 오디오 트랙 추가</CardTitle>
+                  <p className="mt-1 text-xs text-surface-500">
+                    더빙된 오디오를 원본 영상에 멀티 트랙으로 추가합니다.
+                  </p>
                 </div>
+                <button
+                  type="button"
+                  onClick={() => setAudioTrackEnabled((v) => !v)}
+                  className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
+                    audioTrackEnabled
+                      ? 'bg-brand-500 text-white'
+                      : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+                  }`}
+                >
+                  {audioTrackEnabled ? 'ON' : 'OFF'}
+                </button>
               </div>
+
+              {!audioTrackEnabled && (
+                <p className="mt-3 text-xs text-amber-600 dark:text-amber-400">
+                  YouTube 멀티 오디오 트랙 기능 허가가 필요합니다. 허가 후 ON으로 전환하세요.
+                </p>
+              )}
+
+              {audioTrackEnabled && (
+                <div className="mt-4 space-y-4">
+                  <YouTubeExtensionUpload
+                    videoId={multiAudioVideoId}
+                    completedLangs={completedLangs}
+                    autoTrigger={autoUpload}
+                    getAudioUrl={async (langCode) => {
+                      const data = await fetchDownloads(langCode, 'voiceAudio')
+                      const raw = data?.audioFile?.voiceAudioDownloadLink
+                      return raw ? (raw.startsWith('http') ? raw : getPersoFileUrl(raw)) : undefined
+                    }}
+                  />
+
+                  <div className="border-t border-surface-200 pt-4 dark:border-surface-700">
+                    <p className="text-xs text-surface-500 mb-3">
+                      확장 프로그램 없이 수동으로 진행하려면 아래 버튼을 사용하세요.
+                    </p>
+                    <div className="space-y-2">
+                      {completedLangs.map((code) => {
+                        const lang = getLanguageByCode(code)
+                        if (!lang) return null
+                        const opening = studioOpenedLang === code
+                        return (
+                          <div key={code} className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+                            <div className="flex items-center gap-3">
+                              <span className="text-lg">{lang.flag}</span>
+                              <p className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</p>
+                            </div>
+                            <Button variant="outline" size="sm" onClick={() => handleAudioToStudio(code, multiAudioVideoId)} loading={opening}>
+                              <Volume2 className="h-3.5 w-3.5" />
+                              오디오 + Studio
+                            </Button>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                </div>
+              )}
             </Card>
           )}
         </>

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -10,10 +10,12 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
 import { useAuthStore } from '@/stores/authStore'
-import { ytUploadVideo, ytUploadCaption, getPersoFileUrl } from '@/lib/api-client'
+import { ytUploadVideo, ytUploadCaption, getPersoFileUrl, getProjectScript } from '@/lib/api-client'
 import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
+import { toSRT } from '@/utils/srt'
 import { ScriptEditor } from '../ScriptEditor'
+import { SubtitleEditor } from '../SubtitleEditor'
 import { YouTubeExtensionUpload } from '../YouTubeExtensionUpload'
 
 type UploadStatus = 'idle' | 'uploading' | 'done' | 'error'
@@ -148,20 +150,38 @@ export function UploadStep() {
   const handleDownload = useCallback(async (langCode: string, type: 'video' | 'voiceAudio' | 'translatedSubtitle') => {
     setLoadingDownload(`${langCode}-${type}`)
     try {
-      const target = type === 'video' ? 'dubbingVideo' : type === 'voiceAudio' ? 'voiceAudio' : 'translatedSubtitle'
+      const lang = getLanguageByCode(langCode)
+
+      if (type === 'translatedSubtitle') {
+        const pSeq = projectMap[langCode]
+        if (!pSeq || !spaceSeq) return
+        const data = await getProjectScript(pSeq, spaceSeq)
+        const list = Array.isArray(data) ? data : []
+        const srtContent = toSRT(list)
+        const blob = new Blob([srtContent], { type: 'text/plain;charset=utf-8' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${lang?.name || langCode}_${langCode}.srt`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+        URL.revokeObjectURL(url)
+        return
+      }
+
+      const target = type === 'video' ? 'dubbingVideo' : 'voiceAudio'
       const data = await fetchDownloads(langCode, target as 'all')
       if (!data) return
 
       let rawUrl: string | undefined
       if (type === 'video' && data.videoFile?.videoDownloadLink) rawUrl = data.videoFile.videoDownloadLink
       else if (type === 'voiceAudio' && data.audioFile?.voiceAudioDownloadLink) rawUrl = data.audioFile.voiceAudioDownloadLink
-      else if (type === 'translatedSubtitle' && data.srtFile?.translatedSubtitleDownloadLink) rawUrl = data.srtFile.translatedSubtitleDownloadLink
       else if (data.zippedFileDownloadLink) rawUrl = data.zippedFileDownloadLink
 
       if (rawUrl) {
         const fullUrl = rawUrl.startsWith('http') ? rawUrl : getPersoFileUrl(rawUrl)
-        const ext = type === 'video' ? 'mp4' : type === 'voiceAudio' ? 'wav' : 'srt'
-        const lang = getLanguageByCode(langCode)
+        const ext = type === 'video' ? 'mp4' : 'wav'
         const a = document.createElement('a')
         a.href = fullUrl
         a.download = `${lang?.name || langCode}_${langCode}.${ext}`
@@ -172,7 +192,7 @@ export function UploadStep() {
     } finally {
       setLoadingDownload(null)
     }
-  }, [fetchDownloads])
+  }, [fetchDownloads, projectMap, spaceSeq])
 
   // ─── Upload dubbed video to YouTube (newDubbedVideos mode) ──────────
   const handleYouTubeUpload = useCallback(async (langCode: string) => {
@@ -211,20 +231,22 @@ export function UploadStep() {
       })
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 90 } }))
 
-      // Upload SRT caption
+      // Upload SRT caption from Script API
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 92 } }))
       try {
-        const srtDownloads = await fetchDownloads(langCode, 'translatedSubtitle')
-        const srtUrl = srtDownloads?.srtFile?.translatedSubtitleDownloadLink
-        if (srtUrl) {
-          const srtResponse = await fetch(srtUrl)
-          const srtText = await srtResponse.text()
-          await ytUploadCaption({
-            videoId: result.videoId,
-            language: toBcp47(langCode),
-            name: `${lang.name} subtitles`,
-            srtContent: srtText,
-          })
+        const pSeq = projectMap[langCode]
+        if (pSeq && spaceSeq) {
+          const scriptData = await getProjectScript(pSeq, spaceSeq)
+          const scriptList = Array.isArray(scriptData) ? scriptData : []
+          if (scriptList.length > 0) {
+            const srtText = toSRT(scriptList)
+            await ytUploadCaption({
+              videoId: result.videoId,
+              language: toBcp47(langCode),
+              name: `${lang.name} subtitles`,
+              srtContent: srtText,
+            })
+          }
         }
       } catch { /* caption upload is optional */ }
 
@@ -269,7 +291,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription, projectMap, spaceSeq])
 
   // ─── Queue upload (background — survives tab close) ─────────────────
   const queueYouTubeUpload = useCallback(async (langCode: string) => {
@@ -758,6 +780,26 @@ export function UploadStep() {
           <div className="space-y-2">
             {completedLangs.map((code) => (
               <ScriptEditor
+                key={code}
+                langCode={code}
+                projectSeq={projectMap[code] || 0}
+                spaceSeq={spaceSeq}
+              />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {/* ─── Subtitle editor ─── */}
+      {completedLangs.length > 0 && spaceSeq && (
+        <Card>
+          <CardTitle>자막 편집 · 다운로드</CardTitle>
+          <p className="mb-4 mt-1 text-xs text-surface-500">
+            자막 타이밍과 텍스트를 수정하고 SRT 파일로 다운로드할 수 있습니다.
+          </p>
+          <div className="space-y-2">
+            {completedLangs.map((code) => (
+              <SubtitleEditor
                 key={code}
                 langCode={code}
                 projectSeq={projectMap[code] || 0}

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -42,7 +42,7 @@ export function VideoInputStep() {
     setLoading(true)
     setError(null)
     try {
-      setVideoSource({ type: 'url', url: videoUrl })
+      setVideoSource({ type: 'channel', url: videoUrl, videoId })
       await importVideoByUrl(videoUrl)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to import video')

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -262,6 +262,9 @@ export function usePersoFlow() {
     try {
       const result = await persoUploadVideoFile(spaceSeq!, file)
       store.getState().setMediaSeq(result.seq)
+      if (result.videoFilePath) {
+        store.getState().setOriginalVideoUrl(getPersoFileUrl(result.videoFilePath))
+      }
       store.getState().setVideoMeta({
         id: String(result.seq),
         title: file.name.replace(/\.\w+$/, ''),

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -10,6 +10,7 @@ import type {
   GlossaryEntry,
   JobStatus,
   UploadSettings,
+  DeliverableMode,
 } from '../types/dubbing.types'
 
 const DEFAULT_UPLOAD_SETTINGS: UploadSettings = {
@@ -42,8 +43,10 @@ interface DubbingState {
   // Step 1: Video source
   videoSource: VideoSource | null
   videoMeta: VideoMetadata | null
+  originalVideoUrl: string | null
   setVideoSource: (source: VideoSource) => void
   setVideoMeta: (meta: VideoMetadata) => void
+  setOriginalVideoUrl: (url: string) => void
 
   // Step 2: Language selection
   sourceLanguage: string
@@ -76,6 +79,12 @@ interface DubbingState {
   isShort: boolean
   setIsShort: (v: boolean) => void
 
+  // Deliverable mode
+  deliverableMode: DeliverableMode
+  copyrightAcknowledged: boolean
+  setDeliverableMode: (mode: DeliverableMode) => void
+  setCopyrightAcknowledged: (v: boolean) => void
+
   // Upload settings (chosen before dubbing starts)
   uploadSettings: UploadSettings
   setUploadSettings: (patch: Partial<UploadSettings>) => void
@@ -96,6 +105,7 @@ const initialState = {
   mediaSeq: null as number | null,
   videoSource: null as VideoSource | null,
   videoMeta: null as VideoMetadata | null,
+  originalVideoUrl: null as string | null,
   sourceLanguage: 'ko',
   selectedLanguages: [] as string[],
   lipSyncEnabled: false,
@@ -106,6 +116,8 @@ const initialState = {
   jobStatus: 'idle' as JobStatus,
   languageProgress: [] as LanguageProgress[],
   glossary: [] as GlossaryEntry[],
+  deliverableMode: 'newDubbedVideos' as DeliverableMode,
+  copyrightAcknowledged: false,
   uploadSettings: { ...DEFAULT_UPLOAD_SETTINGS } as UploadSettings,
 }
 
@@ -114,14 +126,23 @@ export const useDubbingStore = create<DubbingState>((set) => ({
 
   setStep: (step) => set({ currentStep: step }),
   setIsSubmitted: (v) => set({ isSubmitted: v }),
-  nextStep: () => set((s) => ({ currentStep: Math.min(6, s.currentStep + 1) as DubbingStep })),
-  prevStep: () => set((s) => ({ currentStep: Math.max(1, s.currentStep - 1) as DubbingStep })),
+  nextStep: () => set((s) => {
+    let next = s.currentStep + 1
+    if (next === 4 && s.deliverableMode === 'downloadOnly') next = 5
+    return { currentStep: Math.min(7, next) as DubbingStep }
+  }),
+  prevStep: () => set((s) => {
+    let prev = s.currentStep - 1
+    if (prev === 4 && s.deliverableMode === 'downloadOnly') prev = 3
+    return { currentStep: Math.max(1, prev) as DubbingStep }
+  }),
 
   setSpaceSeq: (seq) => set({ spaceSeq: seq }),
   setMediaSeq: (seq) => set({ mediaSeq: seq }),
 
   setVideoSource: (source) => set({ videoSource: source }),
   setVideoMeta: (meta) => set({ videoMeta: meta }),
+  setOriginalVideoUrl: (url) => set({ originalVideoUrl: url }),
 
   setSourceLanguage: (code) =>
     set((s) => ({
@@ -173,6 +194,9 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     isShort: v,
     uploadSettings: { ...s.uploadSettings, uploadAsShort: v },
   })),
+
+  setDeliverableMode: (mode) => set({ deliverableMode: mode }),
+  setCopyrightAcknowledged: (v) => set({ copyrightAcknowledged: v }),
 
   setUploadSettings: (patch) => set((s) => ({
     uploadSettings: { ...s.uploadSettings, ...patch },

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -1,4 +1,6 @@
-export type DubbingStep = 1 | 2 | 3 | 4 | 5 | 6
+export type DubbingStep = 1 | 2 | 3 | 4 | 5 | 6 | 7
+
+export type DeliverableMode = 'newDubbedVideos' | 'originalWithMultiAudio' | 'downloadOnly'
 
 export type PrivacyStatus = 'public' | 'unlisted' | 'private'
 

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -25,6 +25,13 @@ export {
 } from './youtube'
 
 export {
+  createUploadQueueItem,
+  getPendingUploads,
+  updateQueueItemStatus,
+  getUserQueueItems,
+} from './upload-queue'
+
+export {
   getUserDubbingJobs,
   getUserSummary,
   getCreditUsageByMonth,

--- a/src/lib/db/queries/upload-queue.ts
+++ b/src/lib/db/queries/upload-queue.ts
@@ -1,0 +1,153 @@
+import 'server-only'
+
+import { getDb } from '@/lib/db/client'
+
+export type QueueStatus = 'pending' | 'processing' | 'done' | 'failed'
+
+export interface UploadQueueItem {
+  id: number
+  userId: string
+  jobId: number
+  langCode: string
+  videoUrl: string
+  title: string
+  description: string
+  tags: string
+  privacyStatus: string
+  language: string
+  isShort: boolean
+  status: QueueStatus
+  retries: number
+  error: string | null
+  youtubeVideoId: string | null
+  createdAt: string
+}
+
+let tableEnsured = false
+
+async function ensureTable() {
+  if (tableEnsured) return
+  const db = getDb()
+  await db.execute({
+    sql: `CREATE TABLE IF NOT EXISTS upload_queue (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      job_id INTEGER NOT NULL,
+      lang_code TEXT NOT NULL,
+      video_url TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      tags TEXT NOT NULL DEFAULT '',
+      privacy_status TEXT NOT NULL DEFAULT 'private',
+      language TEXT NOT NULL DEFAULT '',
+      is_short INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'pending',
+      retries INTEGER NOT NULL DEFAULT 0,
+      error TEXT,
+      youtube_video_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    args: [],
+  })
+  tableEnsured = true
+}
+
+export async function createUploadQueueItem(item: {
+  userId: string
+  jobId: number
+  langCode: string
+  videoUrl: string
+  title: string
+  description: string
+  tags: string[]
+  privacyStatus: string
+  language: string
+  isShort: boolean
+}): Promise<number> {
+  await ensureTable()
+  const db = getDb()
+  const result = await db.execute({
+    sql: `INSERT INTO upload_queue (user_id, job_id, lang_code, video_url, title, description, tags, privacy_status, language, is_short)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      item.userId,
+      item.jobId,
+      item.langCode,
+      item.videoUrl,
+      item.title,
+      item.description,
+      item.tags.join(','),
+      item.privacyStatus,
+      item.language,
+      item.isShort ? 1 : 0,
+    ],
+  })
+  return Number(result.lastInsertRowid)
+}
+
+export async function getPendingUploads(limit = 5): Promise<UploadQueueItem[]> {
+  await ensureTable()
+  const db = getDb()
+  const result = await db.execute({
+    sql: `SELECT * FROM upload_queue WHERE status IN ('pending', 'failed') AND retries < 3 ORDER BY created_at ASC LIMIT ?`,
+    args: [limit],
+  })
+  return result.rows.map(rowToItem)
+}
+
+export async function updateQueueItemStatus(
+  id: number,
+  status: QueueStatus,
+  extra?: { error?: string; youtubeVideoId?: string },
+) {
+  await ensureTable()
+  const db = getDb()
+  if (extra?.youtubeVideoId) {
+    await db.execute({
+      sql: `UPDATE upload_queue SET status = ?, youtube_video_id = ?, error = NULL, updated_at = datetime('now') WHERE id = ?`,
+      args: [status, extra.youtubeVideoId, id],
+    })
+  } else if (extra?.error) {
+    await db.execute({
+      sql: `UPDATE upload_queue SET status = ?, error = ?, retries = retries + 1, updated_at = datetime('now') WHERE id = ?`,
+      args: [status, extra.error, id],
+    })
+  } else {
+    await db.execute({
+      sql: `UPDATE upload_queue SET status = ?, updated_at = datetime('now') WHERE id = ?`,
+      args: [status, id],
+    })
+  }
+}
+
+export async function getUserQueueItems(userId: string): Promise<UploadQueueItem[]> {
+  await ensureTable()
+  const db = getDb()
+  const result = await db.execute({
+    sql: `SELECT * FROM upload_queue WHERE user_id = ? ORDER BY created_at DESC LIMIT 50`,
+    args: [userId],
+  })
+  return result.rows.map(rowToItem)
+}
+
+function rowToItem(row: Record<string, unknown>): UploadQueueItem {
+  return {
+    id: Number(row.id),
+    userId: String(row.user_id),
+    jobId: Number(row.job_id),
+    langCode: String(row.lang_code),
+    videoUrl: String(row.video_url),
+    title: String(row.title),
+    description: String(row.description),
+    tags: String(row.tags),
+    privacyStatus: String(row.privacy_status),
+    language: String(row.language),
+    isShort: Boolean(row.is_short),
+    status: String(row.status) as QueueStatus,
+    retries: Number(row.retries),
+    error: row.error ? String(row.error) : null,
+    youtubeVideoId: row.youtube_video_id ? String(row.youtube_video_id) : null,
+    createdAt: String(row.created_at),
+  }
+}

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -128,6 +128,22 @@ const deleteDubbingJobSchema = z.object({
   }),
 })
 
+const queueYouTubeUploadSchema = z.object({
+  type: z.literal('queueYouTubeUpload'),
+  payload: z.object({
+    userId: z.string().min(1),
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+    videoUrl: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string(),
+    tags: z.array(z.string()),
+    privacyStatus: z.string().min(1),
+    language: z.string(),
+    isShort: z.boolean(),
+  }),
+})
+
 export const mutationActionSchema = z.discriminatedUnion('type', [
   createDubbingJobSchema,
   createJobLanguagesSchema,
@@ -140,6 +156,7 @@ export const mutationActionSchema = z.discriminatedUnion('type', [
   deductUserMinutesSchema,
   addCreditsSchema,
   deleteDubbingJobSchema,
+  queueYouTubeUploadSchema,
 ])
 
 export type MutationAction = z.infer<typeof mutationActionSchema>
@@ -156,6 +173,8 @@ export function getUserIdFromAction(action: MutationAction): string | null {
     case 'createDubbingJobWithLanguages':
       return action.payload.job.userId
     case 'createYouTubeUpload':
+      return action.payload.userId
+    case 'queueYouTubeUpload':
       return action.payload.userId
     case 'deductUserMinutes':
       return action.payload.userId
@@ -182,6 +201,8 @@ export function getJobIdFromAction(action: MutationAction): number | null {
     case 'deleteDubbingJob':
       return action.payload.jobId
     case 'deductUserMinutes':
+      return action.payload.jobId
+    case 'queueYouTubeUpload':
       return action.payload.jobId
     default:
       return null

--- a/src/utils/srt.ts
+++ b/src/utils/srt.ts
@@ -1,0 +1,15 @@
+export function toSRT(sentences: { startMs: number; endMs: number; translatedText: string }[]): string {
+  return sentences.map((s, i) => {
+    const start = msToSRTTime(s.startMs)
+    const end = msToSRTTime(s.endMs)
+    return `${i + 1}\n${start} --> ${end}\n${s.translatedText}\n`
+  }).join('\n')
+}
+
+function msToSRTTime(ms: number): string {
+  const h = Math.floor(ms / 3600000)
+  const m = Math.floor((ms % 3600000) / 60000)
+  const s = Math.floor((ms % 60000) / 1000)
+  const ms2 = ms % 1000
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(ms2).padStart(3, '0')}`
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,11 @@
       "feature/*": false,
       "fix/*": false
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/process-uploads",
+      "schedule": "*/2 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- **결과물 모드 통합 리팩터**: OutputModeStep 신규 추가, UploadSettingsStep/UploadStep 전면 개편으로 자막 중심 워크플로우 전환
- **SRT 자막 생성 및 편집기**: Script API 기반 SRT 자동 생성, SubtitleEditor 컴포넌트 신규 추가, 자막 자동/수동 업로드 지원
- **백그라운드 업로드 큐**: upload-queue DB 쿼리 + cron API(`/api/cron/process-uploads`) 추가로 비동기 업로드 처리
- **오디오 트랙 업로드 토글**: 기본 OFF, 확장 기본 모드 auto로 변경
- **기타**: 더빙 취소 API, 탭 순서 변경, 직렬화 오류 수정, 의존성 업데이트

## Test plan
- [ ] 더빙 위자드에서 결과물 모드 선택 (자막/오디오/비디오) 정상 동작 확인
- [ ] SRT 자막 자동 생성 및 편집기 내 수정 후 저장 확인
- [ ] 자막 자동 업로드 / 수동 업로드 버튼 동작 확인
- [ ] 오디오 트랙 업로드 토글 ON/OFF 전환 확인
- [ ] 백그라운드 업로드 큐 cron 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)