### PR TITLE
chore(legal): OAuth 검증용 개인정보처리방침·서비스 약관 페이지 추가

### DIFF
--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침 — Dubtube',
+  description:
+    'Dubtube의 개인정보처리방침. YouTube API Services 데이터 사용, 수집·보관·삭제 정책을 안내합니다.',
+  alternates: { canonical: '/privacy' },
+  robots: { index: true, follow: true },
+}
+
+const LAST_UPDATED = '2026-04-29'
+
+export default function PrivacyPolicyPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-16 text-surface-700 dark:text-surface-300">
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-surface-900 dark:text-white sm:text-4xl">
+          개인정보처리방침
+        </h1>
+        <p className="mt-2 text-sm text-surface-500">최종 업데이트: {LAST_UPDATED}</p>
+      </header>
+
+      <Section title="1. 개요">
+        <p>
+          Dubtube(&ldquo;본 서비스&rdquo;)는 YouTube 크리에이터가 자신의 영상을 다국어로 더빙하고
+          자막·오디오 트랙을 YouTube에 업로드할 수 있도록 돕는 서비스입니다. 본 방침은 Dubtube가
+          사용자로부터 수집·이용·보관·파기하는 개인정보의 범위와 방법을 설명합니다.
+        </p>
+        <p>
+          Dubtube는{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>
+          를 준수하며, 동 정책의 Limited Use 요구사항을 포함하여 적용됩니다.
+        </p>
+      </Section>
+
+      <Section title="2. 수집하는 정보">
+        <h3 className="mt-4 font-semibold text-surface-900 dark:text-white">2.1 Google 계정 정보</h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>이메일 주소, 이름, 프로필 사진(Google OpenID Connect 표준 클레임)</li>
+          <li>OAuth 2.0 액세스 토큰 / 리프레시 토큰</li>
+        </ul>
+
+        <h3 className="mt-6 font-semibold text-surface-900 dark:text-white">
+          2.2 YouTube 데이터 (사용자 명시 동의 후)
+        </h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>채널 정보(채널명, 구독자 수, 채널 ID, 채널 썸네일)</li>
+          <li>영상 메타데이터(제목, 설명, 썸네일, 조회수, 게시일)</li>
+          <li>사용자가 더빙 대상으로 지정한 영상의 오디오/자막 데이터</li>
+          <li>사용자가 업로드 권한을 부여한 영상에 대한 자막(SRT) 및 오디오 트랙</li>
+        </ul>
+
+        <h3 className="mt-6 font-semibold text-surface-900 dark:text-white">
+          2.3 서비스 이용 데이터
+        </h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>더빙 작업 기록(원본 언어, 대상 언어, 처리 상태, 결과 URL)</li>
+          <li>크레딧 사용 내역</li>
+          <li>업로드 큐 상태</li>
+        </ul>
+      </Section>
+
+      <Section title="3. 정보 사용 목적">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>더빙 영상·오디오·자막 생성 및 사용자 YouTube 채널로의 업로드</li>
+          <li>다국어 자막 트랙 추가/교체(YouTube Captions API 사용)</li>
+          <li>크레딧 차감·결제·잔여량 표시</li>
+          <li>사용자 인증 및 세션 유지</li>
+          <li>서비스 안정성 모니터링 및 오류 진단</li>
+        </ul>
+        <p className="mt-4">
+          Dubtube는 YouTube API Services를 통해 받은 사용자 데이터를{' '}
+          <strong>광고 또는 외부 마케팅 목적으로 사용·전송하지 않으며</strong>,
+          모델 학습·휴먼 리뷰 등에도 사용하지 않습니다.
+        </p>
+      </Section>
+
+      <Section title="4. 제3자 제공 및 처리 위탁">
+        <p>다음의 처리 위탁사에 한해, 서비스 제공 목적으로 필요한 최소 범위에서 데이터를 전달합니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            <strong>Perso.ai</strong> — 보이스 클론, 음성 합성, 번역 처리. 사용자가 더빙
+            대상으로 지정한 영상/오디오 데이터에 한해 전달됨.
+          </li>
+          <li>
+            <strong>Google (YouTube Data API)</strong> — 채널/영상 조회, 영상·자막·오디오 트랙 업로드.
+          </li>
+          <li>
+            <strong>Vercel</strong> — 웹 애플리케이션 호스팅, 로그 수집(IP/User-Agent 기본 로그).
+          </li>
+          <li>
+            <strong>Turso (libSQL)</strong> — 사용자 계정·작업 기록 데이터베이스 호스팅.
+          </li>
+        </ul>
+        <p className="mt-4">
+          위 외의 제3자에게는 사용자의 명시적 동의 없이 제공하지 않습니다.
+          단, 법령에 따라 수사기관의 적법한 요청이 있는 경우는 예외로 합니다.
+        </p>
+      </Section>
+
+      <Section title="5. 보관 기간 및 파기">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>계정 정보: 회원 탈퇴 또는 계정 연결 해제 시 즉시 파기</li>
+          <li>OAuth 토큰: 사용자가 Google 계정 연결을 해제하거나 권한을 회수하면 즉시 폐기</li>
+          <li>더빙 작업 기록: 작업 완료일로부터 12개월 보관 후 자동 파기 (사용자가 즉시 삭제 요청 가능)</li>
+          <li>결제·과금 관련 기록: 관련 법령(전자상거래법 등)에 따라 5년간 보관</li>
+        </ul>
+      </Section>
+
+      <Section title="6. 사용자 권리">
+        <p>사용자는 언제든 다음을 요청할 수 있습니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본인 데이터의 열람/정정/삭제</li>
+          <li>처리 정지 또는 동의 철회</li>
+          <li>YouTube/Google 권한 회수 — {' '}
+            <ExternalA href="https://myaccount.google.com/permissions">
+              Google 계정 보안 → 타사 앱 액세스
+            </ExternalA>
+            에서 직접 회수 가능
+          </li>
+        </ul>
+        <p className="mt-4">
+          위 요청은 본 페이지 하단의 연락처로 이메일을 보내주시면 영업일 기준 7일 이내에 처리합니다.
+        </p>
+      </Section>
+
+      <Section title="7. 보안">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>모든 통신은 HTTPS(TLS 1.2 이상)로 암호화됩니다.</li>
+          <li>OAuth 액세스 토큰은 HttpOnly·Secure 쿠키로만 저장되며, 클라이언트 JavaScript에서 직접 접근할 수 없습니다.</li>
+          <li>리프레시 토큰은 서버 측 데이터베이스에서 암호화 저장됩니다.</li>
+          <li>세션은 HMAC-SHA256으로 서명된 쿠키를 사용합니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="8. 쿠키">
+        <p>
+          본 서비스는 사용자 인증과 환경 설정을 위해 다음 쿠키를 사용합니다:
+          {' '}<code>dubtube_session</code> (세션 식별), <code>google_access_token</code> (YouTube
+          API 호출용 단기 토큰), <code>dubtube-theme</code> (라이트/다크 모드 설정),
+          <code> dubtube-youtube-settings</code> (사용자 기본 업로드 설정).
+        </p>
+      </Section>
+
+      <Section title="9. 미성년자 보호">
+        <p>
+          Dubtube는 만 14세 미만의 개인정보를 수집하지 않습니다. 미성년자가 서비스를 이용할
+          경우 법정대리인의 동의가 필요합니다.
+        </p>
+      </Section>
+
+      <Section title="10. 본 방침의 변경">
+        <p>
+          본 방침이 변경되는 경우, 변경 사항은 본 페이지에 공지하고 적용 7일 전부터 알립니다.
+          중요한 변경(데이터 사용 목적의 확대 등)의 경우 사용자에게 별도 동의를 다시 요청할 수
+          있습니다.
+        </p>
+      </Section>
+
+      <Section title="11. 연락처">
+        <p>
+          개인정보 관련 문의는{' '}
+          <a
+            href="mailto:devrel.365@gmail.com"
+            className="text-brand-600 hover:underline dark:text-brand-400"
+          >
+            devrel.365@gmail.com
+          </a>
+          으로 보내주세요.
+        </p>
+      </Section>
+
+      <footer className="mt-12 border-t border-surface-200 pt-6 text-sm text-surface-500 dark:border-surface-800">
+        <p>
+          관련 문서:{' '}
+          <Link href="/terms" className="text-brand-600 hover:underline dark:text-brand-400">
+            서비스 약관
+          </Link>{' '}
+          ·{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>{' '}
+          ·{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>
+        </p>
+      </footer>
+    </article>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{title}</h2>
+      <div className="mt-3 space-y-3 leading-relaxed">{children}</div>
+    </section>
+  )
+}
+
+function ExternalA({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-brand-600 hover:underline dark:text-brand-400"
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '서비스 약관 — Dubtube',
+  description:
+    'Dubtube 서비스 약관. YouTube API Services Terms of Service 동의를 포함합니다.',
+  alternates: { canonical: '/terms' },
+  robots: { index: true, follow: true },
+}
+
+const LAST_UPDATED = '2026-04-29'
+
+export default function TermsPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-16 text-surface-700 dark:text-surface-300">
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-surface-900 dark:text-white sm:text-4xl">
+          서비스 약관
+        </h1>
+        <p className="mt-2 text-sm text-surface-500">최종 업데이트: {LAST_UPDATED}</p>
+      </header>
+
+      <Section title="1. 약관의 동의">
+        <p>
+          본 약관은 Dubtube(&ldquo;본 서비스&rdquo;)의 이용 조건을 규정합니다. 본 서비스에
+          가입하거나 사용함으로써 사용자는 본 약관과{' '}
+          <Link href="/privacy" className="text-brand-600 hover:underline dark:text-brand-400">
+            개인정보처리방침
+          </Link>
+          에 동의한 것으로 간주됩니다. 또한 사용자는 본 서비스가 YouTube API Services를 사용하므로,{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">YouTube Terms of Service</ExternalA>
+          에도 함께 동의해야 합니다.
+        </p>
+      </Section>
+
+      <Section title="2. 서비스 개요">
+        <p>
+          Dubtube는 YouTube 크리에이터가 자신의 영상을 다국어로 자동 더빙하고, 결과물을 영상·자막·오디오
+          트랙 형태로 YouTube에 업로드할 수 있게 하는 웹 서비스입니다. 본 서비스는 다음
+          제3자 API를 사용합니다:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            <strong>YouTube Data API v3</strong> — 채널/영상 조회, 영상·자막·오디오 트랙 업로드
+          </li>
+          <li>
+            <strong>YouTube Analytics API</strong> — 사용자 채널의 분석 데이터 표시
+          </li>
+          <li>
+            <strong>Perso.ai API</strong> — 보이스 클론, 음성 합성, 번역
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="3. 계정 및 인증">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본 서비스는 Google OAuth 2.0을 통한 로그인만 제공합니다.</li>
+          <li>사용자는 정확한 정보를 제공해야 하며, 계정 보안에 대한 책임을 집니다.</li>
+          <li>한 사용자는 하나의 계정만 가질 수 있으며, 계정 양도는 금지됩니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="4. 사용자 의무">
+        <p>사용자는 본 서비스를 이용함에 있어 다음 행위를 하지 않습니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>저작권자의 동의 없이 타인의 영상을 더빙·업로드하는 행위</li>
+          <li>YouTube 커뮤니티 가이드 및 저작권 정책에 위배되는 콘텐츠 생성</li>
+          <li>딥페이크 등 타인의 명예를 훼손하거나 사기에 이용될 수 있는 콘텐츠 생성</li>
+          <li>본 서비스의 API/시스템에 대한 비정상적·자동화된 호출(스크래핑, DDoS 등)</li>
+          <li>크레딧 시스템의 회피·부정 사용</li>
+        </ul>
+      </Section>
+
+      <Section title="5. YouTube API Services 동의 및 제한">
+        <p>
+          본 서비스를 사용함으로써 사용자는{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>
+          에 동의하게 됩니다. YouTube로부터 데이터에 대한 권한을 부여받는 시점부터 다음의
+          제한이 적용됩니다.
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            사용자는 언제든{' '}
+            <ExternalA href="https://myaccount.google.com/permissions">
+              Google 계정 보안 → 타사 앱 액세스
+            </ExternalA>
+            에서 Dubtube의 권한을 회수할 수 있습니다.
+          </li>
+          <li>
+            본 서비스는 받은 YouTube 데이터를 광고·마케팅 목적으로 사용하거나 외부에 양도하지
+            않습니다.
+          </li>
+          <li>
+            본 서비스가 저장·캐시한 YouTube 데이터는 30일 이내에 갱신되거나, 사용자 요청 시
+            즉시 삭제됩니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="6. 크레딧 및 결제">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본 서비스는 1분 더빙당 크레딧 1을 차감하는 선불 크레딧 모델을 사용합니다.</li>
+          <li>구매한 크레딧은 환불되지 않으나, 만료 기한은 없습니다.</li>
+          <li>본 서비스 장애로 처리가 실패한 작업은 크레딧이 자동 환원됩니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="7. 지적 재산권">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            본 서비스가 생성한 더빙 영상·자막·오디오의 저작권은 원본 영상의 권리자(통상 사용자
+            본인)에게 귀속됩니다.
+          </li>
+          <li>
+            Dubtube의 로고·UI·코드 등 서비스 자체의 지적 재산권은 Dubtube에 귀속됩니다.
+          </li>
+          <li>
+            보이스 클론에 사용되는 사용자 음성은 사용자 본인 또는 사용자가 권리를 보유한
+            인물의 것이어야 합니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="8. 면책 및 책임 제한">
+        <p>
+          본 서비스는 &ldquo;있는 그대로(as-is)&rdquo; 제공되며, 다음 사항에 대해서는 명시적으로
+          면책됩니다.
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>제3자 API(YouTube, Google, Perso.ai)의 장애 또는 정책 변경으로 인한 서비스 중단</li>
+          <li>사용자가 업로드한 콘텐츠로 인한 저작권/명예훼손 분쟁</li>
+          <li>AI 더빙 결과물의 정확성·자연스러움</li>
+          <li>천재지변, 정전, 네트워크 장애 등 불가항력적 사유로 인한 손해</li>
+        </ul>
+        <p className="mt-4">
+          Dubtube의 책임은 사용자가 본 서비스에 직전 12개월간 지불한 금액을 한도로 합니다.
+        </p>
+      </Section>
+
+      <Section title="9. 서비스 변경 및 종료">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            본 서비스는 사전 공지 후 기능을 변경하거나 일부 기능을 종료할 수 있습니다.
+          </li>
+          <li>
+            사용자는 언제든 계정 연결 해제로 서비스 이용을 중단할 수 있으며, 이 경우 본 서비스가
+            보유한 사용자 데이터는 개인정보처리방침에 따라 파기됩니다.
+          </li>
+          <li>
+            사용자가 본 약관을 중대하게 위반한 경우 사전 공지 없이 계정 이용이 정지될 수
+            있습니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="10. 약관의 변경">
+        <p>
+          본 약관이 변경되는 경우 변경 사항은 본 페이지에 공지하고, 적용 7일 전부터 알립니다.
+          중요한 변경의 경우 사용자에게 별도 동의를 다시 요청할 수 있습니다.
+        </p>
+      </Section>
+
+      <Section title="11. 준거법 및 분쟁 해결">
+        <p>
+          본 약관은 대한민국 법령에 따라 해석되며, 본 서비스 이용과 관련하여 분쟁이 발생할 경우
+          서울중앙지방법원을 1심 관할 법원으로 합니다.
+        </p>
+      </Section>
+
+      <Section title="12. 연락처">
+        <p>
+          본 약관에 관한 문의는{' '}
+          <a
+            href="mailto:devrel.365@gmail.com"
+            className="text-brand-600 hover:underline dark:text-brand-400"
+          >
+            devrel.365@gmail.com
+          </a>
+          으로 보내주세요.
+        </p>
+      </Section>
+
+      <footer className="mt-12 border-t border-surface-200 pt-6 text-sm text-surface-500 dark:border-surface-800">
+        <p>
+          관련 문서:{' '}
+          <Link href="/privacy" className="text-brand-600 hover:underline dark:text-brand-400">
+            개인정보처리방침
+          </Link>{' '}
+          ·{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>{' '}
+          ·{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>
+        </p>
+      </footer>
+    </article>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{title}</h2>
+      <div className="mt-3 space-y-3 leading-relaxed">{children}</div>
+    </section>
+  )
+}
+
+function ExternalA({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-brand-600 hover:underline dark:text-brand-400"
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/components/layout/LandingFooter.tsx
+++ b/src/components/layout/LandingFooter.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Languages } from 'lucide-react'
 
 export function LandingFooter() {
@@ -13,7 +14,29 @@ export function LandingFooter() {
               Dub<span className="text-brand-500">tube</span>
             </span>
           </div>
-          <p className="text-sm text-surface-500">
+
+          <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm">
+            <Link
+              href="/privacy"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              개인정보처리방침
+            </Link>
+            <Link
+              href="/terms"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              서비스 약관
+            </Link>
+            <a
+              href="mailto:devrel.365@gmail.com"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              문의
+            </a>
+          </nav>
+
+          <p className="text-xs text-surface-500">
             &copy; {new Date().getFullYear()} Dubtube. All rights reserved.
           </p>
         </div>


### PR DESCRIPTION
## Summary
Google OAuth Sensitive/Restricted 스코프 정식 검증을 위한 Phase 1 작업입니다. 검증 폼에서 요구하는 공개 페이지(개인정보처리방침, 서비스 약관)를 신설하고 Footer에서 도달 가능하도록 연결합니다.

### 신규 페이지
- **`/privacy`** — Google API Services User Data Policy 준수 명시, YouTube 데이터의 수집 항목·사용 목적·보관 기간·제3자 위탁(Perso/YouTube/Vercel/Turso)·사용자 권리(Google 권한 회수 링크)·보안·쿠키·미성년자·연락처
- **`/terms`** — YouTube Terms of Service 동의 및 사용자 의무, 크레딧/결제, 지적 재산권, 면책, 준거법. \`YouTube API Services Terms of Service\` 명시적 동의 포함

### Footer 변경
- LandingFooter에 \`/privacy\`, \`/terms\`, 문의 메일(devrel.365@gmail.com) 링크 추가
- Google 검증 폼이 Footer 도달성을 확인하므로 모든 마케팅 페이지에서 접근 가능

### Metadata
- 두 페이지 모두 \`robots: index/follow\` + \`canonical\` 지정 → Search Console 도메인 인증 후 색인 가능

## 검증 진행 단계
이번 PR로 **Phase 1(공개 문서 인프라)** 완료. 이후 순서:
- Phase 2: Search Console에서 \`dubtube.vercel.app\` 도메인 소유권 인증
- Phase 3: OAuth consent screen에 \`https://dubtube.vercel.app\`, \`/privacy\`, \`/terms\` URL 입력 + 로고 업로드
- Phase 4: 스코프별 사용 시연 데모 영상(YouTube Unlisted 업로드)
- Phase 5: 정식 검증 신청 → Sensitive 4~6주 + Restricted(force-ssl) CASA 8~16주

## Test plan
- [ ] 로컬에서 \`/privacy\`, \`/terms\` 페이지 정상 렌더링 확인
- [ ] LandingFooter의 두 링크 클릭 시 정상 이동
- [ ] 다크 모드에서 가독성 OK
- [ ] \`npx tsc --noEmit\` 통과
- [ ] 배포 후 https://dubtube.vercel.app/privacy , https://dubtube.vercel.app/terms 에 접근 가능한지 확인
- [ ] 약관·정책 본문에 회사·서비스명·연락처가 정확한지 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)