### PR TITLE
fix(batch): 큐 삭제 시 Perso cancel 병렬 + 클릭 UX 개선

### DIFF
--- a/src/app/(app)/batch/page.tsx
+++ b/src/app/(app)/batch/page.tsx
@@ -23,26 +23,24 @@ export default function BatchPage() {
   const { data: jobs = [], isLoading } = useRecentJobs()
   const queryClient = useQueryClient()
   const user = useAuthStore((s) => s.user)
-  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
   const [deletingId, setDeletingId] = useState<number | null>(null)
 
   const handleDeleteJob = async (jobId: number) => {
     if (deletingId === jobId) return
-    if (confirmDeleteId === jobId) {
-      setDeletingId(jobId)
-      setConfirmDeleteId(null)
-      queryClient.setQueryData(['recent-jobs', user?.uid], (old: typeof jobs) =>
-        old ? old.filter((j) => j.id !== jobId) : old,
-      )
-      try {
-        await dbMutation({ type: 'deleteDubbingJob', payload: { jobId } })
-      } finally {
-        setDeletingId(null)
-        queryClient.invalidateQueries({ queryKey: ['recent-jobs'] })
-      }
-    } else {
-      setConfirmDeleteId(jobId)
-      setTimeout(() => setConfirmDeleteId((prev) => (prev === jobId ? null : prev)), 3000)
+    const ok = window.confirm(
+      '이 작업을 큐에서 삭제하시겠습니까?\n진행 중인 Perso 더빙도 함께 취소됩니다.',
+    )
+    if (!ok) return
+
+    setDeletingId(jobId)
+    queryClient.setQueryData(['recent-jobs', user?.uid], (old: typeof jobs) =>
+      old ? old.filter((j) => j.id !== jobId) : old,
+    )
+    try {
+      await dbMutation({ type: 'deleteDubbingJob', payload: { jobId } })
+    } finally {
+      setDeletingId(null)
+      queryClient.invalidateQueries({ queryKey: ['recent-jobs'] })
     }
   }
 
@@ -165,16 +163,16 @@ export default function BatchPage() {
                 </div>
 
                 <button
+                  type="button"
                   onClick={() => handleDeleteJob(job.id)}
                   disabled={deletingId === job.id}
+                  aria-label="작업 삭제"
                   className={`shrink-0 rounded-md p-1.5 transition-colors ${
                     deletingId === job.id
-                      ? 'text-surface-300 cursor-not-allowed'
-                      : confirmDeleteId === job.id
-                        ? 'bg-red-50 text-red-500 dark:bg-red-900/20'
-                        : 'text-surface-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20'
+                      ? 'cursor-not-allowed text-surface-300'
+                      : 'text-surface-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20'
                   }`}
-                  title={deletingId === job.id ? '삭제 중...' : confirmDeleteId === job.id ? '한번 더 클릭하면 삭제됩니다' : '작업 삭제'}
+                  title={deletingId === job.id ? '삭제 중...' : '작업 삭제 (Perso 처리도 함께 취소)'}
                 >
                   {deletingId === job.id ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -129,7 +129,8 @@ export async function POST(req: NextRequest) {
           sql: 'SELECT jl.project_seq, dj.space_seq FROM job_languages jl JOIN dubbing_jobs dj ON dj.id = jl.job_id WHERE jl.job_id = ?',
           args: [jobId],
         })
-        await Promise.allSettled(
+        // Perso cancel + DB delete를 병렬로 실행. cancel 실패가 DB 삭제를 막지 않도록 allSettled.
+        const cancelAll = Promise.allSettled(
           langRows.rows.map((row) => {
             const projectSeq = row.project_seq as number
             const spaceSeq = row.space_seq as number
@@ -137,10 +138,10 @@ export async function POST(req: NextRequest) {
             return persoFetch<unknown>(
               `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/cancel`,
               { method: 'POST', baseURL: 'api' },
-            ).catch(() => {})
+            )
           }),
         )
-        await deleteDubbingJob(jobId)
+        await Promise.all([cancelAll, deleteDubbingJob(jobId)])
         return apiOk({ jobId })
       }
       default: {


### PR DESCRIPTION
## Summary
배치 큐의 삭제 버튼이 두 번 클릭하지 않으면 동작하지 않아 사용자에게 "버튼이 깨졌다"고 인식되던 문제와, Perso 처리 취소와 DB 삭제가 순차로 호출되어 응답이 느렸던 부분을 함께 수정합니다.

### UX
- two-click 확정 패턴 제거 → `window.confirm()` 한 번으로 처리
- 다이얼로그 문구: "이 작업을 큐에서 삭제하시겠습니까? 진행 중인 Perso 더빙도 함께 취소됩니다."
- 단 한 번의 클릭으로 즉시 삭제 흐름 진입

### Server-side cascade
- `/api/dashboard/mutations` `deleteDubbingJob`:
  - 모든 언어 `project_seq`에 대해 `POST /video-translator/api/v1/projects/{projectSeq}/spaces/{spaceSeq}/cancel` 호출 (allSettled로 일부 언어가 이미 완료/실패해도 무시)
  - 위 cancel과 `deleteDubbingJob`(jl + dj 배치 삭제)을 `Promise.all`로 **병렬** 실행

## Test plan
- [ ] 진행 중인 더빙 작업이 있는 상태에서 휴지통 클릭 → 다이얼로그 한 번 → 즉시 사라지는지 확인
- [ ] Perso Portal 또는 진행 폴링 응답으로 cancel이 실제 호출됐는지 확인
- [ ] 이미 완료된 작업 삭제 시에도 다이얼로그 → 즉시 삭제(서버 400 VT4004는 무시되어야 정상)
- [ ] 다이얼로그에서 "취소" 누르면 아무 일도 안 일어나는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)