### PR TITLE
feat(dubbing): 위자드 UX 개편 — 다국어 확장, 영상 선택/단계 흐름, 립싱크 컨텍스트

### DIFF
--- a/src/features/dubbing/components/DubbingWizard.tsx
+++ b/src/features/dubbing/components/DubbingWizard.tsx
@@ -13,8 +13,8 @@ import { UploadStep } from './steps/UploadStep'
 
 const steps = [
   { num: 1, label: '영상' },
-  { num: 2, label: '언어' },
-  { num: 3, label: '결과물' },
+  { num: 2, label: '결과물' },
+  { num: 3, label: '언어' },
   { num: 4, label: '업로드 설정' },
   { num: 5, label: '확인' },
   { num: 6, label: '처리' },
@@ -71,8 +71,8 @@ export function DubbingWizard() {
       {/* Step content */}
       <div className="animate-fade-in">
         {currentStep === 1 && <VideoInputStep />}
-        {currentStep === 2 && <LanguageSelectStep />}
-        {currentStep === 3 && <OutputModeStep />}
+        {currentStep === 2 && <OutputModeStep />}
+        {currentStep === 3 && <LanguageSelectStep />}
         {currentStep === 4 && <UploadSettingsStep />}
         {currentStep === 5 && <TranslationEditStep />}
         {currentStep === 6 && <ProcessingStep />}

--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -1,22 +1,61 @@
 'use client'
 
-import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, ArrowRight, Check, Search, X } from 'lucide-react'
 import { Button, Card, Toggle, Tooltip } from '@/components/ui'
 import { cn } from '@/utils/cn'
-import { SUPPORTED_LANGUAGES } from '@/utils/languages'
+import {
+  REGION_LABELS,
+  SUPPORTED_LANGUAGES,
+  getLanguageByCode,
+  type LanguageRegion,
+} from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
+
+type RegionFilter = 'all' | LanguageRegion
+
+const REGION_TABS: { id: RegionFilter; label: string }[] = [
+  { id: 'all', label: '전체' },
+  { id: 'popular', label: REGION_LABELS.popular },
+  { id: 'asia', label: REGION_LABELS.asia },
+  { id: 'europe', label: REGION_LABELS.europe },
+  { id: 'middle-east', label: REGION_LABELS['middle-east'] },
+]
 
 export function LanguageSelectStep() {
   const {
-    sourceLanguage,
-    setSourceLanguage,
     selectedLanguages,
     toggleLanguage,
     lipSyncEnabled,
     setLipSync,
+    deliverableMode,
     prevStep,
     nextStep,
   } = useDubbingStore()
+
+  const [region, setRegion] = useState<RegionFilter>('popular')
+  const [query, setQuery] = useState('')
+
+  // 원본 영상에 자막/오디오 트랙만 추가하는 모드는 비디오 픽셀을 건드리지 않으므로
+  // 립싱크가 적용될 곳이 없다. 스텝을 오가며 stale 상태가 남는 것을 막기 위해 강제 reset.
+  const lipSyncApplicable = deliverableMode !== 'originalWithMultiAudio'
+  useEffect(() => {
+    if (!lipSyncApplicable && lipSyncEnabled) setLipSync(false)
+  }, [lipSyncApplicable, lipSyncEnabled, setLipSync])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return SUPPORTED_LANGUAGES.filter((l) => {
+      if (q) {
+        return (
+          l.code.toLowerCase().includes(q) ||
+          l.name.toLowerCase().includes(q) ||
+          l.nativeName.toLowerCase().includes(q)
+        )
+      }
+      return region === 'all' ? true : l.region === region
+    })
+  }, [region, query])
 
   const estimatedCredits = selectedLanguages.length * 15 + (lipSyncEnabled ? selectedLanguages.length * 8 : 0)
 
@@ -25,77 +64,125 @@ export function LanguageSelectStep() {
       <div className="text-center">
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">대상 언어 선택</h2>
         <p className="mt-1 text-surface-500">
-          더빙할 언어를 최대 10개까지 선택하세요 ({selectedLanguages.length}/10 선택됨)
+          더빙할 언어를 선택하세요 ({selectedLanguages.length}개 선택됨)
         </p>
       </div>
 
-      {/* Source language selector */}
-      <Card>
-        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
-          원본 영상 언어
-        </label>
-        <select
-          value={sourceLanguage}
-          onChange={(e) => setSourceLanguage(e.target.value)}
-          className="w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
-        >
-          <option value="auto">🌐 자동 감지 (권장)</option>
-          {SUPPORTED_LANGUAGES.map((lang) => (
-            <option key={lang.code} value={lang.code}>
-              {lang.flag} {lang.name} ({lang.nativeName})
-            </option>
-          ))}
-        </select>
-        <p className="mt-2 text-xs text-surface-500">
-          자동 감지를 사용하면 Perso AI가 영상 음성에서 언어를 자동으로 판별합니다.
-          정확한 언어를 알고 있다면 직접 선택하는 편이 안정적입니다.
-        </p>
-      </Card>
+      {/* Selected chips */}
+      {selectedLanguages.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedLanguages.map((code) => {
+            const lang = getLanguageByCode(code)
+            if (!lang) return null
+            return (
+              <button
+                key={code}
+                onClick={() => toggleLanguage(code)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-brand-500 bg-brand-50 px-3 py-1 text-sm font-medium text-brand-700 transition hover:bg-brand-100 dark:bg-brand-900/30 dark:text-brand-200 dark:hover:bg-brand-900/50"
+              >
+                <span>{lang.flag}</span>
+                <span>{lang.name}</span>
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )
+          })}
+        </div>
+      )}
 
-      {/* Language grid — exclude the current source language */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
-        {SUPPORTED_LANGUAGES.filter((l) => l.code !== sourceLanguage).map((lang) => {
-          const isSelected = selectedLanguages.includes(lang.code)
-          return (
+      {/* Search + region tabs */}
+      <div className="space-y-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="언어 검색 (예: Korean, 한국어, ko)"
+            className="w-full rounded-md border border-surface-300 bg-white py-2 pl-9 pr-9 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+          />
+          {query && (
             <button
-              key={lang.code}
-              onClick={() => toggleLanguage(lang.code)}
-              className={cn(
-                'relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-all cursor-pointer',
-                isSelected
-                  ? 'border-brand-500 bg-brand-50 shadow-md shadow-brand-500/10 dark:bg-brand-900/20'
-                  : 'border-surface-200 bg-white hover:border-surface-300 dark:border-surface-800 dark:bg-surface-900 dark:hover:border-surface-700',
-              )}
+              onClick={() => setQuery('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-400 hover:text-surface-600"
             >
-              {isSelected && (
-                <div className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-white">
-                  <Check className="h-3 w-3" />
-                </div>
-              )}
-              <span className="text-2xl">{lang.flag}</span>
-              <span className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</span>
-              <span className="text-xs text-surface-400">{lang.nativeName}</span>
+              <X className="h-4 w-4" />
             </button>
-          )
-        })}
-      </div>
-
-      {/* Options */}
-      <Card>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-surface-900 dark:text-white">립싱크</span>
-              <Tooltip content="AI가 더빙 오디오에 맞춰 입 모양을 조절합니다. 실사 영상에 최적화.">
-                <span className="cursor-help text-xs text-surface-400">(?)</span>
-              </Tooltip>
-            </div>
-            <p className="text-xs text-surface-500 mt-0.5">언어당 크레딧 50% 추가</p>
-          </div>
-          <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
+          )}
         </div>
 
-        <div className="mt-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+        {!query && (
+          <div className="flex flex-wrap gap-2">
+            {REGION_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setRegion(tab.id)}
+                className={cn(
+                  'rounded-full px-3 py-1 text-sm font-medium transition',
+                  region === tab.id
+                    ? 'bg-brand-500 text-white'
+                    : 'bg-surface-100 text-surface-700 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700',
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Language grid */}
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-sm text-surface-500">
+          검색 결과가 없습니다
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+          {filtered.map((lang) => {
+            const isSelected = selectedLanguages.includes(lang.code)
+            return (
+              <button
+                key={lang.code}
+                onClick={() => toggleLanguage(lang.code)}
+                className={cn(
+                  'relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-all cursor-pointer',
+                  isSelected
+                    ? 'border-brand-500 bg-brand-50 shadow-md shadow-brand-500/10 dark:bg-brand-900/20'
+                    : 'border-surface-200 bg-white hover:border-surface-300 dark:border-surface-800 dark:bg-surface-900 dark:hover:border-surface-700',
+                )}
+              >
+                {isSelected && (
+                  <div className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-white">
+                    <Check className="h-3 w-3" />
+                  </div>
+                )}
+                <span className="text-2xl">{lang.flag}</span>
+                <span className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</span>
+                <span className="text-xs text-surface-400">{lang.nativeName}</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Dub options */}
+      <Card>
+        <p className="mb-3 text-sm font-semibold text-surface-900 dark:text-white">더빙 옵션</p>
+        {lipSyncApplicable && (
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-surface-900 dark:text-white">립싱크</span>
+                <Tooltip content="AI가 더빙 오디오에 맞춰 입 모양을 조절합니다. 실사 영상에 최적화.">
+                  <span className="cursor-help text-xs text-surface-400">(?)</span>
+                </Tooltip>
+              </div>
+              <p className="text-xs text-surface-500 mt-0.5">언어당 크레딧 50% 추가</p>
+            </div>
+            <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
+          </div>
+        )}
+
+        <div className={cn('rounded-lg bg-surface-50 p-3 dark:bg-surface-800', lipSyncApplicable && 'mt-4')}>
           <div className="flex items-center justify-between text-sm">
             <span className="text-surface-600 dark:text-surface-400">예상 크레딧</span>
             <span className="font-bold text-surface-900 dark:text-white">{estimatedCredits} 크레딧</span>
@@ -109,7 +196,7 @@ export function LanguageSelectStep() {
           이전
         </Button>
         <Button onClick={nextStep} disabled={selectedLanguages.length === 0}>
-          다음: 설정 확인
+          {deliverableMode === 'downloadOnly' ? '다음: 번역 확인' : '다음: 업로드 설정'}
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -29,14 +29,14 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '기존 영상에 자막 추가',
-      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다. 오디오 트랙도 선택 가능합니다.',
+      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다.',
     })
   } else if (sourceType === 'upload') {
     options.push({
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '원본 업로드 + 자막 추가',
-      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다. 오디오 트랙도 선택 가능합니다.',
+      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다.',
     })
   }
 
@@ -128,7 +128,7 @@ export function OutputModeStep() {
           이전
         </Button>
         <Button onClick={nextStep}>
-          {deliverableMode === 'downloadOnly' ? '다음: 설정 확인' : '다음: 업로드 설정'}
+          다음: 언어 선택
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -102,18 +102,20 @@ export function TranslationEditStep() {
               ))}
             </div>
             <p className="mt-2 text-xs text-surface-400">
-              영상에 등장하는 화자 수를 선택하세요. 정확하게 설정하면 Perso AI가 화자별로 음성을 분리해 더빙합니다.
+              영상에 등장하는 화자 수를 선택하세요.
             </p>
           </div>
 
-          {/* Lip sync */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <div>
-              <span className="text-sm text-surface-600 dark:text-surface-400">립싱크</span>
-              <p className="text-xs text-surface-400 mt-0.5">더빙 오디오에 맞춰 입 모양을 조절합니다</p>
+          {/* Lip sync — 원본+자막 모드는 비디오 픽셀을 건드리지 않으므로 미노출 */}
+          {deliverableMode !== 'originalWithMultiAudio' && (
+            <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+              <div>
+                <span className="text-sm text-surface-600 dark:text-surface-400">립싱크</span>
+                <p className="text-xs text-surface-400 mt-0.5">더빙 오디오에 맞춰 입 모양을 조절합니다</p>
+              </div>
+              <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
             </div>
-            <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
-          </div>
+          )}
 
           {/* Deliverable mode */}
           <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
@@ -144,7 +146,9 @@ export function TranslationEditStep() {
         <div>
           <p className="text-sm font-medium text-blue-900 dark:text-blue-300">처리 과정</p>
           <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
-            Perso.ai가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 오디오를 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 보통 3-10분입니다.
+            {deliverableMode === 'originalWithMultiAudio'
+              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
+              : 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 영상을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'}
           </p>
         </div>
       </Card>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo } from 'react'
-import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
 import { getLanguageByCode } from '@/utils/languages'
@@ -91,7 +91,7 @@ export function UploadSettingsStep() {
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">업로드 설정</h2>
         <p className="mt-1 text-surface-500">
           {isMultiAudio
-            ? '원본 영상에 오디오 트랙을 추가합니다. 기본 설정을 확인하세요.'
+            ? '원본 영상에 자막을 추가합니다. 기본 설정을 확인하세요.'
             : '처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요.'}
         </p>
       </div>
@@ -198,7 +198,10 @@ export function UploadSettingsStep() {
             onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
           />
 
-          {deliverableMode === 'newDubbedVideos' && (
+          {/* Shorts 토글: 새로 영상을 YouTube에 올리는 케이스에만 노출.
+              channel 모드는 이미 업로드된 영상이라 Shorts 분류가 고정됨. */}
+          {(deliverableMode === 'newDubbedVideos' ||
+            (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')) && (
             <ToggleRow
               icon={<Zap className="h-4 w-4 text-brand-500" />}
               label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
@@ -219,6 +222,20 @@ export function UploadSettingsStep() {
               activeLabel="첨부 ON"
               inactiveLabel="첨부 OFF"
               onToggle={() => setUploadSettings({ attachOriginalLink: !uploadSettings.attachOriginalLink })}
+            />
+          )}
+
+          {/* 다국어 오디오 트랙: 자막 모드에서만 노출. 실서비스 검증 전이라 비활성. */}
+          {isMultiAudio && (
+            <ToggleRow
+              icon={<Languages className="h-4 w-4 text-surface-400" />}
+              label="다국어 오디오 트랙 추가"
+              description="번역된 더빙 오디오를 YouTube 다국어 오디오 트랙으로 함께 추가합니다. 추후 기능이 추가될 예정입니다."
+              active={false}
+              activeLabel="ON"
+              inactiveLabel="준비 중"
+              onToggle={() => {}}
+              disabled
             />
           )}
         </div>
@@ -263,27 +280,38 @@ interface ToggleRowProps {
   activeLabel: string
   inactiveLabel: string
   onToggle: () => void
+  disabled?: boolean
 }
 
-function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle }: ToggleRowProps) {
+function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle, disabled }: ToggleRowProps) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+    <div className={`flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 ${disabled ? 'opacity-60' : ''}`}>
       <div className="flex min-w-0 items-start gap-2">
         <div className="mt-0.5 flex-shrink-0">{icon}</div>
         <div className="min-w-0">
-          <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+            {disabled && (
+              <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                준비 중
+              </span>
+            )}
+          </div>
           {description && (
-            <p className="mt-0.5 truncate text-xs text-surface-400">{description}</p>
+            <p className={`mt-0.5 text-xs text-surface-400 ${disabled ? '' : 'truncate'}`}>{description}</p>
           )}
         </div>
       </div>
       <button
         type="button"
-        onClick={onToggle}
-        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-          active
-            ? 'bg-brand-500 text-white'
-            : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+        onClick={disabled ? undefined : onToggle}
+        disabled={disabled}
+        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all ${
+          disabled
+            ? 'bg-surface-200 text-surface-400 dark:bg-surface-700 dark:text-surface-500 cursor-not-allowed'
+            : `cursor-pointer ${active
+              ? 'bg-brand-500 text-white'
+              : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'}`
         }`}
       >
         {active ? activeLabel : inactiveLabel}

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
-import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap, Loader2 } from 'lucide-react'
+import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap, Loader2, Search, Lock, Info } from 'lucide-react'
 
 function YouTubeLogo({ className }: { className?: string }) {
   return (
@@ -34,7 +34,19 @@ export function VideoInputStep() {
 
   const { data: channel, isLoading: channelLoading } = useChannelStats()
   const isConnected = !!channel
-  const { data: myVideos = [], isLoading: myVideosLoading } = useMyVideos(10)
+  const { data: myVideos = [], isLoading: myVideosLoading } = useMyVideos(50)
+  const [videoSearch, setVideoSearch] = useState('')
+
+  const publicVideos = useMemo(
+    () => myVideos.filter((v) => v.privacyStatus === 'public'),
+    [myVideos],
+  )
+  const filteredVideos = useMemo(() => {
+    const q = videoSearch.trim().toLowerCase()
+    if (!q) return publicVideos
+    return publicVideos.filter((v) => v.title.toLowerCase().includes(q))
+  }, [publicVideos, videoSearch])
+  const hiddenCount = myVideos.length - publicVideos.length
 
   const handleMyVideoSelect = async (videoId: string) => {
     const videoUrl = `https://www.youtube.com/watch?v=${videoId}`
@@ -110,7 +122,10 @@ export function VideoInputStep() {
         <p className="mt-1 text-surface-500">YouTube URL을 붙여넣거나 영상 파일을 업로드하세요</p>
       </div>
 
-      <Tabs defaultValue={searchParams.get('url') ? 'url' : 'upload'}>
+      <Tabs
+        defaultValue={searchParams.get('url') ? 'url' : 'upload'}
+        onChange={() => setError(null)}
+      >
         <TabsList className="mx-auto w-fit">
           <TabsTrigger value="upload">
             <span className="flex items-center gap-1.5"><Upload className="h-4 w-4" /> 업로드</span>
@@ -125,6 +140,10 @@ export function VideoInputStep() {
 
         <TabsContent value="url" className="mt-6">
           <Card>
+            <div className="mb-3 flex items-start gap-2 rounded-lg bg-blue-50 p-2.5 text-xs text-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+              <Info className="h-4 w-4 shrink-0 mt-0.5" />
+              <p>공개 영상만 가져올 수 있습니다. 비공개·일부공개 영상은 외부 다운로드가 막혀 있어 가져올 수 없으니, YouTube에서 공개로 변경하거나 영상 파일을 직접 업로드해 주세요.</p>
+            </div>
             <div className="flex gap-2">
               <Input
                 placeholder="YouTube URL 또는 영상 직접 링크 (.mp4, .mov, .webm)"
@@ -211,48 +230,78 @@ export function VideoInputStep() {
               <Film className="mx-auto h-10 w-10 text-surface-400" />
               <p className="mt-3 text-sm text-surface-500">채널에 업로드된 영상이 없습니다</p>
             </Card>
+          ) : publicVideos.length === 0 ? (
+            <Card className="py-12 text-center">
+              <Lock className="mx-auto h-10 w-10 text-surface-400" />
+              <p className="mt-3 text-sm text-surface-500">공개된 영상이 없습니다</p>
+              <p className="mt-1 text-xs text-surface-400">
+                비공개·일부공개 영상은 외부 다운로드가 막혀 가져올 수 없습니다.<br />
+                YouTube에서 공개로 변경하거나 영상 파일을 직접 업로드해 주세요.
+              </p>
+            </Card>
           ) : (
             <Card>
-              <div className="space-y-2">
-                {myVideos.map((video) => (
-                  <div
-                    key={video.videoId}
-                    className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
-                  >
-                    <div className="flex items-center gap-3 min-w-0 flex-1">
-                      {video.thumbnail ? (
-                        <Image
-                          src={video.thumbnail}
-                          alt={video.title}
-                          width={64}
-                          height={36}
-                          className="rounded object-cover shrink-0"
-                        />
-                      ) : (
-                        <div className="flex h-9 w-16 shrink-0 items-center justify-center rounded bg-surface-100 dark:bg-surface-800">
-                          <YouTubeLogo className="h-5 w-7" />
-                        </div>
-                      )}
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
-                        <p className="text-xs text-surface-500">
-                          {new Date(video.publishedAt).toLocaleDateString('ko-KR')}
-                        </p>
-                      </div>
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="shrink-0 ml-3"
-                      loading={loading}
-                      disabled={loading}
-                      onClick={() => handleMyVideoSelect(video.videoId)}
-                    >
-                      선택
-                    </Button>
-                  </div>
-                ))}
+              <div className="relative mb-3">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" />
+                <input
+                  type="text"
+                  value={videoSearch}
+                  onChange={(e) => setVideoSearch(e.target.value)}
+                  placeholder="영상 제목으로 검색"
+                  className="w-full rounded-md border border-surface-300 bg-white py-2 pl-9 pr-3 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+                />
               </div>
+
+              <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
+                {filteredVideos.length === 0 ? (
+                  <p className="py-8 text-center text-sm text-surface-500">검색 결과가 없습니다</p>
+                ) : (
+                  filteredVideos.map((video) => (
+                    <div
+                      key={video.videoId}
+                      className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
+                    >
+                      <div className="flex items-center gap-3 min-w-0 flex-1">
+                        {video.thumbnail ? (
+                          <Image
+                            src={video.thumbnail}
+                            alt={video.title}
+                            width={64}
+                            height={36}
+                            className="rounded object-cover shrink-0"
+                          />
+                        ) : (
+                          <div className="flex h-9 w-16 shrink-0 items-center justify-center rounded bg-surface-100 dark:bg-surface-800">
+                            <YouTubeLogo className="h-5 w-7" />
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
+                          <p className="text-xs text-surface-500">
+                            {new Date(video.publishedAt).toLocaleDateString('ko-KR')}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 ml-3"
+                        loading={loading}
+                        disabled={loading}
+                        onClick={() => handleMyVideoSelect(video.videoId)}
+                      >
+                        선택
+                      </Button>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {hiddenCount > 0 && !videoSearch && (
+                <p className="mt-3 text-xs text-surface-400">
+                  비공개·일부공개 영상 {hiddenCount}개는 외부 다운로드가 막혀 표시되지 않습니다.
+                </p>
+              )}
               {error && !loading && (
                 <p className="mt-3 text-sm text-red-500">{error}</p>
               )}

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -135,16 +135,20 @@ describe('fetchChannelStatistics', () => {
 
 describe('fetchMyVideos', () => {
   it('returns mapped video items', async () => {
-    mockFetch.mockResolvedValueOnce(
-      jsonResponse({
-        items: [{
-          id: { videoId: 'v1' },
-          snippet: { title: 'T1', publishedAt: '2026-01-01', thumbnails: { medium: { url: 'http://thumb' } } },
-        }],
-      }),
-    )
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{
+            id: { videoId: 'v1' },
+            snippet: { title: 'T1', publishedAt: '2026-01-01', thumbnails: { medium: { url: 'http://thumb' } } },
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ id: 'v1', status: { privacyStatus: 'public' } }] }),
+      )
     const vids = await fetchMyVideos('tok', 5)
-    expect(vids).toEqual([{ videoId: 'v1', title: 'T1', thumbnail: 'http://thumb', publishedAt: '2026-01-01' }])
+    expect(vids).toEqual([{ videoId: 'v1', title: 'T1', thumbnail: 'http://thumb', publishedAt: '2026-01-01', privacyStatus: 'public' }])
   })
 
   it('returns empty array on non-ok response', async () => {
@@ -157,12 +161,12 @@ describe('fetchMyVideos', () => {
     expect(await fetchMyVideos('tok')).toEqual([])
   })
 
-  it('defaults missing snippet fields to empty strings', async () => {
-    mockFetch.mockResolvedValueOnce(
-      jsonResponse({ items: [{ id: { videoId: 'v1' } }] }),
-    )
+  it('defaults missing snippet fields and unknown privacy', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: { videoId: 'v1' } }] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
     const vids = await fetchMyVideos('tok')
-    expect(vids).toEqual([{ videoId: 'v1', title: '', thumbnail: '', publishedAt: '' }])
+    expect(vids).toEqual([{ videoId: 'v1', title: '', thumbnail: '', publishedAt: '', privacyStatus: 'unknown' }])
   })
 })
 

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -95,10 +95,43 @@ export async function fetchMyVideos(
     }>
   }
 
-  return (data.items || []).map((item) => ({
+  const base = (data.items || []).map((item) => ({
     videoId: item.id.videoId,
     title: item.snippet?.title || '',
     thumbnail: item.snippet?.thumbnails?.medium?.url || '',
     publishedAt: item.snippet?.publishedAt || '',
   }))
+
+  // search.list는 status를 안 돌려주므로 videos.list로 privacyStatus 보강.
+  const privacyById = await fetchPrivacyStatuses(accessToken, base.map((v) => v.videoId))
+
+  return base.map((v) => ({
+    ...v,
+    privacyStatus: privacyById.get(v.videoId) ?? 'unknown',
+  }))
+}
+
+async function fetchPrivacyStatuses(
+  accessToken: string,
+  videoIds: string[],
+): Promise<Map<string, MyVideoItem['privacyStatus']>> {
+  const result = new Map<string, MyVideoItem['privacyStatus']>()
+  if (videoIds.length === 0) return result
+
+  const res = await fetch(
+    `${YOUTUBE_API_BASE}/youtube/v3/videos?part=status&id=${videoIds.join(',')}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) return result
+
+  const data = (await res.json()) as {
+    items?: Array<{ id: string; status?: { privacyStatus?: string } }>
+  }
+  for (const item of data.items || []) {
+    const p = item.status?.privacyStatus
+    if (p === 'public' || p === 'unlisted' || p === 'private') {
+      result.set(item.id, p)
+    }
+  }
+  return result
 }

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -29,6 +29,7 @@ export interface MyVideoItem {
   title: string
   thumbnail: string
   publishedAt: string
+  privacyStatus: 'public' | 'unlisted' | 'private' | 'unknown'
 }
 
 export interface AnalyticsDailyRow {

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -1,23 +1,61 @@
+export type LanguageRegion = 'popular' | 'asia' | 'europe' | 'middle-east'
+
 export interface Language {
   code: string // Perso API language code
   name: string
   nativeName: string
   flag: string
+  region: LanguageRegion
 }
 
-// Perso.ai uses ISO 639-1 codes
+export const REGION_LABELS: Record<LanguageRegion, string> = {
+  popular: '인기',
+  asia: '아시아',
+  europe: '유럽',
+  'middle-east': '중동',
+}
+
+// Perso.ai supported target languages (sourced from /video-translator/api/v1/languages).
+// Codes are mostly ISO 639-1 with a few exceptions (e.g. `fil` for Filipino).
 export const SUPPORTED_LANGUAGES: Language[] = [
-  { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
-  { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', flag: '🇮🇳' },
-  { code: 'pt', name: 'Portuguese (Brazil)', nativeName: 'Português', flag: '🇧🇷' },
-  { code: 'ja', name: 'Japanese', nativeName: '日本語', flag: '🇯🇵' },
-  { code: 'ko', name: 'Korean', nativeName: '한국어', flag: '🇰🇷' },
-  { code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷' },
-  { code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪' },
-  { code: 'ar', name: 'Arabic', nativeName: 'العربية', flag: '🇸🇦' },
-  { code: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia', flag: '🇮🇩' },
-  { code: 'zh', name: 'Chinese', nativeName: '中文', flag: '🇨🇳' },
-  { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸' },
+  // Popular — 사용 빈도 높은 메이저 언어
+  { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸', region: 'popular' },
+  { code: 'ko', name: 'Korean', nativeName: '한국어', flag: '🇰🇷', region: 'popular' },
+  { code: 'ja', name: 'Japanese', nativeName: '日本語', flag: '🇯🇵', region: 'popular' },
+  { code: 'zh', name: 'Chinese', nativeName: '中文', flag: '🇨🇳', region: 'popular' },
+  { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸', region: 'popular' },
+  { code: 'pt', name: 'Portuguese (Brazil)', nativeName: 'Português', flag: '🇧🇷', region: 'popular' },
+  { code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷', region: 'popular' },
+  { code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪', region: 'popular' },
+  // Asia
+  { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', flag: '🇮🇳', region: 'asia' },
+  { code: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia', flag: '🇮🇩', region: 'asia' },
+  { code: 'vi', name: 'Vietnamese', nativeName: 'Tiếng Việt', flag: '🇻🇳', region: 'asia' },
+  { code: 'th', name: 'Thai', nativeName: 'ไทย', flag: '🇹🇭', region: 'asia' },
+  { code: 'ms', name: 'Malay', nativeName: 'Bahasa Melayu', flag: '🇲🇾', region: 'asia' },
+  { code: 'fil', name: 'Filipino', nativeName: 'Filipino', flag: '🇵🇭', region: 'asia' },
+  { code: 'ta', name: 'Tamil', nativeName: 'தமிழ்', flag: '🇮🇳', region: 'asia' },
+  { code: 'kk', name: 'Kazakh', nativeName: 'Қазақ тілі', flag: '🇰🇿', region: 'asia' },
+  // Europe
+  { code: 'it', name: 'Italian', nativeName: 'Italiano', flag: '🇮🇹', region: 'europe' },
+  { code: 'nl', name: 'Dutch', nativeName: 'Nederlands', flag: '🇳🇱', region: 'europe' },
+  { code: 'ru', name: 'Russian', nativeName: 'Русский', flag: '🇷🇺', region: 'europe' },
+  { code: 'uk', name: 'Ukrainian', nativeName: 'Українська', flag: '🇺🇦', region: 'europe' },
+  { code: 'pl', name: 'Polish', nativeName: 'Polski', flag: '🇵🇱', region: 'europe' },
+  { code: 'cs', name: 'Czech', nativeName: 'Čeština', flag: '🇨🇿', region: 'europe' },
+  { code: 'sk', name: 'Slovak', nativeName: 'Slovenčina', flag: '🇸🇰', region: 'europe' },
+  { code: 'hu', name: 'Hungarian', nativeName: 'Magyar', flag: '🇭🇺', region: 'europe' },
+  { code: 'ro', name: 'Romanian', nativeName: 'Română', flag: '🇷🇴', region: 'europe' },
+  { code: 'bg', name: 'Bulgarian', nativeName: 'Български', flag: '🇧🇬', region: 'europe' },
+  { code: 'hr', name: 'Croatian', nativeName: 'Hrvatski', flag: '🇭🇷', region: 'europe' },
+  { code: 'el', name: 'Greek', nativeName: 'Ελληνικά', flag: '🇬🇷', region: 'europe' },
+  { code: 'sv', name: 'Swedish', nativeName: 'Svenska', flag: '🇸🇪', region: 'europe' },
+  { code: 'no', name: 'Norwegian', nativeName: 'Norsk', flag: '🇳🇴', region: 'europe' },
+  { code: 'da', name: 'Danish', nativeName: 'Dansk', flag: '🇩🇰', region: 'europe' },
+  { code: 'fi', name: 'Finnish', nativeName: 'Suomi', flag: '🇫🇮', region: 'europe' },
+  { code: 'tr', name: 'Turkish', nativeName: 'Türkçe', flag: '🇹🇷', region: 'europe' },
+  // Middle East
+  { code: 'ar', name: 'Arabic', nativeName: 'العربية', flag: '🇸🇦', region: 'middle-east' },
 ]
 
 export function getLanguageByCode(code: string): Language | undefined {


### PR DESCRIPTION
Closes #191

## Summary
- **다국어 지원 확장**: perso `/video-translator/api/v1/languages` 응답 기준 11→34개 타깃 언어 노출. region 메타(`popular`/`asia`/`europe`/`middle-east`) + 검색창 + chip UI로 고르기 쉽게.
- **위자드 흐름 정리**: 영상 → **결과물** → **언어** → 업로드 설정 → 확인 → 처리 → 결과 (step 2/3 swap). 결과물 모드에 따라 이후 옵션 의미가 분기되므로 모드 선택을 앞으로.
- **립싱크 분기**: `originalWithMultiAudio`(원본+자막)에선 립싱크 토글 숨김 + 모드 전환 시 강제 reset. 언어 카드를 "더빙 옵션"으로 라벨링.
- **Shorts 토글 보정**: `originalWithMultiAudio + videoSource.type === 'upload'`(로컬 파일을 새로 올리는 케이스)에 누락된 Shorts 토글 추가.
- **영상 선택 UX**: 비공개·일부공개 영상은 perso 외부 다운로드가 막혀 INVALID_YOUTUBE_URL을 유발하므로 **리스트에서 제외**. `MyVideoItem.privacyStatus` 필드 추가, `fetchMyVideos`가 `videos.list?part=status` 보강 호출. 제목 검색, 내부 스크롤, 사전 안내 배너, 탭 전환 시 에러 자동 클리어.
- **다국어 오디오 placeholder**: 자막 모드 업로드 옵션에 disabled 상태 "다국어 오디오 트랙 추가" 토글("준비 중" 배지) — 후속 기능 안내 목적.
- **카피 정리**: 처리 과정 안내, 화자 수 도움말, 결과물 모드 description 등.

## Test plan
- [ ] 더빙 위자드 진입: 단계 표시기 라벨이 영상→결과물→언어→업로드설정→확인→처리→결과 순으로 보이는지
- [ ] 언어 스텝: popular 탭 기본 8개 표시, 검색에 "한국어"/"ko"/"Korean" 모두 매칭
- [ ] 결과물=원본+자막 선택 후 언어 스텝/확인 스텝에서 립싱크 토글 미노출
- [ ] 결과물=원본+자막 + 로컬 파일 업로드 케이스에서 Shorts 토글 노출
- [ ] 결과물=원본+자막 + 채널 영상 케이스에서 Shorts 토글 미노출
- [ ] 내 영상 탭: 비공개/일부공개 영상이 리스트에 안 보이고 "N개 표시되지 않습니다" 안내 노출
- [ ] 영상 URL 탭/내 영상 탭 모두 상단 안내 배너 노출
- [ ] 한 탭에서 에러 발생 후 다른 탭 전환 시 에러 사라짐
- [ ] 자막 모드 업로드 옵션의 "다국어 오디오 트랙" 토글이 "준비 중" 배지와 함께 disabled

## Notes
- 사전 존재 테스트 5건(`youtube-routes.test.ts`, `fetchChannelStatistics`)은 main에서도 동일 실패 — 본 PR 무관.
- TypeScript 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)