### PR TITLE
fix(dashboard): Recharts ResponsiveContainer width(-1)/height(-1) 경고 제거

### DIFF
--- a/src/features/dashboard/components/AnalyticsChart.tsx
+++ b/src/features/dashboard/components/AnalyticsChart.tsx
@@ -106,7 +106,7 @@ export function AnalyticsChart({ videoIds }: { videoIds?: string[] }) {
         </div>
       </div>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           {tab === 'daily' ? (
             <BarChart data={mergedDaily} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>

--- a/src/features/dashboard/components/CreditChart.tsx
+++ b/src/features/dashboard/components/CreditChart.tsx
@@ -32,7 +32,7 @@ export function CreditChart({ initialData }: CreditChartProps) {
       <CardTitle>크레딧 사용량</CardTitle>
       <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">월별 크레딧 소비 현황</p>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
             <defs>

--- a/src/features/dashboard/components/LanguagePerformance.tsx
+++ b/src/features/dashboard/components/LanguagePerformance.tsx
@@ -37,7 +37,7 @@ export function LanguagePerformance() {
       <CardTitle>언어별 성과</CardTitle>
       <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">더빙 언어별 조회수</p>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} horizontal={false} />


### PR DESCRIPTION
## Summary
대시보드 페이지에서 다음 dev 콘솔 경고가 발생하던 것을 수정합니다.

\`\`\`
The width(-1) and height(-1) of chart should be greater than 0,
please check the style of container, or the props width(100%) and height(100%),
or add a minWidth(0) or minHeight(undefined) or use aspect(undefined) to control the
height and width.
\`\`\`

### 원인
CreditChart / LanguagePerformance / AnalyticsChart 모두 동일 패턴:
\`\`\`tsx
<div className="h-64">
  <ResponsiveContainer width="100%" height="100%">
\`\`\`

- 차트가 \`dynamic({ ssr:false })\`로 클라이언트에서만 마운트되어 첫 paint 직전 ResizeObserver가 -1 반환
- 외부 div에 명시적 width가 없고, CSS Grid 자식의 기본 \`min-width: auto\`가 SVG intrinsic content 때문에 트랙을 넘치는 케이스도 가능
- DashboardContent의 \`<div className="grid gap-6 lg:grid-cols-2">\` 안에 들어 있는 차트들이 특히 영향

### 수정
3개 차트의 wrapper div에 \`w-full min-w-0\` 추가:
- \`w-full\` — 부모로부터 즉시 100% 너비를 픽셀로 확정 → 첫 측정값이 -1로 떨어지지 않음
- \`min-w-0\` — Grid/Flex 자식이 SVG intrinsic content 때문에 부풀어지는 케이스 차단

기능 변화 없음. 콘솔 경고만 사라집니다.

## Files
- \`src/features/dashboard/components/CreditChart.tsx\` — 1줄
- \`src/features/dashboard/components/LanguagePerformance.tsx\` — 1줄
- \`src/features/dashboard/components/AnalyticsChart.tsx\` — 1줄

## Test plan
- [ ] \`npx tsc --noEmit\` 통과 (확인 완료)
- [ ] /dashboard 진입 시 콘솔에 \`width(-1) and height(-1)...\` 경고 사라짐
- [ ] 차트 3개 모두 정상 렌더링 (CreditChart Area, LanguagePerformance BarChart, AnalyticsChart 일별/주별 토글)
- [ ] 다크 모드, 모바일 폭(\`lg\` 미만)에서도 차트 깨짐 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)