### PR TITLE
fix(youtube): analytics_cache 테이블 lazy bootstrap (SQLITE_UNKNOWN 500 해결)

### DIFF
--- a/src/app/api/youtube/analytics/route.ts
+++ b/src/app/api/youtube/analytics/route.ts
@@ -17,6 +17,28 @@ export const dynamic = 'force-dynamic'
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
+let cacheTableEnsured = false
+
+/**
+ * Lazy bootstrap analytics_cache table.
+ * Idempotent — runs CREATE TABLE IF NOT EXISTS once per process.
+ */
+async function ensureCacheTable(): Promise<void> {
+  if (cacheTableEnsured) return
+  const db = getDb()
+  await db.execute({
+    sql: `CREATE TABLE IF NOT EXISTS analytics_cache (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      video_id TEXT NOT NULL,
+      data TEXT NOT NULL,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    args: [],
+  })
+  cacheTableEnsured = true
+}
+
 function defaultDateRange() {
   const end = new Date()
   const start = new Date()
@@ -31,6 +53,7 @@ async function getCached(
   userId: string,
   videoId: string,
 ): Promise<VideoAnalytics | null> {
+  await ensureCacheTable()
   const db = getDb()
   const row = await db.execute({
     sql: 'SELECT data, fetched_at FROM analytics_cache WHERE id = ? AND user_id = ?',
@@ -47,6 +70,7 @@ async function setCache(
   videoId: string,
   data: VideoAnalytics,
 ): Promise<void> {
+  await ensureCacheTable()
   const db = getDb()
   await db.execute({
     sql: `INSERT OR REPLACE INTO analytics_cache (id, user_id, video_id, data, fetched_at)


### PR DESCRIPTION
## Summary
\`/api/youtube/analytics\` 호출이 500 \`SQLITE_UNKNOWN\`으로 실패하던 문제를 수정합니다.

### 증상
\`\`\`
GET /api/youtube/analytics?videoIds=JOtGDJl1n-0 500
ERROR api error status=500 code="SQLITE_UNKNOWN" message="Internal Server Error"
\`\`\`

### 원인
\`src/app/api/youtube/analytics/route.ts\` 의 \`getCached\` / \`setCache\` 가 \`analytics_cache\` 테이블에 SELECT / INSERT 를 하지만, **해당 테이블의 \`CREATE TABLE\` 정의가 코드베이스 어디에도 없습니다.** 신규 Turso 환경에서 첫 호출 시 *no such table* 에러 → libsql 드라이버가 \`SQLITE_UNKNOWN\`으로 surface.

(참고) 같은 이슈를 피한 다른 라우트는 \`src/lib/db/queries/upload-queue.ts:26-54\`에서 \`tableEnsured\` 플래그로 lazy bootstrap을 하고 있음.

### 수정
analytics 라우트에 동일 패턴 적용:
- 모듈 스코프 \`cacheTableEnsured\` 플래그
- \`ensureCacheTable()\` lazy 함수 (idempotent \`CREATE TABLE IF NOT EXISTS\`)
- \`getCached\` / \`setCache\` 진입 시 await

### 적용 스키마
\`\`\`sql
CREATE TABLE IF NOT EXISTS analytics_cache (
  id          TEXT PRIMARY KEY,        -- "{userId}:{videoId}"
  user_id     TEXT NOT NULL,
  video_id    TEXT NOT NULL,
  data        TEXT NOT NULL,           -- VideoAnalytics JSON
  fetched_at  TEXT NOT NULL DEFAULT (datetime('now'))
)
\`\`\`

라우트의 SELECT/INSERT 컬럼/타입과 정확히 일치 (id, user_id, video_id, data, fetched_at).

## Test plan
- [ ] 머지 + 배포 후 \`/api/youtube/analytics?videoIds=...\` 200 정상 응답
- [ ] 첫 호출에서 테이블 자동 생성, 동일 프로세스 내 후속 호출은 추가 \`CREATE TABLE\` 호출 없음 (플래그로 차단됨)
- [ ] 24h 후 같은 영상 분석 요청 시 캐시 만료되어 새로 fetch + setCache 정상
- [ ] Turso 콘솔에서 analytics_cache 테이블이 생성됐는지 확인

## 부수 효과
사용자 로그에 동시에 보였던 차트 \`width(-1)/height(-1)\` 경고는 별개 이슈이며 PR #185(머지됨)에서 처리. analytics 500이 React re-render를 유발해 차트 경고가 함께 출력되던 사이클이라 이번 PR 머지 후 둘 다 자연스럽게 잠잠해질 가능성이 높음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)