### PR TITLE
fix(youtube): stats 라우트 빌드 타입 오류 수정 (main 빌드 실패 hotfix)

### DIFF
--- a/src/app/api/youtube/stats/route.ts
+++ b/src/app/api/youtube/stats/route.ts
@@ -22,11 +22,13 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const query = parseQuery(url, statsQuerySchema)
 
-    return withTokenRetry(req, (accessToken) => {
-      if (query.channel === 'true') {
-        return fetchChannelStatistics(accessToken)
-      }
-      return fetchVideoStatistics(accessToken, query.videoIds)
-    })
+    if (query.channel === 'true') {
+      return withTokenRetry(req, (accessToken) =>
+        fetchChannelStatistics(accessToken),
+      )
+    }
+    return withTokenRetry(req, (accessToken) =>
+      fetchVideoStatistics(accessToken, query.videoIds),
+    )
   })
 }


### PR DESCRIPTION
## Summary
PR #180으로 main에 머지된 후 Vercel 프로덕션 빌드가 다음 타입 에러로 실패한 것을 수정합니다.

\`\`\`
./src/app/api/youtube/stats/route.ts:25:32
Type error: Argument of type '(accessToken: string) => Promise<VideoStats[]> | Promise<ChannelStats | null>' is not assignable to parameter of type '(accessToken: string) => Promise<VideoStats[] | null>'.
\`\`\`

### 원인
\`withTokenRetry<T>\`의 제네릭 T는 콜백 본문의 첫 return 표현식에서 추론되는데, 채널/비디오 두 분기가 서로 다른 타입을 반환해 두 번째 분기가 첫 분기 타입에 호환되지 않음.

### 수정
\`withTokenRetry\`를 두 분기 각각에 한 번씩 호출하도록 분리. 각 호출이 독립된 T로 추론된다. 401 자동 재시도 동작은 동일.

\`\`\`ts
if (query.channel === 'true') {
  return withTokenRetry(req, (accessToken) =>
    fetchChannelStatistics(accessToken),
  )
}
return withTokenRetry(req, (accessToken) =>
  fetchVideoStatistics(accessToken, query.videoIds),
)
\`\`\`

로컬 \`npx tsc --noEmit\` 통과 확인.

## Follow-up
develop에 머지 후 develop → main 한 번 더 PR해서 Vercel main 빌드를 복구합니다.

## Test plan
- [ ] CI 타입체크 통과
- [ ] /api/youtube/stats?channel=true 호출 정상
- [ ] /api/youtube/stats?videoIds=... 호출 정상
- [ ] stale 토큰 시나리오에서 자동 갱신 + 1회 재시도 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)