### PR TITLE
fix(dubbing): 15분 자동 취소 타이머 제거 — 다국어 자막 업로드 fail 원인

### DIFF
--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -24,7 +24,6 @@ const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
 const POLL_BACKOFF = 1.5          // 매 폴링마다 1.5배씩 증가
 const POLL_FINALIZING = 2_000     // 100%인데 COMPLETED 아직 안 온 경우 빠르게 재확인
-const AUTO_CANCEL_TIMEOUT = 15 * 60_000 // 15분 경과 시 자동 취소
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -236,7 +235,6 @@ async function cancelAllProjects(
 export function usePersoFlow() {
   const addToast = useNotificationStore((s) => s.addToast)
   const pollTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
-  const timeoutTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const initSpace = useCallback(async () => {
     try {
@@ -404,13 +402,6 @@ export function usePersoFlow() {
 
     Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
-    if (timeoutTimer.current) clearTimeout(timeoutTimer.current)
-
-    timeoutTimer.current = setTimeout(() => {
-      Object.values(pollTimers.current).forEach(clearTimeout)
-      pollTimers.current = {}
-      cancelAllProjects(addToast, '15분 초과 — 자동 취소됨')
-    }, AUTO_CANCEL_TIMEOUT)
 
     function scheduleNext(langCode: string, projectSeq: number, interval: number) {
       pollTimers.current[langCode] = setTimeout(async () => {
@@ -436,10 +427,6 @@ export function usePersoFlow() {
   const stopPolling = useCallback(() => {
     Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
-    if (timeoutTimer.current) {
-      clearTimeout(timeoutTimer.current)
-      timeoutTimer.current = null
-    }
   }, [])
 
   const cancelAll = useCallback(async () => {


### PR DESCRIPTION
## Summary

다국어 동시 더빙 시 폴링·후속 업로드(자막 업로드 등)가 누적돼 15분을 넘기면 `AUTO_CANCEL_TIMEOUT`이 발동해 active 프로젝트에 cancel API가 호출됐고, 더빙은 성공했음에도 자막 업로드가 fail로 처리되던 문제를 수정.

## Changes

- `AUTO_CANCEL_TIMEOUT` 상수 제거
- `timeoutTimer` ref 제거
- `startPolling`의 자동 취소 `setTimeout` 블록 제거
- `stopPolling`의 timeoutTimer 정리 코드 제거
- 이제 사용자가 직접 `cancelAll` 버튼을 누른 경우에만 cancel 호출됨

## Test plan
- [ ] 여러 언어(예: 5개+)를 선택해 더빙 시도
- [ ] 더빙 시간이 길어져도 자동 취소되지 않음 확인
- [ ] 자막 자동 업로드 정상 완료 확인
- [ ] 사용자가 Cancel 버튼을 누르면 정상 취소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)