### PR TITLE
feat(youtube): 기본 공개 설정을 더빙 위저드와 동기화

### DIFF
--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -1,17 +1,20 @@
 'use client'
 
-import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe, Loader2 } from 'lucide-react'
 import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from '@/components/ui'
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
+import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 export default function YouTubeSettingsPage() {
   const router = useRouter()
-  const [defaultVisibility, setDefaultVisibility] = useState('public')
-  const [autoSubtitles, setAutoSubtitles] = useState(true)
+  const defaultVisibility = useYouTubeSettingsStore((s) => s.defaultPrivacy)
+  const setDefaultVisibility = useYouTubeSettingsStore((s) => s.setDefaultPrivacy)
+  const autoSubtitles = useYouTubeSettingsStore((s) => s.autoSubtitles)
+  const setAutoSubtitles = useYouTubeSettingsStore((s) => s.setAutoSubtitles)
 
   const { data: channel, isLoading: channelLoading } = useChannelStats()
   const isConnected = !!channel
@@ -115,13 +118,16 @@ export default function YouTubeSettingsPage() {
           <Select
             label="기본 공개 설정"
             value={defaultVisibility}
-            onChange={(e) => setDefaultVisibility(e.target.value)}
+            onChange={(e) => setDefaultVisibility(e.target.value as PrivacyStatus)}
             options={[
               { value: 'public', label: '공개' },
               { value: 'unlisted', label: '일부 공개' },
               { value: 'private', label: '비공개' },
             ]}
           />
+          <p className="-mt-3 text-xs text-surface-400">
+            새 더빙 시작 시 이 값이 기본값으로 적용됩니다. 각 더빙 별로 변경할 수 있습니다.
+          </p>
 
           <div className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
             <div>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -23,9 +23,15 @@ export function UploadSettingsStep() {
     deliverableMode,
     uploadSettings,
     setUploadSettings,
+    syncPrivacyFromGlobalDefault,
     prevStep,
     nextStep,
   } = useDubbingStore()
+
+  // YouTube 설정 페이지의 기본 공개 설정과 동기화 (사용자 override 없을 때만).
+  useEffect(() => {
+    syncPrivacyFromGlobalDefault()
+  }, [syncPrivacyFromGlobalDefault])
 
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
+import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
 import type {
   DubbingStep,
   VideoSource,
@@ -11,17 +12,29 @@ import type {
   JobStatus,
   UploadSettings,
   DeliverableMode,
+  PrivacyStatus,
 } from '../types/dubbing.types'
 
-const DEFAULT_UPLOAD_SETTINGS: UploadSettings = {
+// YouTube 설정 페이지의 기본 공개 설정을 그때그때 가져온다.
+// SSR 단계에서는 localStorage가 없으므로 fallback 'private'.
+const readDefaultPrivacy = (): PrivacyStatus => {
+  if (typeof window === 'undefined') return 'private'
+  try {
+    return useYouTubeSettingsStore.getState().defaultPrivacy
+  } catch {
+    return 'private'
+  }
+}
+
+const buildDefaultUploadSettings = (): UploadSettings => ({
   autoUpload: true,
   uploadAsShort: false,
   attachOriginalLink: true,
   title: '',
   description: '',
   tags: ['Dubtube', 'AI더빙', 'dubbed'],
-  privacyStatus: 'private',
-}
+  privacyStatus: readDefaultPrivacy(),
+})
 
 interface DubbingState {
   // Wizard navigation
@@ -87,7 +100,12 @@ interface DubbingState {
 
   // Upload settings (chosen before dubbing starts)
   uploadSettings: UploadSettings
+  /** Wizard 세션 내에서 사용자가 privacyStatus를 직접 변경했는지 여부.
+   * true이면 YouTube 설정 페이지의 글로벌 기본값으로 덮어쓰지 않는다. */
+  privacyOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
+  /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
+  syncPrivacyFromGlobalDefault: () => void
 
   // Glossary
   glossary: GlossaryEntry[]
@@ -118,7 +136,8 @@ const initialState = {
   glossary: [] as GlossaryEntry[],
   deliverableMode: 'newDubbedVideos' as DeliverableMode,
   copyrightAcknowledged: false,
-  uploadSettings: { ...DEFAULT_UPLOAD_SETTINGS } as UploadSettings,
+  uploadSettings: buildDefaultUploadSettings() as UploadSettings,
+  privacyOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -200,10 +219,21 @@ export const useDubbingStore = create<DubbingState>((set) => ({
 
   setUploadSettings: (patch) => set((s) => ({
     uploadSettings: { ...s.uploadSettings, ...patch },
+    privacyOverridden:
+      patch.privacyStatus !== undefined ? true : s.privacyOverridden,
   })),
+
+  syncPrivacyFromGlobalDefault: () => set((s) => {
+    if (s.privacyOverridden) return s
+    const next = readDefaultPrivacy()
+    if (s.uploadSettings.privacyStatus === next) return s
+    return {
+      uploadSettings: { ...s.uploadSettings, privacyStatus: next },
+    }
+  }),
 
   addGlossaryEntry: (entry) => set((s) => ({ glossary: [...s.glossary, entry] })),
   removeGlossaryEntry: (id) => set((s) => ({ glossary: s.glossary.filter((e) => e.id !== id) })),
 
-  reset: () => set(initialState),
+  reset: () => set({ ...initialState, uploadSettings: buildDefaultUploadSettings() }),
 }))

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
+
+interface YouTubeSettingsState {
+  defaultPrivacy: PrivacyStatus
+  autoSubtitles: boolean
+  setDefaultPrivacy: (v: PrivacyStatus) => void
+  setAutoSubtitles: (v: boolean) => void
+}
+
+export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
+  persist(
+    (set) => ({
+      defaultPrivacy: 'private',
+      autoSubtitles: true,
+      setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
+      setAutoSubtitles: (v) => set({ autoSubtitles: v }),
+    }),
+    { name: 'dubtube-youtube-settings' },
+  ),
+)


### PR DESCRIPTION
## Summary
- /youtube 설정 페이지의 "기본 공개 설정"이 로컬 useState라 새로고침 시 사라지고, 더빙 위저드의 privacyStatus와도 무관했던 문제 수정
- 신규 영구 저장 store(`src/stores/youtubeSettingsStore.ts`)에 `defaultPrivacy`, `autoSubtitles`를 localStorage 기반으로 보관
- 더빙 위저드는 시작/UploadSettingsStep 마운트 시 글로벌 기본값을 자동 동기화
- 사용자가 위저드 안에서 직접 변경한 경우(`privacyOverridden` 플래그)에만 글로벌 변경에 덮어쓰이지 않도록 보호

## Behavior
1. /youtube에서 "기본 공개 설정 → 공개"로 변경 → localStorage 저장
2. 새 더빙 시작 → reset()이 yt store에서 'public' 읽어서 적용
3. 사용자가 위저드 내 공개 설정을 다시 "비공개"로 바꿔도 향후 글로벌 기본 변경이 덮어쓰지 않음

## Test plan
- [ ] /youtube 페이지에서 기본 공개 설정 변경 → 새로고침 시 유지되는지 확인
- [ ] 새 더빙 위저드 시작 → 업로드 설정 단계의 공개 설정이 yt 페이지에서 정한 값으로 초기화되는지 확인
- [ ] 위저드 안에서 공개 설정을 직접 변경 → /youtube에서 글로벌 기본 변경 후 위저드에 다시 들어가도 사용자 선택이 유지되는지 확인
- [ ] 위저드 reset(새 더빙) 시 다시 글로벌 기본값으로 돌아가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)