### PR TITLE
release: dubtube 리브랜딩 + 더빙·자막·YouTube 워크플로 대규모 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@libsql/client": "^0.17.3",
         "@tanstack/react-query": "^5.100.6",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.12.0",
+        "lucide-react": "^1.14.0",
         "next": "16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -8261,9 +8261,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.12.0.tgz",
-      "integrity": "sha512-rTKR3RN6HIAxdNZALoPvqxd64vjL9nTThU0JF9q1Qg8yUnmo1r+d8baN72YNVK3RGxUmzBzbd77IWJq/fkm+Xw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@libsql/client": "^0.17.3",
     "@tanstack/react-query": "^5.100.6",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.12.0",
+    "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침 — Dubtube',
+  description:
+    'Dubtube의 개인정보처리방침. YouTube API Services 데이터 사용, 수집·보관·삭제 정책을 안내합니다.',
+  alternates: { canonical: '/privacy' },
+  robots: { index: true, follow: true },
+}
+
+const LAST_UPDATED = '2026-04-29'
+
+export default function PrivacyPolicyPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-16 text-surface-700 dark:text-surface-300">
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-surface-900 dark:text-white sm:text-4xl">
+          개인정보처리방침
+        </h1>
+        <p className="mt-2 text-sm text-surface-500">최종 업데이트: {LAST_UPDATED}</p>
+      </header>
+
+      <Section title="1. 개요">
+        <p>
+          Dubtube(&ldquo;본 서비스&rdquo;)는 YouTube 크리에이터가 자신의 영상을 다국어로 더빙하고
+          자막·오디오 트랙을 YouTube에 업로드할 수 있도록 돕는 서비스입니다. 본 방침은 Dubtube가
+          사용자로부터 수집·이용·보관·파기하는 개인정보의 범위와 방법을 설명합니다.
+        </p>
+        <p>
+          Dubtube는{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>
+          를 준수하며, 동 정책의 Limited Use 요구사항을 포함하여 적용됩니다.
+        </p>
+      </Section>
+
+      <Section title="2. 수집하는 정보">
+        <h3 className="mt-4 font-semibold text-surface-900 dark:text-white">2.1 Google 계정 정보</h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>이메일 주소, 이름, 프로필 사진(Google OpenID Connect 표준 클레임)</li>
+          <li>OAuth 2.0 액세스 토큰 / 리프레시 토큰</li>
+        </ul>
+
+        <h3 className="mt-6 font-semibold text-surface-900 dark:text-white">
+          2.2 YouTube 데이터 (사용자 명시 동의 후)
+        </h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>채널 정보(채널명, 구독자 수, 채널 ID, 채널 썸네일)</li>
+          <li>영상 메타데이터(제목, 설명, 썸네일, 조회수, 게시일)</li>
+          <li>사용자가 더빙 대상으로 지정한 영상의 오디오/자막 데이터</li>
+          <li>사용자가 업로드 권한을 부여한 영상에 대한 자막(SRT) 및 오디오 트랙</li>
+        </ul>
+
+        <h3 className="mt-6 font-semibold text-surface-900 dark:text-white">
+          2.3 서비스 이용 데이터
+        </h3>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>더빙 작업 기록(원본 언어, 대상 언어, 처리 상태, 결과 URL)</li>
+          <li>크레딧 사용 내역</li>
+          <li>업로드 큐 상태</li>
+        </ul>
+      </Section>
+
+      <Section title="3. 정보 사용 목적">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>더빙 영상·오디오·자막 생성 및 사용자 YouTube 채널로의 업로드</li>
+          <li>다국어 자막 트랙 추가/교체(YouTube Captions API 사용)</li>
+          <li>크레딧 차감·결제·잔여량 표시</li>
+          <li>사용자 인증 및 세션 유지</li>
+          <li>서비스 안정성 모니터링 및 오류 진단</li>
+        </ul>
+        <p className="mt-4">
+          Dubtube는 YouTube API Services를 통해 받은 사용자 데이터를{' '}
+          <strong>광고 또는 외부 마케팅 목적으로 사용·전송하지 않으며</strong>,
+          모델 학습·휴먼 리뷰 등에도 사용하지 않습니다.
+        </p>
+      </Section>
+
+      <Section title="4. 제3자 제공 및 처리 위탁">
+        <p>다음의 처리 위탁사에 한해, 서비스 제공 목적으로 필요한 최소 범위에서 데이터를 전달합니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            <strong>Perso.ai</strong> — 보이스 클론, 음성 합성, 번역 처리. 사용자가 더빙
+            대상으로 지정한 영상/오디오 데이터에 한해 전달됨.
+          </li>
+          <li>
+            <strong>Google (YouTube Data API)</strong> — 채널/영상 조회, 영상·자막·오디오 트랙 업로드.
+          </li>
+          <li>
+            <strong>Vercel</strong> — 웹 애플리케이션 호스팅, 로그 수집(IP/User-Agent 기본 로그).
+          </li>
+          <li>
+            <strong>Turso (libSQL)</strong> — 사용자 계정·작업 기록 데이터베이스 호스팅.
+          </li>
+        </ul>
+        <p className="mt-4">
+          위 외의 제3자에게는 사용자의 명시적 동의 없이 제공하지 않습니다.
+          단, 법령에 따라 수사기관의 적법한 요청이 있는 경우는 예외로 합니다.
+        </p>
+      </Section>
+
+      <Section title="5. 보관 기간 및 파기">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>계정 정보: 회원 탈퇴 또는 계정 연결 해제 시 즉시 파기</li>
+          <li>OAuth 토큰: 사용자가 Google 계정 연결을 해제하거나 권한을 회수하면 즉시 폐기</li>
+          <li>더빙 작업 기록: 작업 완료일로부터 12개월 보관 후 자동 파기 (사용자가 즉시 삭제 요청 가능)</li>
+          <li>결제·과금 관련 기록: 관련 법령(전자상거래법 등)에 따라 5년간 보관</li>
+        </ul>
+      </Section>
+
+      <Section title="6. 사용자 권리">
+        <p>사용자는 언제든 다음을 요청할 수 있습니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본인 데이터의 열람/정정/삭제</li>
+          <li>처리 정지 또는 동의 철회</li>
+          <li>YouTube/Google 권한 회수 — {' '}
+            <ExternalA href="https://myaccount.google.com/permissions">
+              Google 계정 보안 → 타사 앱 액세스
+            </ExternalA>
+            에서 직접 회수 가능
+          </li>
+        </ul>
+        <p className="mt-4">
+          위 요청은 본 페이지 하단의 연락처로 이메일을 보내주시면 영업일 기준 7일 이내에 처리합니다.
+        </p>
+      </Section>
+
+      <Section title="7. 보안">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>모든 통신은 HTTPS(TLS 1.2 이상)로 암호화됩니다.</li>
+          <li>OAuth 액세스 토큰은 HttpOnly·Secure 쿠키로만 저장되며, 클라이언트 JavaScript에서 직접 접근할 수 없습니다.</li>
+          <li>리프레시 토큰은 서버 측 데이터베이스에서 암호화 저장됩니다.</li>
+          <li>세션은 HMAC-SHA256으로 서명된 쿠키를 사용합니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="8. 쿠키">
+        <p>
+          본 서비스는 사용자 인증과 환경 설정을 위해 다음 쿠키를 사용합니다:
+          {' '}<code>dubtube_session</code> (세션 식별), <code>google_access_token</code> (YouTube
+          API 호출용 단기 토큰), <code>dubtube-theme</code> (라이트/다크 모드 설정),
+          <code> dubtube-youtube-settings</code> (사용자 기본 업로드 설정).
+        </p>
+      </Section>
+
+      <Section title="9. 미성년자 보호">
+        <p>
+          Dubtube는 만 14세 미만의 개인정보를 수집하지 않습니다. 미성년자가 서비스를 이용할
+          경우 법정대리인의 동의가 필요합니다.
+        </p>
+      </Section>
+
+      <Section title="10. 본 방침의 변경">
+        <p>
+          본 방침이 변경되는 경우, 변경 사항은 본 페이지에 공지하고 적용 7일 전부터 알립니다.
+          중요한 변경(데이터 사용 목적의 확대 등)의 경우 사용자에게 별도 동의를 다시 요청할 수
+          있습니다.
+        </p>
+      </Section>
+
+      <Section title="11. 연락처">
+        <p>
+          개인정보 관련 문의는{' '}
+          <a
+            href="mailto:devrel.365@gmail.com"
+            className="text-brand-600 hover:underline dark:text-brand-400"
+          >
+            devrel.365@gmail.com
+          </a>
+          으로 보내주세요.
+        </p>
+      </Section>
+
+      <footer className="mt-12 border-t border-surface-200 pt-6 text-sm text-surface-500 dark:border-surface-800">
+        <p>
+          관련 문서:{' '}
+          <Link href="/terms" className="text-brand-600 hover:underline dark:text-brand-400">
+            서비스 약관
+          </Link>{' '}
+          ·{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>{' '}
+          ·{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>
+        </p>
+      </footer>
+    </article>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{title}</h2>
+      <div className="mt-3 space-y-3 leading-relaxed">{children}</div>
+    </section>
+  )
+}
+
+function ExternalA({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-brand-600 hover:underline dark:text-brand-400"
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '서비스 약관 — Dubtube',
+  description:
+    'Dubtube 서비스 약관. YouTube API Services Terms of Service 동의를 포함합니다.',
+  alternates: { canonical: '/terms' },
+  robots: { index: true, follow: true },
+}
+
+const LAST_UPDATED = '2026-04-29'
+
+export default function TermsPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-6 py-16 text-surface-700 dark:text-surface-300">
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-surface-900 dark:text-white sm:text-4xl">
+          서비스 약관
+        </h1>
+        <p className="mt-2 text-sm text-surface-500">최종 업데이트: {LAST_UPDATED}</p>
+      </header>
+
+      <Section title="1. 약관의 동의">
+        <p>
+          본 약관은 Dubtube(&ldquo;본 서비스&rdquo;)의 이용 조건을 규정합니다. 본 서비스에
+          가입하거나 사용함으로써 사용자는 본 약관과{' '}
+          <Link href="/privacy" className="text-brand-600 hover:underline dark:text-brand-400">
+            개인정보처리방침
+          </Link>
+          에 동의한 것으로 간주됩니다. 또한 사용자는 본 서비스가 YouTube API Services를 사용하므로,{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">YouTube Terms of Service</ExternalA>
+          에도 함께 동의해야 합니다.
+        </p>
+      </Section>
+
+      <Section title="2. 서비스 개요">
+        <p>
+          Dubtube는 YouTube 크리에이터가 자신의 영상을 다국어로 자동 더빙하고, 결과물을 영상·자막·오디오
+          트랙 형태로 YouTube에 업로드할 수 있게 하는 웹 서비스입니다. 본 서비스는 다음
+          제3자 API를 사용합니다:
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            <strong>YouTube Data API v3</strong> — 채널/영상 조회, 영상·자막·오디오 트랙 업로드
+          </li>
+          <li>
+            <strong>YouTube Analytics API</strong> — 사용자 채널의 분석 데이터 표시
+          </li>
+          <li>
+            <strong>Perso.ai API</strong> — 보이스 클론, 음성 합성, 번역
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="3. 계정 및 인증">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본 서비스는 Google OAuth 2.0을 통한 로그인만 제공합니다.</li>
+          <li>사용자는 정확한 정보를 제공해야 하며, 계정 보안에 대한 책임을 집니다.</li>
+          <li>한 사용자는 하나의 계정만 가질 수 있으며, 계정 양도는 금지됩니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="4. 사용자 의무">
+        <p>사용자는 본 서비스를 이용함에 있어 다음 행위를 하지 않습니다.</p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>저작권자의 동의 없이 타인의 영상을 더빙·업로드하는 행위</li>
+          <li>YouTube 커뮤니티 가이드 및 저작권 정책에 위배되는 콘텐츠 생성</li>
+          <li>딥페이크 등 타인의 명예를 훼손하거나 사기에 이용될 수 있는 콘텐츠 생성</li>
+          <li>본 서비스의 API/시스템에 대한 비정상적·자동화된 호출(스크래핑, DDoS 등)</li>
+          <li>크레딧 시스템의 회피·부정 사용</li>
+        </ul>
+      </Section>
+
+      <Section title="5. YouTube API Services 동의 및 제한">
+        <p>
+          본 서비스를 사용함으로써 사용자는{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>
+          에 동의하게 됩니다. YouTube로부터 데이터에 대한 권한을 부여받는 시점부터 다음의
+          제한이 적용됩니다.
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            사용자는 언제든{' '}
+            <ExternalA href="https://myaccount.google.com/permissions">
+              Google 계정 보안 → 타사 앱 액세스
+            </ExternalA>
+            에서 Dubtube의 권한을 회수할 수 있습니다.
+          </li>
+          <li>
+            본 서비스는 받은 YouTube 데이터를 광고·마케팅 목적으로 사용하거나 외부에 양도하지
+            않습니다.
+          </li>
+          <li>
+            본 서비스가 저장·캐시한 YouTube 데이터는 30일 이내에 갱신되거나, 사용자 요청 시
+            즉시 삭제됩니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="6. 크레딧 및 결제">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>본 서비스는 1분 더빙당 크레딧 1을 차감하는 선불 크레딧 모델을 사용합니다.</li>
+          <li>구매한 크레딧은 환불되지 않으나, 만료 기한은 없습니다.</li>
+          <li>본 서비스 장애로 처리가 실패한 작업은 크레딧이 자동 환원됩니다.</li>
+        </ul>
+      </Section>
+
+      <Section title="7. 지적 재산권">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            본 서비스가 생성한 더빙 영상·자막·오디오의 저작권은 원본 영상의 권리자(통상 사용자
+            본인)에게 귀속됩니다.
+          </li>
+          <li>
+            Dubtube의 로고·UI·코드 등 서비스 자체의 지적 재산권은 Dubtube에 귀속됩니다.
+          </li>
+          <li>
+            보이스 클론에 사용되는 사용자 음성은 사용자 본인 또는 사용자가 권리를 보유한
+            인물의 것이어야 합니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="8. 면책 및 책임 제한">
+        <p>
+          본 서비스는 &ldquo;있는 그대로(as-is)&rdquo; 제공되며, 다음 사항에 대해서는 명시적으로
+          면책됩니다.
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>제3자 API(YouTube, Google, Perso.ai)의 장애 또는 정책 변경으로 인한 서비스 중단</li>
+          <li>사용자가 업로드한 콘텐츠로 인한 저작권/명예훼손 분쟁</li>
+          <li>AI 더빙 결과물의 정확성·자연스러움</li>
+          <li>천재지변, 정전, 네트워크 장애 등 불가항력적 사유로 인한 손해</li>
+        </ul>
+        <p className="mt-4">
+          Dubtube의 책임은 사용자가 본 서비스에 직전 12개월간 지불한 금액을 한도로 합니다.
+        </p>
+      </Section>
+
+      <Section title="9. 서비스 변경 및 종료">
+        <ul className="mt-2 list-disc space-y-1 pl-6">
+          <li>
+            본 서비스는 사전 공지 후 기능을 변경하거나 일부 기능을 종료할 수 있습니다.
+          </li>
+          <li>
+            사용자는 언제든 계정 연결 해제로 서비스 이용을 중단할 수 있으며, 이 경우 본 서비스가
+            보유한 사용자 데이터는 개인정보처리방침에 따라 파기됩니다.
+          </li>
+          <li>
+            사용자가 본 약관을 중대하게 위반한 경우 사전 공지 없이 계정 이용이 정지될 수
+            있습니다.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="10. 약관의 변경">
+        <p>
+          본 약관이 변경되는 경우 변경 사항은 본 페이지에 공지하고, 적용 7일 전부터 알립니다.
+          중요한 변경의 경우 사용자에게 별도 동의를 다시 요청할 수 있습니다.
+        </p>
+      </Section>
+
+      <Section title="11. 준거법 및 분쟁 해결">
+        <p>
+          본 약관은 대한민국 법령에 따라 해석되며, 본 서비스 이용과 관련하여 분쟁이 발생할 경우
+          서울중앙지방법원을 1심 관할 법원으로 합니다.
+        </p>
+      </Section>
+
+      <Section title="12. 연락처">
+        <p>
+          본 약관에 관한 문의는{' '}
+          <a
+            href="mailto:devrel.365@gmail.com"
+            className="text-brand-600 hover:underline dark:text-brand-400"
+          >
+            devrel.365@gmail.com
+          </a>
+          으로 보내주세요.
+        </p>
+      </Section>
+
+      <footer className="mt-12 border-t border-surface-200 pt-6 text-sm text-surface-500 dark:border-surface-800">
+        <p>
+          관련 문서:{' '}
+          <Link href="/privacy" className="text-brand-600 hover:underline dark:text-brand-400">
+            개인정보처리방침
+          </Link>{' '}
+          ·{' '}
+          <ExternalA href="https://www.youtube.com/t/terms">
+            YouTube Terms of Service
+          </ExternalA>{' '}
+          ·{' '}
+          <ExternalA href="https://developers.google.com/terms/api-services-user-data-policy">
+            Google API Services User Data Policy
+          </ExternalA>
+        </p>
+      </footer>
+    </article>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold text-surface-900 dark:text-white">{title}</h2>
+      <div className="mt-3 space-y-3 leading-relaxed">{children}</div>
+    </section>
+  )
+}
+
+function ExternalA({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-brand-600 hover:underline dark:text-brand-400"
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/app/api/perso/srt/route.ts
+++ b/src/app/api/perso/srt/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { persoFetch } from '@/lib/perso/client'
+import { fail, requireIntParam } from '@/lib/perso/route-helpers'
+import { getPersoFileUrl } from '@/lib/api-client/perso'
+import type { DownloadResponse } from '@/lib/perso/types'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * Perso가 생성한 자막 SRT 본문을 그대로 반환한다 (Content-Type: application/x-subrip).
+ *
+ * Flow
+ *   1. GET /download?target=audioScript 로 srtFile.translatedSubtitleDownloadLink
+ *      (perso-storage 상대 경로) 획득
+ *   2. https://perso.ai{path} 를 서버에서 fetch (브라우저 CORS 우회)
+ *   3. SRT 텍스트 그대로 반환
+ *
+ * 주의: Perso 공식 문서엔 originalSubtitle / translatedSubtitle target이 적혀
+ * 있으나 현재 백엔드는 두 값에 대해 500을 반환한다. audioScript가 정상 동작.
+ *
+ * Query
+ *   - projectSeq (required, integer)
+ *   - spaceSeq   (required, integer)
+ *   - kind       (optional, default 'translated') — 'translated' | 'original'
+ */
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  try {
+    const url = new URL(req.url)
+    const projectSeq = requireIntParam(url, 'projectSeq')
+    const spaceSeq = requireIntParam(url, 'spaceSeq')
+    const kind = url.searchParams.get('kind') === 'original' ? 'original' : 'translated'
+
+    const data = await persoFetch<DownloadResponse>(
+      `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`,
+      { baseURL: 'api', query: { target: 'audioScript' } },
+    )
+
+    const path =
+      kind === 'translated'
+        ? data.srtFile?.translatedSubtitleDownloadLink
+        : data.srtFile?.originalSubtitleDownloadLink
+
+    if (!path) {
+      throw Object.assign(new Error(`No ${kind} subtitle link in audioScript response`), {
+        name: 'PersoError',
+        code: 'SRT_NOT_AVAILABLE',
+        status: 404,
+      })
+    }
+
+    const fileUrl = path.startsWith('http') ? path : getPersoFileUrl(path)
+    const res = await fetch(fileUrl)
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw Object.assign(new Error(`Failed to fetch SRT: ${body}`), {
+        name: 'PersoError',
+        code: 'SRT_FETCH_FAILED',
+        status: res.status,
+      })
+    }
+
+    const srt = await res.text()
+    return new Response(srt, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/x-subrip; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err) {
+    return fail(err)
+  }
+}

--- a/src/app/api/youtube/analytics/route.ts
+++ b/src/app/api/youtube/analytics/route.ts
@@ -17,6 +17,28 @@ export const dynamic = 'force-dynamic'
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
+let cacheTableEnsured = false
+
+/**
+ * Lazy bootstrap analytics_cache table.
+ * Idempotent — runs CREATE TABLE IF NOT EXISTS once per process.
+ */
+async function ensureCacheTable(): Promise<void> {
+  if (cacheTableEnsured) return
+  const db = getDb()
+  await db.execute({
+    sql: `CREATE TABLE IF NOT EXISTS analytics_cache (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      video_id TEXT NOT NULL,
+      data TEXT NOT NULL,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    args: [],
+  })
+  cacheTableEnsured = true
+}
+
 function defaultDateRange() {
   const end = new Date()
   const start = new Date()
@@ -31,6 +53,7 @@ async function getCached(
   userId: string,
   videoId: string,
 ): Promise<VideoAnalytics | null> {
+  await ensureCacheTable()
   const db = getDb()
   const row = await db.execute({
     sql: 'SELECT data, fetched_at FROM analytics_cache WHERE id = ? AND user_id = ?',
@@ -47,6 +70,7 @@ async function setCache(
   videoId: string,
   data: VideoAnalytics,
 ): Promise<void> {
+  await ensureCacheTable()
   const db = getDb()
   await db.execute({
     sql: `INSERT OR REPLACE INTO analytics_cache (id, user_id, video_id, data, fetched_at)

--- a/src/components/layout/LandingFooter.tsx
+++ b/src/components/layout/LandingFooter.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Languages } from 'lucide-react'
 
 export function LandingFooter() {
@@ -13,7 +14,29 @@ export function LandingFooter() {
               Dub<span className="text-brand-500">tube</span>
             </span>
           </div>
-          <p className="text-sm text-surface-500">
+
+          <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm">
+            <Link
+              href="/privacy"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              개인정보처리방침
+            </Link>
+            <Link
+              href="/terms"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              서비스 약관
+            </Link>
+            <a
+              href="mailto:devrel.365@gmail.com"
+              className="text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100"
+            >
+              문의
+            </a>
+          </nav>
+
+          <p className="text-xs text-surface-500">
             &copy; {new Date().getFullYear()} Dubtube. All rights reserved.
           </p>
         </div>

--- a/src/features/dashboard/components/AnalyticsChart.tsx
+++ b/src/features/dashboard/components/AnalyticsChart.tsx
@@ -106,7 +106,7 @@ export function AnalyticsChart({ videoIds }: { videoIds?: string[] }) {
         </div>
       </div>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           {tab === 'daily' ? (
             <BarChart data={mergedDaily} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>

--- a/src/features/dashboard/components/CreditChart.tsx
+++ b/src/features/dashboard/components/CreditChart.tsx
@@ -32,7 +32,7 @@ export function CreditChart({ initialData }: CreditChartProps) {
       <CardTitle>크레딧 사용량</CardTitle>
       <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">월별 크레딧 소비 현황</p>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
             <defs>

--- a/src/features/dashboard/components/LanguagePerformance.tsx
+++ b/src/features/dashboard/components/LanguagePerformance.tsx
@@ -37,7 +37,7 @@ export function LanguagePerformance() {
       <CardTitle>언어별 성과</CardTitle>
       <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">더빙 언어별 조회수</p>
 
-      <div className="h-64">
+      <div className="h-64 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} horizontal={false} />

--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -17,33 +17,23 @@ import { getLanguageByCode, toBcp47 } from '@/utils/languages'
 import { useNotificationStore } from '@/stores/notificationStore'
 import {
   getProjectScript,
+  getTranslatedSrt,
   regenerateSentenceAudio,
   updateSentenceTranslation,
   ytUploadCaption,
 } from '@/lib/api-client'
-import { toSRT } from '@/utils/srt'
 import type { ScriptSentence } from '@/lib/perso/types'
 
-function formatMs(ms: number): string {
+function formatMs(ms: number | undefined | null): string {
+  if (ms == null || isNaN(ms)) return '0:00'
   const safe = Math.max(0, Math.floor(ms))
-  const h = Math.floor(safe / 3600000)
-  const m = Math.floor((safe % 3600000) / 60000)
+  const m = Math.floor(safe / 60000)
   const s = Math.floor((safe % 60000) / 1000)
-  const remainder = safe % 1000
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(remainder).padStart(3, '0')}`
-}
-
-function parseTimeToMs(timeStr: string): number | null {
-  const match = timeStr.match(/^(\d{1,2}):(\d{2}):(\d{2}),(\d{3})$/)
-  if (!match) return null
-  const [, h, m, s, ms] = match
-  return Number(h) * 3600000 + Number(m) * 60000 + Number(s) * 1000 + Number(ms)
+  return `${m}:${String(s).padStart(2, '0')}`
 }
 
 interface EditableSentence extends ScriptSentence {
   editedTranslatedText: string
-  editedStartMs: number
-  editedEndMs: number
   /** Perso 서버에 저장된 마지막 번역 텍스트(되돌림 비교용). */
   savedTranslatedText: string
 }
@@ -53,12 +43,7 @@ interface RowProps {
   projectSeq: number
   onPatch: (
     sentenceSeq: number,
-    patch: Partial<
-      Pick<
-        EditableSentence,
-        'editedTranslatedText' | 'editedStartMs' | 'editedEndMs' | 'savedTranslatedText'
-      >
-    >,
+    patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'savedTranslatedText'>>,
   ) => void
 }
 
@@ -66,8 +51,6 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
   const addToast = useNotificationStore((s) => s.addToast)
   const [saving, setSaving] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
-  const [startStr, setStartStr] = useState(formatMs(sentence.editedStartMs))
-  const [endStr, setEndStr] = useState(formatMs(sentence.editedEndMs))
 
   const textDirty = sentence.editedTranslatedText !== sentence.savedTranslatedText
 
@@ -98,7 +81,7 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
       addToast({
         type: 'success',
         title: '재생성 요청됨',
-        message: '오디오가 재생성됩니다. 완료 후 영상을 다시 다운로드하세요.',
+        message: '오디오가 재생성됩니다. 완료 후 SRT를 다시 다운로드하거나 YouTube에 적용하세요.',
       })
     } catch {
       addToast({ type: 'error', title: '재생성 실패' })
@@ -107,44 +90,14 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
     }
   }, [textDirty, handleSave, projectSeq, sentence.audioSentenceSeq, addToast])
 
-  const handleStartBlur = useCallback(() => {
-    const ms = parseTimeToMs(startStr)
-    if (ms !== null) {
-      onPatch(sentence.sentenceSeq, { editedStartMs: ms })
-    } else {
-      setStartStr(formatMs(sentence.editedStartMs))
-    }
-  }, [startStr, sentence.sentenceSeq, sentence.editedStartMs, onPatch])
-
-  const handleEndBlur = useCallback(() => {
-    const ms = parseTimeToMs(endStr)
-    if (ms !== null) {
-      onPatch(sentence.sentenceSeq, { editedEndMs: ms })
-    } else {
-      setEndStr(formatMs(sentence.editedEndMs))
-    }
-  }, [endStr, sentence.sentenceSeq, sentence.editedEndMs, onPatch])
-
   return (
     <div className="space-y-2 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <input
-          type="text"
-          value={startStr}
-          onChange={(e) => setStartStr(e.target.value)}
-          onBlur={handleStartBlur}
-          className="w-28 rounded border border-surface-300 bg-white px-2 py-0.5 font-mono text-xs text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
-        />
-        <span className="text-surface-400">&rarr;</span>
-        <input
-          type="text"
-          value={endStr}
-          onChange={(e) => setEndStr(e.target.value)}
-          onBlur={handleEndBlur}
-          className="w-28 rounded border border-surface-300 bg-white px-2 py-0.5 font-mono text-xs text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
-        />
+      <div className="flex items-center gap-2 text-xs text-surface-400">
+        <span className="font-mono">
+          {formatMs(sentence.startMs)} → {formatMs(sentence.endMs)}
+        </span>
         {sentence.speakerLabel && (
-          <span className="rounded bg-surface-100 px-1.5 py-0.5 text-surface-400 dark:bg-surface-800">
+          <span className="rounded bg-surface-100 px-1.5 py-0.5 dark:bg-surface-800">
             {sentence.speakerLabel}
           </span>
         )}
@@ -199,6 +152,9 @@ export function SubtitleScriptEditor({
   const [loading, setLoading] = useState(false)
   const [sentences, setSentences] = useState<EditableSentence[] | null>(null)
   const [showPreview, setShowPreview] = useState(false)
+  const [srtPreview, setSrtPreview] = useState<string>('')
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [downloading, setDownloading] = useState(false)
   const [pushingToYT, setPushingToYT] = useState(false)
 
   const lang = getLanguageByCode(langCode)
@@ -217,8 +173,6 @@ export function SubtitleScriptEditor({
         list.map((s) => ({
           ...s,
           editedTranslatedText: s.translatedText,
-          editedStartMs: s.startMs,
-          editedEndMs: s.endMs,
           savedTranslatedText: s.translatedText,
         })),
       )
@@ -233,12 +187,7 @@ export function SubtitleScriptEditor({
   const handlePatch = useCallback(
     (
       sentenceSeq: number,
-      patch: Partial<
-        Pick<
-          EditableSentence,
-          'editedTranslatedText' | 'editedStartMs' | 'editedEndMs' | 'savedTranslatedText'
-        >
-      >,
+      patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'savedTranslatedText'>>,
     ) => {
       setSentences((prev) =>
         prev?.map((s) => (s.sentenceSeq === sentenceSeq ? { ...s, ...patch } : s)) ?? null,
@@ -247,37 +196,59 @@ export function SubtitleScriptEditor({
     [],
   )
 
-  const buildSrt = useCallback((): string => {
-    if (!sentences) return ''
-    return toSRT(
-      sentences.map((s) => ({
-        startMs: s.editedStartMs,
-        endMs: s.editedEndMs,
-        translatedText: s.editedTranslatedText,
-      })),
-    )
-  }, [sentences])
+  const handleDownloadSRT = useCallback(async () => {
+    setDownloading(true)
+    try {
+      const srt = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
+      const blob = new Blob([srt], { type: 'application/x-subrip;charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${lang?.name || langCode}_${langCode}.srt`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: 'SRT 다운로드 실패',
+        message: err instanceof Error ? err.message : '',
+      })
+    } finally {
+      setDownloading(false)
+    }
+  }, [projectSeq, spaceSeq, lang, langCode, addToast])
 
-  const handleDownloadSRT = useCallback(() => {
-    const srtContent = buildSrt()
-    if (!srtContent) return
-    const blob = new Blob([srtContent], { type: 'text/plain;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${lang?.name || langCode}_${langCode}.srt`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }, [buildSrt, lang, langCode])
+  const handleTogglePreview = useCallback(async () => {
+    if (showPreview) {
+      setShowPreview(false)
+      return
+    }
+    if (!srtPreview) {
+      setPreviewLoading(true)
+      try {
+        const srt = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
+        setSrtPreview(srt)
+      } catch (err) {
+        addToast({
+          type: 'error',
+          title: 'SRT 미리보기 실패',
+          message: err instanceof Error ? err.message : '',
+        })
+        return
+      } finally {
+        setPreviewLoading(false)
+      }
+    }
+    setShowPreview(true)
+  }, [showPreview, srtPreview, projectSeq, spaceSeq, addToast])
 
   const handlePushToYouTube = useCallback(async () => {
-    if (!youtubeVideoId || !sentences) return
-    const srtContent = buildSrt()
-    if (!srtContent) return
+    if (!youtubeVideoId) return
     setPushingToYT(true)
     try {
+      const srtContent = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
       await ytUploadCaption({
         videoId: youtubeVideoId,
         language: toBcp47(langCode),
@@ -288,7 +259,7 @@ export function SubtitleScriptEditor({
       addToast({
         type: 'success',
         title: 'YouTube 자막 적용 완료',
-        message: '기존 자막을 삭제하고 새 SRT를 업로드했습니다.',
+        message: '기존 자막을 삭제하고 Perso 자막을 그대로 업로드했습니다.',
       })
     } catch (err) {
       addToast({
@@ -299,9 +270,7 @@ export function SubtitleScriptEditor({
     } finally {
       setPushingToYT(false)
     }
-  }, [youtubeVideoId, sentences, buildSrt, langCode, lang, addToast])
-
-  const srtPreview = sentences ? buildSrt() : ''
+  }, [youtubeVideoId, projectSeq, spaceSeq, langCode, lang, addToast])
 
   return (
     <div className="rounded-lg border border-surface-200 dark:border-surface-800">
@@ -329,23 +298,29 @@ export function SubtitleScriptEditor({
         <div className="space-y-3 border-t border-surface-200 p-3 dark:border-surface-800">
           <div className="rounded-md bg-blue-50 p-3 text-xs text-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
             <p className="font-medium">편집 가이드</p>
-            <ul className="mt-1 list-disc pl-4 space-y-0.5">
+            <ul className="mt-1 list-disc space-y-0.5 pl-4">
               <li>
-                <strong>번역 텍스트</strong> 수정 후 저장 → Perso 더빙 오디오에 반영(오디오 재생성 필요).
+                <strong>번역 텍스트</strong>를 수정하고 저장하면 Perso 서버에 반영되며,
+                오디오 재생성 후 자막(SRT)도 함께 갱신됩니다.
               </li>
               <li>
-                <strong>시간 변경</strong>은 자막(SRT/YouTube 캡션)에만 적용됩니다.
-                Perso 더빙 오디오 타이밍은 변경되지 않습니다.
+                <strong>SRT/YouTube 자막</strong>은 Perso가 생성한 파일을 그대로 사용합니다
+                (타이밍은 Perso 기준, 클라이언트에서 별도 변환 없음).
               </li>
             </ul>
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" variant="outline" onClick={handleDownloadSRT}>
+            <Button size="sm" variant="outline" onClick={handleDownloadSRT} loading={downloading}>
               <Download className="h-3.5 w-3.5" />
               SRT 다운로드
             </Button>
-            <Button size="sm" variant="ghost" onClick={() => setShowPreview((v) => !v)}>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleTogglePreview}
+              loading={previewLoading}
+            >
               {showPreview ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
               SRT 미리보기
             </Button>

--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -22,9 +22,20 @@ import {
   updateSentenceTranslation,
   ytUploadCaption,
 } from '@/lib/api-client'
+import {
+  buildSRT,
+  msToSRTTime,
+  parseSRT,
+  srtTimeToMs,
+  type SrtCue,
+} from '@/utils/srt'
 import type { ScriptSentence } from '@/lib/perso/types'
 
-function formatMs(ms: number | undefined | null): string {
+// ──────────────────────────────────────────────────────────────────────────
+// 표시용: m:ss 짧은 포맷
+// ──────────────────────────────────────────────────────────────────────────
+
+function formatShortTime(ms: number | undefined | null): string {
   if (ms == null || isNaN(ms)) return '0:00'
   const safe = Math.max(0, Math.floor(ms))
   const m = Math.floor(safe / 60000)
@@ -32,27 +43,31 @@ function formatMs(ms: number | undefined | null): string {
   return `${m}:${String(s).padStart(2, '0')}`
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Section 1: 스크립트 (재더빙용) — 텍스트만 편집, Perso에 저장 + 오디오 재생성
+// ──────────────────────────────────────────────────────────────────────────
+
 interface EditableSentence extends ScriptSentence {
   editedTranslatedText: string
-  /** Perso 서버에 저장된 마지막 번역 텍스트(되돌림 비교용). */
   savedTranslatedText: string
 }
 
-interface RowProps {
+function ScriptRow({
+  sentence,
+  projectSeq,
+  onPatch,
+}: {
   sentence: EditableSentence
   projectSeq: number
   onPatch: (
-    sentenceSeq: number,
+    seq: number,
     patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'savedTranslatedText'>>,
   ) => void
-}
-
-function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
+}) {
   const addToast = useNotificationStore((s) => s.addToast)
   const [saving, setSaving] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
-
-  const textDirty = sentence.editedTranslatedText !== sentence.savedTranslatedText
+  const dirty = sentence.editedTranslatedText !== sentence.savedTranslatedText
 
   const handleSave = useCallback(async () => {
     setSaving(true)
@@ -62,9 +77,7 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
         sentence.sentenceSeq,
         sentence.editedTranslatedText,
       )
-      onPatch(sentence.sentenceSeq, {
-        savedTranslatedText: sentence.editedTranslatedText,
-      })
+      onPatch(sentence.sentenceSeq, { savedTranslatedText: sentence.editedTranslatedText })
       addToast({ type: 'success', title: '저장됨', message: '번역이 Perso에 반영되었습니다.' })
     } catch {
       addToast({ type: 'error', title: '저장 실패' })
@@ -73,28 +86,28 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
     }
   }, [projectSeq, sentence.sentenceSeq, sentence.editedTranslatedText, onPatch, addToast])
 
-  const handleRegenerate = useCallback(async () => {
-    if (textDirty) await handleSave()
+  const handleRegen = useCallback(async () => {
+    if (dirty) await handleSave()
     setRegenerating(true)
     try {
       await regenerateSentenceAudio(projectSeq, sentence.audioSentenceSeq)
       addToast({
         type: 'success',
         title: '재생성 요청됨',
-        message: '오디오가 재생성됩니다. 완료 후 SRT를 다시 다운로드하거나 YouTube에 적용하세요.',
+        message: '오디오가 재생성됩니다. 완료 후 더빙 영상이 갱신됩니다.',
       })
     } catch {
       addToast({ type: 'error', title: '재생성 실패' })
     } finally {
       setRegenerating(false)
     }
-  }, [textDirty, handleSave, projectSeq, sentence.audioSentenceSeq, addToast])
+  }, [dirty, handleSave, projectSeq, sentence.audioSentenceSeq, addToast])
 
   return (
     <div className="space-y-2 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
       <div className="flex items-center gap-2 text-xs text-surface-400">
         <span className="font-mono">
-          {formatMs(sentence.startMs)} → {formatMs(sentence.endMs)}
+          {formatShortTime(sentence.startMs)} → {formatShortTime(sentence.endMs)}
         </span>
         {sentence.speakerLabel && (
           <span className="rounded bg-surface-100 px-1.5 py-0.5 dark:bg-surface-800">
@@ -112,7 +125,7 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
         className="w-full resize-none rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
       />
       <div className="flex justify-end gap-2">
-        {textDirty && (
+        {dirty && (
           <Button size="sm" variant="outline" onClick={handleSave} loading={saving}>
             <Save className="h-3.5 w-3.5" />
             저장
@@ -121,7 +134,7 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
         <Button
           size="sm"
           variant="outline"
-          onClick={handleRegenerate}
+          onClick={handleRegen}
           loading={regenerating}
           disabled={saving}
         >
@@ -132,6 +145,69 @@ function SentenceRow({ sentence, projectSeq, onPatch }: RowProps) {
     </div>
   )
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Section 2: 자막 SRT — Perso의 SRT를 받아 시간/텍스트 편집, 다운로드/YT 적용
+// ──────────────────────────────────────────────────────────────────────────
+
+interface EditableCue extends SrtCue {
+  id: number
+}
+
+function SrtRow({
+  cue,
+  onPatch,
+}: {
+  cue: EditableCue
+  onPatch: (id: number, patch: Partial<SrtCue>) => void
+}) {
+  const [startStr, setStartStr] = useState(msToSRTTime(cue.startMs))
+  const [endStr, setEndStr] = useState(msToSRTTime(cue.endMs))
+
+  const commitStart = useCallback(() => {
+    const ms = srtTimeToMs(startStr)
+    if (ms !== null) onPatch(cue.id, { startMs: ms })
+    else setStartStr(msToSRTTime(cue.startMs))
+  }, [startStr, cue.id, cue.startMs, onPatch])
+
+  const commitEnd = useCallback(() => {
+    const ms = srtTimeToMs(endStr)
+    if (ms !== null) onPatch(cue.id, { endMs: ms })
+    else setEndStr(msToSRTTime(cue.endMs))
+  }, [endStr, cue.id, cue.endMs, onPatch])
+
+  return (
+    <div className="space-y-2 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <input
+          type="text"
+          value={startStr}
+          onChange={(e) => setStartStr(e.target.value)}
+          onBlur={commitStart}
+          className="w-32 rounded border border-surface-300 bg-white px-2 py-0.5 font-mono text-xs text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+        />
+        <span className="text-surface-400">&rarr;</span>
+        <input
+          type="text"
+          value={endStr}
+          onChange={(e) => setEndStr(e.target.value)}
+          onBlur={commitEnd}
+          className="w-32 rounded border border-surface-300 bg-white px-2 py-0.5 font-mono text-xs text-surface-700 focus:border-brand-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+        />
+      </div>
+      <textarea
+        value={cue.text}
+        onChange={(e) => onPatch(cue.id, { text: e.target.value })}
+        rows={2}
+        className="w-full resize-none rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+      />
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 메인 컴포넌트
+// ──────────────────────────────────────────────────────────────────────────
 
 interface SubtitleScriptEditorProps {
   langCode: string
@@ -148,24 +224,23 @@ export function SubtitleScriptEditor({
   youtubeVideoId,
 }: SubtitleScriptEditorProps) {
   const addToast = useNotificationStore((s) => s.addToast)
+  const lang = getLanguageByCode(langCode)
   const [open, setOpen] = useState(false)
-  const [loading, setLoading] = useState(false)
+
+  // Script section
   const [sentences, setSentences] = useState<EditableSentence[] | null>(null)
+  const [scriptLoading, setScriptLoading] = useState(false)
+
+  // SRT section
+  const [cues, setCues] = useState<EditableCue[] | null>(null)
+  const [srtLoading, setSrtLoading] = useState(false)
   const [showPreview, setShowPreview] = useState(false)
-  const [srtPreview, setSrtPreview] = useState<string>('')
-  const [previewLoading, setPreviewLoading] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [pushingToYT, setPushingToYT] = useState(false)
-
-  const lang = getLanguageByCode(langCode)
+  const [resetting, setResetting] = useState(false)
 
   const loadScript = useCallback(async () => {
-    if (sentences) {
-      setOpen((v) => !v)
-      return
-    }
-    setLoading(true)
-    setOpen(true)
+    setScriptLoading(true)
     try {
       const data = await getProjectScript(projectSeq, spaceSeq)
       const list: ScriptSentence[] = Array.isArray(data) ? data : []
@@ -178,28 +253,74 @@ export function SubtitleScriptEditor({
       )
     } catch {
       addToast({ type: 'error', title: '스크립트 로드 실패' })
-      setOpen(false)
     } finally {
-      setLoading(false)
+      setScriptLoading(false)
     }
-  }, [sentences, projectSeq, spaceSeq, addToast])
+  }, [projectSeq, spaceSeq, addToast])
 
-  const handlePatch = useCallback(
+  const loadSrt = useCallback(async () => {
+    setSrtLoading(true)
+    try {
+      const text = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
+      const parsed = parseSRT(text)
+      setCues(parsed.map((c, i) => ({ ...c, id: i })))
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: '자막(SRT) 로드 실패',
+        message: err instanceof Error ? err.message : '',
+      })
+    } finally {
+      setSrtLoading(false)
+    }
+  }, [projectSeq, spaceSeq, addToast])
+
+  const handleToggle = useCallback(() => {
+    if (open) {
+      setOpen(false)
+      return
+    }
+    setOpen(true)
+    if (!sentences) loadScript()
+    if (!cues) loadSrt()
+  }, [open, sentences, cues, loadScript, loadSrt])
+
+  const patchSentence = useCallback(
     (
-      sentenceSeq: number,
+      seq: number,
       patch: Partial<Pick<EditableSentence, 'editedTranslatedText' | 'savedTranslatedText'>>,
     ) => {
       setSentences((prev) =>
-        prev?.map((s) => (s.sentenceSeq === sentenceSeq ? { ...s, ...patch } : s)) ?? null,
+        prev?.map((s) => (s.sentenceSeq === seq ? { ...s, ...patch } : s)) ?? null,
       )
     },
     [],
   )
 
-  const handleDownloadSRT = useCallback(async () => {
+  const patchCue = useCallback((id: number, patch: Partial<SrtCue>) => {
+    setCues((prev) => prev?.map((c) => (c.id === id ? { ...c, ...patch } : c)) ?? null)
+  }, [])
+
+  const handleResetSrt = useCallback(async () => {
+    setResetting(true)
+    try {
+      await loadSrt()
+      addToast({ type: 'success', title: '자막을 Perso 원본으로 되돌렸습니다.' })
+    } finally {
+      setResetting(false)
+    }
+  }, [loadSrt, addToast])
+
+  const buildCurrentSrt = useCallback((): string => {
+    if (!cues) return ''
+    return buildSRT(cues)
+  }, [cues])
+
+  const handleDownload = useCallback(() => {
+    const srt = buildCurrentSrt()
+    if (!srt) return
     setDownloading(true)
     try {
-      const srt = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
       const blob = new Blob([srt], { type: 'application/x-subrip;charset=utf-8' })
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
@@ -209,57 +330,28 @@ export function SubtitleScriptEditor({
       a.click()
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
-    } catch (err) {
-      addToast({
-        type: 'error',
-        title: 'SRT 다운로드 실패',
-        message: err instanceof Error ? err.message : '',
-      })
     } finally {
       setDownloading(false)
     }
-  }, [projectSeq, spaceSeq, lang, langCode, addToast])
-
-  const handleTogglePreview = useCallback(async () => {
-    if (showPreview) {
-      setShowPreview(false)
-      return
-    }
-    if (!srtPreview) {
-      setPreviewLoading(true)
-      try {
-        const srt = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
-        setSrtPreview(srt)
-      } catch (err) {
-        addToast({
-          type: 'error',
-          title: 'SRT 미리보기 실패',
-          message: err instanceof Error ? err.message : '',
-        })
-        return
-      } finally {
-        setPreviewLoading(false)
-      }
-    }
-    setShowPreview(true)
-  }, [showPreview, srtPreview, projectSeq, spaceSeq, addToast])
+  }, [buildCurrentSrt, lang, langCode])
 
   const handlePushToYouTube = useCallback(async () => {
     if (!youtubeVideoId) return
+    const srt = buildCurrentSrt()
+    if (!srt) return
     setPushingToYT(true)
     try {
-      const srtContent = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
       await ytUploadCaption({
         videoId: youtubeVideoId,
         language: toBcp47(langCode),
         name: lang?.name || langCode,
-        srtContent,
+        srtContent: srt,
         replace: true,
       })
       addToast({
         type: 'success',
         title: 'YouTube 자막 적용 완료',
-        message: '기존 자막을 삭제하고 Perso 자막을 그대로 업로드했습니다.',
+        message: '기존 자막을 삭제하고 편집한 SRT를 업로드했습니다.',
       })
     } catch (err) {
       addToast({
@@ -270,13 +362,15 @@ export function SubtitleScriptEditor({
     } finally {
       setPushingToYT(false)
     }
-  }, [youtubeVideoId, projectSeq, spaceSeq, langCode, lang, addToast])
+  }, [youtubeVideoId, buildCurrentSrt, langCode, lang, addToast])
+
+  const srtPreview = cues ? buildCurrentSrt() : ''
 
   return (
     <div className="rounded-lg border border-surface-200 dark:border-surface-800">
       <button
         type="button"
-        onClick={loadScript}
+        onClick={handleToggle}
         className="flex w-full cursor-pointer items-center justify-between rounded-lg p-3 text-left transition-colors hover:bg-surface-50 dark:hover:bg-surface-800/50"
       >
         <div className="flex items-center gap-2">
@@ -285,7 +379,7 @@ export function SubtitleScriptEditor({
             {lang?.name} 자막 · 스크립트
           </span>
         </div>
-        {loading ? (
+        {scriptLoading || srtLoading ? (
           <Loader2 className="h-4 w-4 animate-spin text-surface-400" />
         ) : open ? (
           <ChevronUp className="h-4 w-4 text-surface-400" />
@@ -294,78 +388,118 @@ export function SubtitleScriptEditor({
         )}
       </button>
 
-      {open && sentences && (
-        <div className="space-y-3 border-t border-surface-200 p-3 dark:border-surface-800">
-          <div className="rounded-md bg-blue-50 p-3 text-xs text-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
-            <p className="font-medium">편집 가이드</p>
-            <ul className="mt-1 list-disc space-y-0.5 pl-4">
-              <li>
-                <strong>번역 텍스트</strong>를 수정하고 저장하면 Perso 서버에 반영되며,
-                오디오 재생성 후 자막(SRT)도 함께 갱신됩니다.
-              </li>
-              <li>
-                <strong>SRT/YouTube 자막</strong>은 Perso가 생성한 파일을 그대로 사용합니다
-                (타이밍은 Perso 기준, 클라이언트에서 별도 변환 없음).
-              </li>
-            </ul>
-          </div>
+      {open && (
+        <div className="space-y-6 border-t border-surface-200 p-3 dark:border-surface-800">
+          {/* ─── Script section (re-dub only) ─── */}
+          <section className="space-y-3">
+            <div>
+              <h4 className="text-sm font-semibold text-surface-900 dark:text-white">
+                📝 스크립트 (재더빙용)
+              </h4>
+              <p className="mt-1 text-xs text-surface-500 dark:text-surface-400">
+                번역 텍스트를 수정하고 &ldquo;오디오 재생성&rdquo;을 누르면 Perso가 더빙 오디오를
+                다시 만듭니다. 시간은 Perso가 결정하므로 여기서는 변경할 수 없습니다.
+              </p>
+            </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" variant="outline" onClick={handleDownloadSRT} loading={downloading}>
-              <Download className="h-3.5 w-3.5" />
-              SRT 다운로드
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={handleTogglePreview}
-              loading={previewLoading}
-            >
-              {showPreview ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-              SRT 미리보기
-            </Button>
-            {youtubeVideoId && (
-              <Button
-                size="sm"
-                variant="primary"
-                onClick={handlePushToYouTube}
-                loading={pushingToYT}
-              >
-                <UploadCloud className="h-3.5 w-3.5" />
-                YouTube에 자막 적용
-              </Button>
+            {scriptLoading && (
+              <div className="flex items-center gap-2 py-4 text-sm text-surface-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                스크립트를 불러오는 중...
+              </div>
             )}
-          </div>
-          {!youtubeVideoId && (
-            <p className="text-xs text-surface-400">
-              이 언어의 영상이 YouTube에 업로드된 뒤 &ldquo;YouTube에 자막 적용&rdquo; 버튼이 활성화됩니다.
-            </p>
-          )}
 
-          {showPreview && (
-            <textarea
-              readOnly
-              value={srtPreview}
-              rows={12}
-              className="w-full resize-y rounded-md border border-surface-300 bg-surface-50 px-3 py-2 font-mono text-xs text-surface-700 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
-            />
-          )}
+            {!scriptLoading && sentences && sentences.length === 0 && (
+              <p className="py-2 text-xs text-surface-500">표시할 문장이 없습니다.</p>
+            )}
 
-          <div className="max-h-[28rem] space-y-2 overflow-y-auto">
-            {sentences.length === 0 && (
-              <p className="py-4 text-center text-sm text-surface-500">
-                표시할 문장이 없습니다.
+            {!scriptLoading && sentences && sentences.length > 0 && (
+              <div className="max-h-[24rem] space-y-2 overflow-y-auto">
+                {sentences.map((s) => (
+                  <ScriptRow
+                    key={s.sentenceSeq}
+                    sentence={s}
+                    projectSeq={projectSeq}
+                    onPatch={patchSentence}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* ─── SRT section (caption file edit) ─── */}
+          <section className="space-y-3 border-t border-surface-200 pt-6 dark:border-surface-800">
+            <div>
+              <h4 className="text-sm font-semibold text-surface-900 dark:text-white">
+                🎬 자막 SRT 편집
+              </h4>
+              <p className="mt-1 text-xs text-surface-500 dark:text-surface-400">
+                Perso가 생성한 SRT 파일을 그대로 불러와 편집할 수 있습니다.
+                여기서의 변경은 SRT 다운로드와 YouTube 자막 트랙에만 반영되며,
+                Perso 더빙 오디오에는 영향을 주지 않습니다.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button size="sm" variant="outline" onClick={handleDownload} loading={downloading} disabled={!cues}>
+                <Download className="h-3.5 w-3.5" />
+                SRT 다운로드
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setShowPreview((v) => !v)} disabled={!cues}>
+                {showPreview ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                SRT 미리보기
+              </Button>
+              <Button size="sm" variant="ghost" onClick={handleResetSrt} loading={resetting} disabled={!cues}>
+                <RotateCcw className="h-3.5 w-3.5" />
+                Perso 원본으로 되돌리기
+              </Button>
+              {youtubeVideoId && (
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={handlePushToYouTube}
+                  loading={pushingToYT}
+                  disabled={!cues}
+                >
+                  <UploadCloud className="h-3.5 w-3.5" />
+                  YouTube에 자막 적용
+                </Button>
+              )}
+            </div>
+            {!youtubeVideoId && (
+              <p className="text-xs text-surface-400">
+                이 언어의 영상이 YouTube에 업로드된 뒤 &ldquo;YouTube에 자막 적용&rdquo; 버튼이 활성화됩니다.
               </p>
             )}
-            {sentences.map((s) => (
-              <SentenceRow
-                key={s.sentenceSeq}
-                sentence={s}
-                projectSeq={projectSeq}
-                onPatch={handlePatch}
+
+            {showPreview && (
+              <textarea
+                readOnly
+                value={srtPreview}
+                rows={12}
+                className="w-full resize-y rounded-md border border-surface-300 bg-surface-50 px-3 py-2 font-mono text-xs text-surface-700 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
               />
-            ))}
-          </div>
+            )}
+
+            {srtLoading && (
+              <div className="flex items-center gap-2 py-4 text-sm text-surface-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                SRT를 불러오는 중...
+              </div>
+            )}
+
+            {!srtLoading && cues && cues.length === 0 && (
+              <p className="py-2 text-xs text-surface-500">자막 파일이 비어 있습니다.</p>
+            )}
+
+            {!srtLoading && cues && cues.length > 0 && (
+              <div className="max-h-[28rem] space-y-2 overflow-y-auto">
+                {cues.map((c) => (
+                  <SrtRow key={c.id} cue={c} onPatch={patchCue} />
+                ))}
+              </div>
+            )}
+          </section>
         </div>
       )}
     </div>

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -10,10 +10,14 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { usePersoFlow } from '../../hooks/usePersoFlow'
 import { useAuthStore } from '@/stores/authStore'
-import { ytUploadVideo, ytUploadCaption, getPersoFileUrl, getProjectScript } from '@/lib/api-client'
+import {
+  ytUploadVideo,
+  ytUploadCaption,
+  getPersoFileUrl,
+  getTranslatedSrt,
+} from '@/lib/api-client'
 import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
-import { toSRT } from '@/utils/srt'
 import { SubtitleScriptEditor } from '../SubtitleScriptEditor'
 import { YouTubeExtensionUpload } from '../YouTubeExtensionUpload'
 
@@ -156,10 +160,8 @@ export function UploadStep() {
       if (type === 'translatedSubtitle') {
         const pSeq = projectMap[langCode]
         if (!pSeq || !spaceSeq) return
-        const data = await getProjectScript(pSeq, spaceSeq)
-        const list = Array.isArray(data) ? data : []
-        const srtContent = toSRT(list)
-        const blob = new Blob([srtContent], { type: 'text/plain;charset=utf-8' })
+        const srtContent = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+        const blob = new Blob([srtContent], { type: 'application/x-subrip;charset=utf-8' })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
@@ -232,15 +234,13 @@ export function UploadStep() {
       })
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 90 } }))
 
-      // Upload SRT caption from Script API
+      // Upload SRT caption — use Perso's official translated SRT (audioScript target)
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 92 } }))
       try {
         const pSeq = projectMap[langCode]
         if (pSeq && spaceSeq) {
-          const scriptData = await getProjectScript(pSeq, spaceSeq)
-          const scriptList = Array.isArray(scriptData) ? scriptData : []
-          if (scriptList.length > 0) {
-            const srtText = toSRT(scriptList)
+          const srtText = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+          if (srtText.trim().length > 0) {
             await ytUploadCaption({
               videoId: result.videoId,
               language: toBcp47(langCode),
@@ -391,13 +391,11 @@ export function UploadStep() {
 
       setCaptionUploads((prev) => ({ ...prev, [langCode]: 'uploading' }))
       try {
-        const data = await getProjectScript(pSeq, spaceSeq)
-        const list = Array.isArray(data) ? data : []
-        if (list.length === 0) {
+        const srtContent = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+        if (srtContent.trim().length === 0) {
           setCaptionUploads((prev) => ({ ...prev, [langCode]: 'error' }))
           continue
         }
-        const srtContent = toSRT(list)
         await ytUploadCaption({
           videoId: targetVideoId,
           language: toBcp47(langCode),

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -135,7 +135,8 @@ async function pollLanguage(
       const downloads = await getDownloadLinks(projectSeq, spaceSeq, 'all')
       // Normalize to absolute URLs — Perso may return relative paths which break
       // server-side fetch in /api/youtube/upload (requires http-prefixed URLs).
-      const toAbs = (u?: string) => (u ? (u.startsWith('http') ? u : getPersoFileUrl(u)) : undefined)
+      const toAbs = (u?: string | null) =>
+        u ? (u.startsWith('http') ? u : getPersoFileUrl(u)) : undefined
       const absVideoUrl = toAbs(downloads.videoFile?.videoDownloadLink)
       const absAudioUrl = toAbs(downloads.audioFile?.voiceAudioDownloadLink)
       const absSrtUrl = toAbs(downloads.srtFile?.translatedSubtitleDownloadLink)

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -18,6 +18,7 @@ export {
   updateSentenceTranslation,
   regenerateSentenceAudio,
   getDownloadLinks,
+  getTranslatedSrt,
   requestLipSync,
   getPersoFileUrl,
 } from './perso'

--- a/src/lib/api-client/perso.ts
+++ b/src/lib/api-client/perso.ts
@@ -211,6 +211,33 @@ export function requestLipSync(projectSeq: number, spaceSeq: number) {
   )
 }
 
+/**
+ * Perso가 생성한 SRT 자막 본문을 텍스트로 받는다.
+ * 서버 라우트(/api/perso/srt)가 audioScript target으로 다운로드 링크를 얻고
+ * perso-storage에서 파일을 받아 그대로 전달한다.
+ */
+export async function getTranslatedSrt(
+  projectSeq: number,
+  spaceSeq: number,
+  kind: 'translated' | 'original' = 'translated',
+): Promise<string> {
+  const res = await fetch(
+    `${PERSO}/srt?projectSeq=${projectSeq}&spaceSeq=${spaceSeq}&kind=${kind}`,
+    { cache: 'no-store' },
+  )
+  if (!res.ok) {
+    let msg = `SRT fetch failed (${res.status})`
+    try {
+      const body = await res.json()
+      if (body?.error?.message) msg = body.error.message
+    } catch {
+      // raw error response
+    }
+    throw new Error(msg)
+  }
+  return res.text()
+}
+
 // ─── Helper: resolve Perso file path to full URL ──────────────
 
 const PERSO_FILE_BASE =

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -108,21 +108,44 @@ export interface ProgressResponse {
 }
 
 export interface DownloadResponse {
-  videoFile?: { videoDownloadLink: string }
-  audioFile?: { voiceAudioDownloadLink: string }
-  srtFile?: {
-    originalSubtitleDownloadLink: string
-    translatedSubtitleDownloadLink: string
+  videoFile?: { videoDownloadLink: string | null }
+  audioFile?: {
+    voiceAudioDownloadLink?: string | null
+    backgroundAudioDownloadLink?: string | null
+    voiceWithBackgroundAudioDownloadLink?: string | null
+    speakerSegmentExcelFilePath?: string | null
+    speakerSegmentWithTranslationExcelFilePath?: string | null
+    /** target=audioScript 응답에 포함되는 타임스탬프 데이터(있을 때만). */
+    scriptTimestampsDownloadLink?: string | null
+    originalSubBackgroundDownloadLink?: string | null
   }
-  zippedFileDownloadLink?: string
+  srtFile?: {
+    originalSubtitleDownloadLink?: string | null
+    translatedSubtitleDownloadLink?: string | null
+    /** target=audioScript 응답에 포함되는 VTT 자막(있을 때만). */
+    originalSubtitleVttDownloadLink?: string | null
+  }
+  zippedFileDownloadLink?: string | null
 }
 
+/**
+ * 다운로드 가능한 산출물 종류.
+ *
+ * 주의: Perso 공식 문서엔 `originalSubtitle` / `translatedSubtitle`이
+ * 정식으로 적혀 있으나 현재 백엔드는 두 값에 대해 500
+ * (Unexpected Download value: ORIGINAL_SUBTITLE / TRANSLATED_SUBTITLE)을
+ * 반환한다. 대신 문서엔 없는 `audioScript` target을 사용하면 응답의
+ * srtFile.translatedSubtitleDownloadLink / originalSubtitleDownloadLink로
+ * 두 SRT 링크를 한 번에 받을 수 있다.
+ */
 export type DownloadTarget =
   | 'video'
   | 'dubbingVideo'
   | 'lipSyncVideo'
   | 'originalSubtitle'
   | 'translatedSubtitle'
+  /** Perso가 생성한 SRT(원본/번역)와 부가 산출물 링크를 묶어 반환한다. */
+  | 'audioScript'
   | 'voiceAudio'
   | 'backgroundAudio'
   | 'all'

--- a/src/lib/validators/perso.ts
+++ b/src/lib/validators/perso.ts
@@ -51,6 +51,7 @@ export const downloadTargetSchema = z.enum([
   'lipSyncVideo',
   'originalSubtitle',
   'translatedSubtitle',
+  'audioScript',
   'voiceAudio',
   'backgroundAudio',
   'all',

--- a/src/utils/srt.ts
+++ b/src/utils/srt.ts
@@ -1,15 +1,61 @@
-export function toSRT(sentences: { startMs: number; endMs: number; translatedText: string }[]): string {
-  return sentences.map((s, i) => {
-    const start = msToSRTTime(s.startMs)
-    const end = msToSRTTime(s.endMs)
-    return `${i + 1}\n${start} --> ${end}\n${s.translatedText}\n`
-  }).join('\n')
+export interface SrtCue {
+  startMs: number
+  endMs: number
+  text: string
 }
 
-function msToSRTTime(ms: number): string {
-  const h = Math.floor(ms / 3600000)
-  const m = Math.floor((ms % 3600000) / 60000)
-  const s = Math.floor((ms % 60000) / 1000)
-  const ms2 = ms % 1000
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(ms2).padStart(3, '0')}`
+export function msToSRTTime(ms: number): string {
+  const safe = Math.max(0, Math.floor(ms))
+  const h = Math.floor(safe / 3600000)
+  const m = Math.floor((safe % 3600000) / 60000)
+  const s = Math.floor((safe % 60000) / 1000)
+  const r = safe % 1000
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(r).padStart(3, '0')}`
+}
+
+export function srtTimeToMs(timeStr: string): number | null {
+  const m = timeStr.trim().match(/^(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})$/)
+  if (!m) return null
+  return Number(m[1]) * 3600000 + Number(m[2]) * 60000 + Number(m[3]) * 1000 + Number(m[4].padEnd(3, '0'))
+}
+
+/** 표준 SRT 텍스트를 cue 배열로 파싱한다. 잘못된 블록은 건너뛴다. */
+export function parseSRT(text: string): SrtCue[] {
+  if (!text) return []
+  const blocks = text.replace(/\r\n/g, '\n').replace(/^﻿/, '').trim().split(/\n\s*\n/)
+  const cues: SrtCue[] = []
+  for (const block of blocks) {
+    const lines = block.split('\n')
+    if (lines.length < 2) continue
+    // 1번 줄이 인덱스가 아닐 수도 있어 timing 라인을 직접 찾는다
+    let timingIdx = lines[0].includes('-->') ? 0 : 1
+    if (timingIdx >= lines.length) continue
+    const timing = lines[timingIdx].match(
+      /(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})\s*-->\s*(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})/,
+    )
+    if (!timing) continue
+    const startMs = srtTimeToMs(timing[1])
+    const endMs = srtTimeToMs(timing[2])
+    if (startMs === null || endMs === null) continue
+    const textLines = lines.slice(timingIdx + 1).join('\n').trim()
+    if (!textLines) continue
+    cues.push({ startMs, endMs, text: textLines })
+  }
+  return cues
+}
+
+/** cue 배열을 표준 SRT 문자열로 직렬화한다. */
+export function buildSRT(cues: SrtCue[]): string {
+  return cues
+    .map((c, i) => `${i + 1}\n${msToSRTTime(c.startMs)} --> ${msToSRTTime(c.endMs)}\n${c.text}`)
+    .join('\n\n')
+}
+
+/** 호환성: 기존 호출자(`{ startMs, endMs, translatedText }[]` 형태)용 어댑터. */
+export function toSRT(
+  sentences: { startMs: number; endMs: number; translatedText: string }[],
+): string {
+  return buildSRT(
+    sentences.map((s) => ({ startMs: s.startMs, endMs: s.endMs, text: s.translatedText })),
+  )
 }


### PR DESCRIPTION
## Summary

develop 브랜치에 누적된 40+ 커밋을 main으로 머지합니다. 주요 변경 영역:

### 🎨 리브랜딩
- creatordub → **dubtube** 전체 리네이밍 (#170, #171)

### 🎬 더빙·자막 워크플로
- 자막·스크립트 통합 편집기 추가 + YouTube 자막 트랙 교체 지원 (#177)
- 스크립트(재더빙)와 SRT 편집을 두 sub-section으로 분리 (#184)
- Perso 공식 SRT 통일 (클라이언트 변환 제거) (#183)
- 결과물 모드 통합 리팩터 + 백그라운드 업로드 큐
- Script API 기반 SRT 생성 + 자막 편집기
- 자막(SRT) 자동 업로드 + 수동 업로드 버튼
- 오디오 트랙 업로드 토글 (기본 OFF) + 확장 기본 모드 auto
- 원본 언어 자동 감지 + 화자 수 1~10 (#175)

### 📺 YouTube 연동
- OAuth 액세스 토큰 자동 갱신 + 401 재시도 (#179)
- 기본 공개 설정을 더빙 위저드와 동기화 (#176)
- analytics_cache 테이블 lazy bootstrap (SQLITE_UNKNOWN 500 해결) (#186)
- stats 라우트 withTokenRetry 타입 추론 오류 수정 (#181)

### 🛡️ 보안·안정성
- SSRF 취약점 수정 — HTTP 자기호출을 직접 함수 호출로 전환 (#166)
- Vercel cron 제거 → 클라이언트 트리거 방식 전환
- 배치 큐 삭제 시 Perso cancel 병렬 호출 (#178)

### 📄 법적 문서·랜딩
- OAuth 검증용 개인정보처리방침·서비스 약관 페이지 추가
- 랜딩 카피·UI 정리 + Google 공식 로그인 버튼 (#174)

### 📈 대시보드
- Recharts ResponsiveContainer width(-1)/height(-1) 경고 제거 (#185)

### 📦 의존성
- npm-minor-and-patch group 자동 업데이트 (#162, #169, #173)

## Test plan
- [ ] 더빙 위저드 전체 플로우 (영상 입력 → 언어 선택 → 번역 편집 → 자막/스크립트 편집 → 업로드)
- [ ] YouTube OAuth 로그인·토큰 만료 후 자동 갱신
- [ ] 자막 트랙 자동 업로드 + 수동 업로드
- [ ] 배치 페이지 큐 삭제 (Perso cancel 호출 확인)
- [ ] 대시보드 차트 렌더링 (ResponsiveContainer 경고 없음)
- [ ] /privacy, /terms 페이지 접근
- [ ] 랜딩 페이지 Google 로그인 버튼

🤖 Generated with [Claude Code](https://claude.com/claude-code)