### PR TITLE
fix(youtube): OAuth 토큰 자동 갱신 + 401 자동 재시도

### DIFF
--- a/src/app/api/youtube/caption/route.ts
+++ b/src/app/api/youtube/caption/route.ts
@@ -2,8 +2,8 @@ import { NextRequest } from 'next/server'
 import { requireSession } from '@/lib/auth/session'
 import { uploadCaptionToYouTube } from '@/lib/youtube/server'
 import {
-  requireAccessToken,
   parseYtBody,
+  withTokenRetry,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
 import { captionBodySchema } from '@/lib/validators/youtube'
@@ -16,9 +16,10 @@ export async function POST(req: NextRequest) {
   if (!auth.ok) return auth.response
 
   return ytHandle(async () => {
-    const accessToken = await requireAccessToken(req)
     const body = await parseYtBody(req, captionBodySchema)
-    await uploadCaptionToYouTube({ accessToken, ...body })
+    await withTokenRetry(req, (accessToken) =>
+      uploadCaptionToYouTube({ accessToken, ...body }),
+    )
     return { uploaded: true }
   })
 }

--- a/src/app/api/youtube/stats/route.ts
+++ b/src/app/api/youtube/stats/route.ts
@@ -5,8 +5,8 @@ import {
   fetchVideoStatistics,
 } from '@/lib/youtube/server'
 import {
-  requireAccessToken,
   parseQuery,
+  withTokenRetry,
   ytHandle,
 } from '@/lib/youtube/route-helpers'
 import { statsQuerySchema } from '@/lib/validators/youtube'
@@ -19,14 +19,14 @@ export async function GET(req: NextRequest) {
   if (!auth.ok) return auth.response
 
   return ytHandle(async () => {
-    const accessToken = await requireAccessToken(req)
     const url = new URL(req.url)
     const query = parseQuery(url, statsQuerySchema)
 
-    if (query.channel === 'true') {
-      return fetchChannelStatistics(accessToken)
-    }
-
-    return fetchVideoStatistics(accessToken, query.videoIds)
+    return withTokenRetry(req, (accessToken) => {
+      if (query.channel === 'true') {
+        return fetchChannelStatistics(accessToken)
+      }
+      return fetchVideoStatistics(accessToken, query.videoIds)
+    })
   })
 }

--- a/src/lib/auth/token-refresh.ts
+++ b/src/lib/auth/token-refresh.ts
@@ -47,11 +47,16 @@ const inflightRefreshes = new Map<string, Promise<string | null>>()
 
 export async function getOrRefreshAccessToken(
   userId: string,
+  opts: { force?: boolean } = {},
 ): Promise<string | null> {
   const tokens = await getUserTokens(userId)
   if (!tokens) return null
 
-  if (tokens.accessToken && !isTokenExpired(tokens.tokenExpiresAt)) {
+  if (
+    !opts.force &&
+    tokens.accessToken &&
+    !isTokenExpired(tokens.tokenExpiresAt)
+  ) {
     return tokens.accessToken
   }
 

--- a/src/lib/youtube/route-helpers.ts
+++ b/src/lib/youtube/route-helpers.ts
@@ -25,6 +25,29 @@ export async function ytHandle<T>(fn: () => Promise<T>): Promise<Response> {
   }
 }
 
+/**
+ * YouTube API 호출 함수를 401 자동 재시도로 감싼다.
+ * 401(인증 거부)이 떨어지면 DB의 refresh_token으로 강제 리프레시 후 1회 재시도한다.
+ * 사용 예:
+ *   await withTokenRetry(req, (token) => uploadCaptionToYouTube({ accessToken: token, ... }))
+ */
+export async function withTokenRetry<T>(
+  req: Request,
+  fn: (accessToken: string) => Promise<T>,
+): Promise<T> {
+  const token = await requireAccessToken(req)
+  try {
+    return await fn(token)
+  } catch (err) {
+    const status = err instanceof YouTubeError ? err.status : 0
+    if (status !== 401) throw err
+    // 401: 토큰이 stale일 가능성 → 강제 리프레시 후 1회 재시도
+    const fresh = await requireAccessToken(req, { forceRefresh: true })
+    if (fresh === token) throw err
+    return await fn(fresh)
+  }
+}
+
 import type { ZodSchema, ZodError } from 'zod'
 
 export function parseQuery<T>(url: URL, schema: ZodSchema<T>): T {
@@ -58,21 +81,29 @@ import { cookies } from 'next/headers'
 import { verifySessionCookie } from '@/lib/auth/session-cookie'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
 
-export async function requireAccessToken(req: Request): Promise<string> {
+/**
+ * Google 액세스 토큰을 가져온다. DB+세션 기반 리프레시 경로를 최우선으로 삼아
+ * stale 쿠키를 자동으로 우회한다(getOrRefreshAccessToken이 만료 임박 시 자동 갱신).
+ * - 1순위: dubtube_session 쿠키 → uid 검증 → DB의 refresh_token으로 fresh 토큰 확보
+ * - 2순위: google_access_token 쿠키 (세션이 없는 짧은 흐름용 fallback)
+ * - 3순위: Authorization Bearer / x-google-access-token 헤더
+ */
+export async function requireAccessToken(
+  req: Request,
+  opts: { forceRefresh?: boolean } = {},
+): Promise<string> {
   const cookieStore = await cookies()
-  const cookieToken = cookieStore.get('google_access_token')?.value
+  const sessionCookie = cookieStore.get('dubtube_session')?.value
 
-  if (!cookieToken) {
-    const sessionCookie = cookieStore.get('dubtube_session')?.value
-    if (sessionCookie) {
-      const uid = await verifySessionCookie(sessionCookie)
-      if (uid) {
-        const refreshed = await getOrRefreshAccessToken(uid)
-        if (refreshed) return refreshed
-      }
+  if (sessionCookie) {
+    const uid = await verifySessionCookie(sessionCookie)
+    if (uid) {
+      const token = await getOrRefreshAccessToken(uid, { force: opts.forceRefresh })
+      if (token) return token
     }
   }
 
+  const cookieToken = cookieStore.get('google_access_token')?.value
   if (cookieToken) return cookieToken
 
   const auth = req.headers.get('authorization') || ''

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -42,7 +42,14 @@ export async function fetchChannelStatistics(
     `${YOUTUBE_API_BASE}/youtube/v3/channels?part=statistics,snippet&mine=true`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
-  if (!res.ok) return null
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new YouTubeError(
+      res.status,
+      `Channel fetch failed: ${body}`,
+      'CHANNEL_FETCH_FAILED',
+    )
+  }
 
   const data = (await res.json()) as {
     items?: Array<{


### PR DESCRIPTION
## Summary
YouTube API 호출이 401 Unauthorized로 실패하던 근본 원인을 수정합니다. 기존 `requireAccessToken`은 `google_access_token` 쿠키 값이 있으면 토큰의 실제 유효성을 보지 않고 그대로 YouTube에 전달했고, 쿠키 maxAge가 끝나기 전에 토큰만 폐기/만료되면 401이 사용자에게 그대로 노출됐습니다. 또한 `fetchChannelStatistics`는 401을 silently `null`로 삼켜 진단을 어렵게 했습니다.

### Changes
1. `lib/youtube/route-helpers.requireAccessToken`
   - 우선순위를 **dubtube_session(DB+refresh) → cookie → header**로 뒤집음
   - `getOrRefreshAccessToken`이 만료 임박 시 자동 갱신
   - `opts.forceRefresh` 인자로 강제 갱신 경로 노출

2. `lib/auth/token-refresh.getOrRefreshAccessToken`
   - `opts.force` 추가: 캐시(만료 전 토큰) 무시하고 refresh_token으로 강제 새 토큰 발급 (Google이 미리 폐기한 케이스 대응)

3. `lib/youtube/route-helpers.withTokenRetry` (신규)
   - YouTube 호출 결과 401이면 forceRefresh로 한 번 새 토큰 받고 1회 재시도
   - 동일 토큰이 다시 반환되면 그대로 throw

4. `lib/youtube/stats.fetchChannelStatistics`
   - 401 등 에러를 silently `null`로 삼키던 동작 제거 → `YouTubeError` throw

5. `/api/youtube/caption`, `/api/youtube/stats` 라우트를 `withTokenRetry`로 감쌈

### Follow-up
다른 YouTube 라우트(`videos`, `analytics`, `upload`)도 같은 패턴(`withTokenRetry`)으로 일괄 마이그레이션 예정입니다(별도 PR).

## Test plan
- [ ] 기존 stale 쿠키를 가진 상태에서 자막 업로드 → 자동 갱신 후 성공해야 함
- [ ] DB에서 `token_expires_at`을 과거로 강제 변경 → 자막/채널 stats 호출 시 자동으로 새 토큰 발급되는지 확인
- [ ] `/api/youtube/stats?channel=true` 호출이 채널이 진짜 없으면 `null`, 401이면 `{ ok: false, ... }`로 정확히 구분되는지 확인
- [ ] refresh_token 자체가 만료된 케이스(권한 회수)에선 401 그대로 노출되어 재로그인 유도되는지 확인
- [ ] 정상 토큰일 땐 추가 호출/지연 없이 단발 fetch만 일어나는지 네트워크 탭으로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)