### PR TITLE
fix: Vercel cron 제거 → 클라이언트 트리거 방식으로 전환

### DIFF
--- a/src/app/api/cron/process-uploads/route.ts
+++ b/src/app/api/cron/process-uploads/route.ts
@@ -3,21 +3,19 @@ import { getPendingUploads, updateQueueItemStatus } from '@/lib/db/queries/uploa
 import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
 import { uploadVideoToYouTube } from '@/lib/youtube/upload'
-import { apiOk, apiFail } from '@/lib/api/response'
+import { apiOk } from '@/lib/api/response'
+import { requireSession } from '@/lib/auth/session'
 import { logger } from '@/lib/logger'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
 
-export async function GET(req: NextRequest) {
-  const secret = req.headers.get('authorization')?.replace('Bearer ', '')
-  const expected = process.env.CRON_SECRET
-  if (expected && secret !== expected) {
-    return apiFail('UNAUTHORIZED', 'Invalid cron secret', 401)
-  }
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
 
-  const items = await getPendingUploads(3)
+  const items = await getPendingUploads(50)
   if (items.length === 0) {
     return apiOk({ processed: 0, message: 'No pending uploads' })
   }
@@ -35,7 +33,6 @@ export async function GET(req: NextRequest) {
         continue
       }
 
-      // Fetch video from source URL
       const allowed = ['.blob.core.windows.net', '.perso.ai', 'perso.ai']
       const urlHost = new URL(item.videoUrl).hostname
       const isAllowed = allowed.some((d) => urlHost === d || urlHost.endsWith(d))
@@ -65,7 +62,6 @@ export async function GET(req: NextRequest) {
 
       await updateQueueItemStatus(item.id, 'done', { youtubeVideoId: result.videoId })
 
-      // Update DB records
       try {
         await createYouTubeUpload({
           userId: item.userId,

--- a/src/app/api/cron/process-uploads/route.ts
+++ b/src/app/api/cron/process-uploads/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest } from 'next/server'
-import { getPendingUploads, updateQueueItemStatus } from '@/lib/db/queries/upload-queue'
-import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
-import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
-import { uploadVideoToYouTube } from '@/lib/youtube/upload'
 import { apiOk } from '@/lib/api/response'
 import { requireSession } from '@/lib/auth/session'
-import { logger } from '@/lib/logger'
+import { processUploadQueue } from '@/lib/upload-queue/process'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -15,76 +11,6 @@ export async function POST(req: NextRequest) {
   const auth = await requireSession(req)
   if (!auth.ok) return auth.response
 
-  const items = await getPendingUploads(50)
-  if (items.length === 0) {
-    return apiOk({ processed: 0, message: 'No pending uploads' })
-  }
-
-  const results: { id: number; status: string; videoId?: string; error?: string }[] = []
-
-  for (const item of items) {
-    await updateQueueItemStatus(item.id, 'processing')
-
-    try {
-      const accessToken = await getOrRefreshAccessToken(item.userId)
-      if (!accessToken) {
-        await updateQueueItemStatus(item.id, 'failed', { error: 'No valid access token — user may need to re-login' })
-        results.push({ id: item.id, status: 'failed', error: 'no_token' })
-        continue
-      }
-
-      const allowed = ['.blob.core.windows.net', '.perso.ai', 'perso.ai']
-      const urlHost = new URL(item.videoUrl).hostname
-      const isAllowed = allowed.some((d) => urlHost === d || urlHost.endsWith(d))
-      if (!isAllowed) {
-        await updateQueueItemStatus(item.id, 'failed', { error: 'Video URL domain not allowed' })
-        results.push({ id: item.id, status: 'failed', error: 'invalid_domain' })
-        continue
-      }
-
-      const videoRes = await fetch(item.videoUrl)
-      if (!videoRes.ok) {
-        await updateQueueItemStatus(item.id, 'failed', { error: `Failed to fetch video: ${videoRes.status}` })
-        results.push({ id: item.id, status: 'failed', error: 'fetch_failed' })
-        continue
-      }
-      const videoBlob = await videoRes.blob()
-
-      const result = await uploadVideoToYouTube({
-        accessToken,
-        videoBlob,
-        title: item.title,
-        description: item.description,
-        tags: item.tags ? item.tags.split(',') : [],
-        privacyStatus: item.privacyStatus as 'public' | 'unlisted' | 'private',
-        language: item.language || undefined,
-      })
-
-      await updateQueueItemStatus(item.id, 'done', { youtubeVideoId: result.videoId })
-
-      try {
-        await createYouTubeUpload({
-          userId: item.userId,
-          youtubeVideoId: result.videoId,
-          title: item.title,
-          languageCode: item.langCode,
-          privacyStatus: item.privacyStatus,
-          isShort: item.isShort,
-        })
-        await updateJobLanguageYouTube(item.jobId, item.langCode, result.videoId)
-      } catch {
-        // DB update is best-effort
-      }
-
-      results.push({ id: item.id, status: 'done', videoId: result.videoId })
-      logger.info('queue upload success', { queueId: item.id, videoId: result.videoId })
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error'
-      await updateQueueItemStatus(item.id, 'failed', { error: msg })
-      results.push({ id: item.id, status: 'failed', error: msg })
-      logger.error('queue upload failed', { queueId: item.id, error: msg })
-    }
-  }
-
-  return apiOk({ processed: results.length, results })
+  const result = await processUploadQueue()
+  return apiOk(result)
 }

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -18,6 +18,7 @@ import { mutationActionSchema, getUserIdFromAction, getJobIdFromAction } from '@
 import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
 import { getDb } from '@/lib/db/client'
 import { persoFetch } from '@/lib/perso/client'
+import { processUploadQueue } from '@/lib/upload-queue/process'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -118,11 +119,7 @@ export async function POST(req: NextRequest) {
       }
       case 'queueYouTubeUpload': {
         const id = await createUploadQueueItem(action.payload)
-        const origin = req.nextUrl.origin
-        fetch(`${origin}/api/cron/process-uploads`, {
-          method: 'POST',
-          headers: { cookie: req.headers.get('cookie') || '' },
-        }).catch(() => {})
+        processUploadQueue().catch(() => {})
         return apiOk({ queueId: id })
       }
       case 'deleteDubbingJob': {

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -118,6 +118,11 @@ export async function POST(req: NextRequest) {
       }
       case 'queueYouTubeUpload': {
         const id = await createUploadQueueItem(action.payload)
+        const origin = req.nextUrl.origin
+        fetch(`${origin}/api/cron/process-uploads`, {
+          method: 'POST',
+          headers: { cookie: req.headers.get('cookie') || '' },
+        }).catch(() => {})
         return apiOk({ queueId: id })
       }
       case 'deleteDubbingJob': {

--- a/src/lib/upload-queue/process.ts
+++ b/src/lib/upload-queue/process.ts
@@ -1,0 +1,80 @@
+import 'server-only'
+
+import { getPendingUploads, updateQueueItemStatus } from '@/lib/db/queries/upload-queue'
+import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
+import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
+import { uploadVideoToYouTube } from '@/lib/youtube/upload'
+import { logger } from '@/lib/logger'
+
+export async function processUploadQueue() {
+  const items = await getPendingUploads(50)
+  if (items.length === 0) return { processed: 0, results: [] }
+
+  const results: { id: number; status: string; videoId?: string; error?: string }[] = []
+
+  for (const item of items) {
+    await updateQueueItemStatus(item.id, 'processing')
+
+    try {
+      const accessToken = await getOrRefreshAccessToken(item.userId)
+      if (!accessToken) {
+        await updateQueueItemStatus(item.id, 'failed', { error: 'No valid access token — user may need to re-login' })
+        results.push({ id: item.id, status: 'failed', error: 'no_token' })
+        continue
+      }
+
+      const allowed = ['.blob.core.windows.net', '.perso.ai', 'perso.ai']
+      const urlHost = new URL(item.videoUrl).hostname
+      const isAllowed = allowed.some((d) => urlHost === d || urlHost.endsWith(d))
+      if (!isAllowed) {
+        await updateQueueItemStatus(item.id, 'failed', { error: 'Video URL domain not allowed' })
+        results.push({ id: item.id, status: 'failed', error: 'invalid_domain' })
+        continue
+      }
+
+      const videoRes = await fetch(item.videoUrl)
+      if (!videoRes.ok) {
+        await updateQueueItemStatus(item.id, 'failed', { error: `Failed to fetch video: ${videoRes.status}` })
+        results.push({ id: item.id, status: 'failed', error: 'fetch_failed' })
+        continue
+      }
+      const videoBlob = await videoRes.blob()
+
+      const result = await uploadVideoToYouTube({
+        accessToken,
+        videoBlob,
+        title: item.title,
+        description: item.description,
+        tags: item.tags ? item.tags.split(',') : [],
+        privacyStatus: item.privacyStatus as 'public' | 'unlisted' | 'private',
+        language: item.language || undefined,
+      })
+
+      await updateQueueItemStatus(item.id, 'done', { youtubeVideoId: result.videoId })
+
+      try {
+        await createYouTubeUpload({
+          userId: item.userId,
+          youtubeVideoId: result.videoId,
+          title: item.title,
+          languageCode: item.langCode,
+          privacyStatus: item.privacyStatus,
+          isShort: item.isShort,
+        })
+        await updateJobLanguageYouTube(item.jobId, item.langCode, result.videoId)
+      } catch {
+        // DB update is best-effort
+      }
+
+      results.push({ id: item.id, status: 'done', videoId: result.videoId })
+      logger.info('queue upload success', { queueId: item.id, videoId: result.videoId })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      await updateQueueItemStatus(item.id, 'failed', { error: msg })
+      results.push({ id: item.id, status: 'failed', error: msg })
+      logger.error('queue upload failed', { queueId: item.id, error: msg })
+    }
+  }
+
+  return { processed: results.length, results }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,5 @@
       "feature/*": false,
       "fix/*": false
     }
-  },
-  "crons": [
-    {
-      "path": "/api/cron/process-uploads",
-      "schedule": "*/2 * * * *"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Hobby 플랜에서 2분 간격 cron 사용 불가 → 배포 실패 해결
- `vercel.json`에서 cron 설정 제거
- 큐 등록(`queueYouTubeUpload`) 시 서버에서 `process-uploads` API를 fire-and-forget으로 즉시 호출
- `process-uploads`: GET→POST, CRON_SECRET→세션 인증, 배치 3→50개로 확대

## Test plan
- [ ] Vercel 배포 정상 통과 확인
- [ ] 큐 업로드 등록 후 서버에서 자동 처리 확인
- [ ] 탭 닫아도 업로드 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)