### PR TITLE
feat(dubbing): 원본 언어 AUTO + 화자 1~10 + 하드코딩 버그 수정

### DIFF
--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -39,6 +39,7 @@ export function LanguageSelectStep() {
           onChange={(e) => setSourceLanguage(e.target.value)}
           className="w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
         >
+          <option value="auto">🌐 자동 감지 (권장)</option>
           {SUPPORTED_LANGUAGES.map((lang) => (
             <option key={lang.code} value={lang.code}>
               {lang.flag} {lang.name} ({lang.nativeName})
@@ -46,7 +47,8 @@ export function LanguageSelectStep() {
           ))}
         </select>
         <p className="mt-2 text-xs text-surface-500">
-          영상 속 음성의 언어입니다. 잘못 설정하면 전사가 실패할 수 있습니다.
+          자동 감지를 사용하면 Perso AI가 영상 음성에서 언어를 자동으로 판별합니다.
+          정확한 언어를 알고 있다면 직접 선택하는 편이 안정적입니다.
         </p>
       </Card>
 

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -1,17 +1,30 @@
 'use client'
 
-import { useState } from 'react'
 import { ArrowLeft, ArrowRight, Info } from 'lucide-react'
 import { Button, Card, Badge, Toggle } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 
+const MAX_SPEAKERS = 10
+
 export function TranslationEditStep() {
-  const { sourceLanguage, selectedLanguages, lipSyncEnabled, setLipSync, videoMeta, deliverableMode, uploadSettings, prevStep, nextStep } = useDubbingStore()
-  const [speakers, setSpeakers] = useState(1)
+  const {
+    sourceLanguage,
+    selectedLanguages,
+    lipSyncEnabled,
+    setLipSync,
+    numberOfSpeakers,
+    setNumberOfSpeakers,
+    videoMeta,
+    deliverableMode,
+    uploadSettings,
+    prevStep,
+    nextStep,
+  } = useDubbingStore()
 
   const sourceLang = getLanguageByCode(sourceLanguage)
+  const isAutoSource = sourceLanguage === 'auto'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -39,7 +52,9 @@ export function TranslationEditStep() {
           <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
             <span className="text-sm text-surface-600 dark:text-surface-400">원본 언어</span>
             <span className="text-sm font-medium text-surface-900 dark:text-white">
-              {sourceLang?.flag} {sourceLang?.name || '자동 감지'}
+              {isAutoSource
+                ? '🌐 자동 감지'
+                : `${sourceLang?.flag ?? ''} ${sourceLang?.name ?? '알 수 없음'}`}
             </span>
           </div>
 
@@ -62,16 +77,22 @@ export function TranslationEditStep() {
           </div>
 
           {/* Number of speakers */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400">화자 수</span>
-            <div className="flex items-center gap-2">
-              {[1, 2, 3].map((n) => (
+          <div className="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-surface-600 dark:text-surface-400">화자 수</span>
+              <span className="text-sm font-semibold text-surface-900 dark:text-white">
+                {numberOfSpeakers}명
+              </span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {Array.from({ length: MAX_SPEAKERS }, (_, i) => i + 1).map((n) => (
                 <button
                   key={n}
-                  onClick={() => setSpeakers(n)}
+                  type="button"
+                  onClick={() => setNumberOfSpeakers(n)}
                   className={cn(
                     'h-8 w-8 rounded-lg text-sm font-medium transition-all cursor-pointer',
-                    speakers === n
+                    numberOfSpeakers === n
                       ? 'bg-brand-500 text-white'
                       : 'bg-white text-surface-600 border border-surface-300 hover:border-brand-300 dark:bg-surface-700 dark:text-surface-300 dark:border-surface-600',
                   )}
@@ -80,6 +101,9 @@ export function TranslationEditStep() {
                 </button>
               ))}
             </div>
+            <p className="mt-2 text-xs text-surface-400">
+              영상에 등장하는 화자 수를 선택하세요. 정확하게 설정하면 Perso AI가 화자별로 음성을 분리해 더빙합니다.
+            </p>
           </div>
 
           {/* Lip sync */}

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -320,7 +320,7 @@ export function usePersoFlow() {
   }, [initSpace, addToast])
 
   const submitDubbing = useCallback(async () => {
-    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, sourceLanguage } = store.getState()
+    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, sourceLanguage, numberOfSpeakers } = store.getState()
     if (!spaceSeq || !mediaSeq) throw new Error('Missing space or media')
 
     // Credit check before starting
@@ -357,7 +357,7 @@ export function usePersoFlow() {
         isVideoProject: true,
         sourceLanguageCode: sourceLanguage,
         targetLanguageCodes: selectedLanguages,
-        numberOfSpeakers: 1,
+        numberOfSpeakers: Math.max(1, Math.min(10, numberOfSpeakers || 1)),
         withLipSync: lipSyncEnabled,
         preferredSpeedType: 'GREEN',
       })

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -52,9 +52,11 @@ interface DubbingState {
   sourceLanguage: string
   selectedLanguages: string[]
   lipSyncEnabled: boolean
+  numberOfSpeakers: number
   setSourceLanguage: (code: string) => void
   toggleLanguage: (code: string) => void
   setLipSync: (enabled: boolean) => void
+  setNumberOfSpeakers: (n: number) => void
 
   // Step 3: Translation editing
   segments: Record<string, TranslationSegment[]>
@@ -106,9 +108,10 @@ const initialState = {
   videoSource: null as VideoSource | null,
   videoMeta: null as VideoMetadata | null,
   originalVideoUrl: null as string | null,
-  sourceLanguage: 'ko',
+  sourceLanguage: 'auto',
   selectedLanguages: [] as string[],
   lipSyncEnabled: false,
+  numberOfSpeakers: 1,
   isShort: false,
   segments: {} as Record<string, TranslationSegment[]>,
   projectMap: {} as Record<string, number>,
@@ -157,6 +160,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
         : [...s.selectedLanguages, code],
     })),
   setLipSync: (enabled) => set({ lipSyncEnabled: enabled }),
+  setNumberOfSpeakers: (n) =>
+    set({ numberOfSpeakers: Math.max(1, Math.min(10, Math.floor(n))) }),
 
   setSegments: (langCode, segments) =>
     set((s) => ({ segments: { ...s.segments, [langCode]: segments } })),


### PR DESCRIPTION
## Summary
- Perso API가 정식 지원하는 'auto' 옵션을 source language select에 추가하고 기본값으로 설정
- numberOfSpeakers를 dubbingStore로 이전 + 1~10 범위에서 사용자가 선택 가능하도록 UI 확장(기존 1~3 → 1~10)
- 사용자가 선택한 화자 수가 무시되고 항상 1로 Perso translate API에 보내지던 버그 수정 (`usePersoFlow.ts`)

## Notes on max speakers
- Perso API 문서에 numberOfSpeakers 상한이 명시되지 않음(`(default: 1)`만 표기)
- 일반적인 화자 분리(diarization) 모델 안정 한계인 10으로 상한 고정
- 추후 Perso 측에서 실제 한계가 더 낮은 것으로 확인되면 `MAX_SPEAKERS` 상수만 조정

## Test plan
- [ ] 새 더빙 위저드에서 원본 영상 언어 select에 "🌐 자동 감지 (권장)" 옵션이 최상단에 표시되는지 확인
- [ ] 자동 감지로 영상을 더빙해도 Perso 전사가 정상 동작
- [ ] 설정 확인 단계에서 화자 수 1~10 버튼이 모두 표시되며 선택값이 store에 반영되는지 확인
- [ ] 화자 수를 3으로 골라 더빙 시작 시 네트워크 요청 body의 numberOfSpeakers가 3으로 전송되는지 확인 (이전엔 항상 1)
- [ ] AUTO 선택 시 TranslationEditStep 요약에 "🌐 자동 감지"로 표기

🤖 Generated with [Claude Code](https://claude.com/claude-code)