### PR TITLE
release: develop → main (Vercel 빌드 hotfix #181)

### DIFF
--- a/src/app/api/youtube/stats/route.ts
+++ b/src/app/api/youtube/stats/route.ts
@@ -22,11 +22,13 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const query = parseQuery(url, statsQuerySchema)
 
-    return withTokenRetry(req, (accessToken) => {
-      if (query.channel === 'true') {
-        return fetchChannelStatistics(accessToken)
-      }
-      return fetchVideoStatistics(accessToken, query.videoIds)
-    })
+    if (query.channel === 'true') {
+      return withTokenRetry(req, (accessToken) =>
+        fetchChannelStatistics(accessToken),
+      )
+    }
+    return withTokenRetry(req, (accessToken) =>
+      fetchVideoStatistics(accessToken, query.videoIds),
+    )
   })
 }


### PR DESCRIPTION
## Summary
직전 릴리스 PR(#180) 머지 후 Vercel main 프로덕션 빌드가 \`/src/app/api/youtube/stats/route.ts\`의 \`withTokenRetry\` 제네릭 추론 오류로 실패했던 것을 복구하는 hotfix 릴리스입니다.

## Included merge
- **#181** fix(youtube): stats 라우트 withTokenRetry 타입 추론 오류 수정

### 변경 내용
\`withTokenRetry<T>\`의 T가 콜백 첫 분기(\`ChannelStats | null\`)에서 추론되어 두 번째 분기(\`VideoStats[]\`)와 호환되지 않던 문제. 분기별로 \`withTokenRetry\`를 두 번 호출하도록 분리해 각각 독립된 T로 추론되도록 수정. 401 자동 재시도 동작은 동일.

로컬 \`npx tsc --noEmit\` 0 errors 확인.

## Test plan
- [ ] Vercel main 빌드 통과 확인
- [ ] /api/youtube/stats?channel=true 정상 응답
- [ ] /api/youtube/stats?videoIds=... 정상 응답
- [ ] 직전 릴리스(#180)의 모든 기능이 그대로 동작하는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)