### PR TITLE
feat(dubbing): 업로드 메타데이터 자동 다국어 번역 + YouTube localizations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,8 @@ SESSION_SECRET=
 TURSO_URL=
 TURSO_AUTH_TOKEN=
 
+# Gemini (메타데이터 다국어 번역용 — Gemini Flash REST API)
+GEMINI_API_KEY=
+
 # Chrome Extension (chrome://extensions에서 확장 로드 후 ID 확인)
 NEXT_PUBLIC_EXTENSION_ID=

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from 
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import { SUPPORTED_LANGUAGES } from '@/utils/languages'
 import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 export default function YouTubeSettingsPage() {
@@ -15,6 +16,8 @@ export default function YouTubeSettingsPage() {
   const setDefaultVisibility = useYouTubeSettingsStore((s) => s.setDefaultPrivacy)
   const autoSubtitles = useYouTubeSettingsStore((s) => s.autoSubtitles)
   const setAutoSubtitles = useYouTubeSettingsStore((s) => s.setAutoSubtitles)
+  const defaultLanguage = useYouTubeSettingsStore((s) => s.defaultLanguage)
+  const setDefaultLanguage = useYouTubeSettingsStore((s) => s.setDefaultLanguage)
 
   const { data: channel, isLoading: channelLoading } = useChannelStats()
   const isConnected = !!channel
@@ -127,6 +130,19 @@ export default function YouTubeSettingsPage() {
           />
           <p className="-mt-3 text-xs text-surface-400">
             새 더빙 시작 시 이 값이 기본값으로 적용됩니다. 각 더빙 별로 변경할 수 있습니다.
+          </p>
+
+          <Select
+            label="기본 작성 언어"
+            value={defaultLanguage}
+            onChange={(e) => setDefaultLanguage(e.target.value)}
+            options={SUPPORTED_LANGUAGES.map((l) => ({
+              value: l.code,
+              label: `${l.flag} ${l.name} (${l.nativeName})`,
+            }))}
+          />
+          <p className="-mt-3 text-xs text-surface-400">
+            업로드 제목·설명을 이 언어로 작성한다고 간주합니다. 다른 대상 언어들은 Gemini로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.
           </p>
 
           <div className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">

--- a/src/app/api/translate/metadata/route.ts
+++ b/src/app/api/translate/metadata/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireSession } from '@/lib/auth/session'
+import { translateMetadata, TranslateError } from '@/lib/translate/gemini'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+const bodySchema = z.object({
+  title: z.string().min(1).max(2000),
+  description: z.string().max(20000).default(''),
+  sourceLang: z.string().min(1),
+  targetLangs: z.array(z.string().min(1)).min(1).max(50),
+})
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  let parsed: z.infer<typeof bodySchema>
+  try {
+    parsed = bodySchema.parse(await req.json())
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: 'INVALID_BODY',
+          message: err instanceof z.ZodError ? err.issues[0]?.message ?? 'Invalid body' : 'Invalid body',
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const translations = await translateMetadata(parsed)
+    return NextResponse.json({ ok: true, data: { translations } })
+  } catch (err) {
+    if (err instanceof TranslateError) {
+      const status = err.code === 'GEMINI_NOT_CONFIGURED' ? 503 : 502
+      return NextResponse.json(
+        { ok: false, error: { code: err.code, message: err.message } },
+        { status },
+      )
+    }
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: 'TRANSLATE_FAILED',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/youtube/upload/route.ts
+++ b/src/app/api/youtube/upload/route.ts
@@ -29,6 +29,7 @@ export async function POST(req: NextRequest) {
       categoryId: (form.get('categoryId') as string) || undefined,
       privacyStatus: (form.get('privacyStatus') as string) || undefined,
       language: (form.get('language') as string) || undefined,
+      localizations: (form.get('localizations') as string) || undefined,
     }
     const fields = uploadFormSchema.parse(rawFields)
 
@@ -63,6 +64,7 @@ export async function POST(req: NextRequest) {
       categoryId: fields.categoryId,
       privacyStatus: fields.privacyStatus,
       language: fields.language,
+      localizations: fields.localizations,
     })
   })
 }

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -147,7 +147,7 @@ export function TranslationEditStep() {
           <p className="text-sm font-medium text-blue-900 dark:text-blue-300">처리 과정</p>
           <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
             {deliverableMode === 'originalWithMultiAudio'
-              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
+              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
               : 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 영상을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'}
           </p>
         </div>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
@@ -46,16 +46,23 @@ export function UploadSettingsStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
+  // 영상 정보로 제목/설명을 초기 1회 채워준다. 사용자가 빈 값으로 지웠을 때
+  // 다시 채워 넣지 않도록 videoMeta.id 단위로 한 번만 실행. (deps에 입력값을
+  // 넣으면 사용자가 지울 때마다 재초기화돼 빈 값이 유지되지 않는다.)
+  const initializedForVideoIdRef = useRef<string | null>(null)
   useEffect(() => {
+    if (!videoMeta?.title) return
+    if (initializedForVideoIdRef.current === videoMeta.id) return
+    initializedForVideoIdRef.current = videoMeta.id
+
+    const { title, description } = useDubbingStore.getState().uploadSettings
     const patch: Partial<typeof uploadSettings> = {}
-    if (!uploadSettings.title && videoMeta?.title) {
-      patch.title = videoMeta.title
-    }
-    if (!uploadSettings.description && videoMeta?.title) {
+    if (!title) patch.title = videoMeta.title
+    if (!description) {
       patch.description = `${videoMeta.title} - Dubtube AI 더빙\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
     }
     if (Object.keys(patch).length > 0) setUploadSettings(patch)
-  }, [videoMeta?.title, uploadSettings.title, uploadSettings.description, setUploadSettings])
+  }, [videoMeta?.id, videoMeta?.title, setUploadSettings])
 
   const firstLangName = useMemo(() => {
     const first = selectedLanguages[0]
@@ -230,11 +237,11 @@ export function UploadSettingsStep() {
             (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')) && (
             <ToggleRow
               icon={<Zap className="h-4 w-4 text-brand-500" />}
-              label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
-              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
+              label={isShort ? 'Shorts 해시태그 붙이기 (자동 감지됨)' : 'Shorts 해시태그 붙이기'}
+              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다. 최종 Shorts 분류는 영상 비율·길이에 따라 YouTube가 결정합니다."
               active={uploadSettings.uploadAsShort}
-              activeLabel="Shorts ON"
-              inactiveLabel="Shorts OFF"
+              activeLabel="ON"
+              inactiveLabel="OFF"
               onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
             />
           )}

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
-import { getLanguageByCode } from '@/utils/languages'
+import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
@@ -13,6 +13,11 @@ const PRIVACY_OPTIONS: { value: PrivacyStatus; label: string }[] = [
   { value: 'unlisted', label: '일부 공개' },
   { value: 'public', label: '공개' },
 ]
+
+const LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((l) => ({
+  value: l.code,
+  label: `${l.flag} ${l.name} (${l.nativeName})`,
+}))
 
 export function UploadSettingsStep() {
   const {
@@ -24,14 +29,16 @@ export function UploadSettingsStep() {
     uploadSettings,
     setUploadSettings,
     syncPrivacyFromGlobalDefault,
+    syncMetadataLanguageFromGlobalDefault,
     prevStep,
     nextStep,
   } = useDubbingStore()
 
-  // YouTube 설정 페이지의 기본 공개 설정과 동기화 (사용자 override 없을 때만).
+  // YouTube 설정 페이지의 기본값과 동기화 (사용자 override 없을 때만).
   useEffect(() => {
     syncPrivacyFromGlobalDefault()
-  }, [syncPrivacyFromGlobalDefault])
+    syncMetadataLanguageFromGlobalDefault()
+  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault])
 
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
@@ -100,8 +107,20 @@ export function UploadSettingsStep() {
       {deliverableMode === 'newDubbedVideos' && (
         <Card>
           <CardTitle>제목 · 설명 · 태그</CardTitle>
-          <p className="mt-1 mb-4 text-xs text-surface-500">각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.</p>
+          <p className="mt-1 mb-4 text-xs text-surface-500">
+            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 각 대상 언어로 자동 번역되어 업로드됩니다.
+          </p>
           <div className="space-y-4">
+            <Select
+              label="제목·설명 작성 언어"
+              value={uploadSettings.metadataLanguage}
+              onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
+              options={LANGUAGE_OPTIONS}
+            />
+            <p className="-mt-2 text-xs text-surface-400">
+              마이페이지의 기본 작성 언어를 따르며, 여기에서 더빙별로 변경할 수 있습니다.
+            </p>
+
             <Input
               label="제목 (공통)"
               value={uploadSettings.title}
@@ -148,9 +167,16 @@ export function UploadSettingsStep() {
         <Card>
           <CardTitle>원본 영상 업로드 설정</CardTitle>
           <p className="mt-1 mb-4 text-xs text-surface-500">
-            원본 영상이 YouTube에 먼저 업로드된 후, 더빙 오디오 트랙이 자동 추가됩니다.
+            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 선택한 대상 언어로 자동 번역되어 YouTube `localizations`에 함께 등록됩니다.
           </p>
           <div className="space-y-4">
+            <Select
+              label="제목·설명 작성 언어"
+              value={uploadSettings.metadataLanguage}
+              onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
+              options={LANGUAGE_OPTIONS}
+            />
+
             <Input
               label="제목"
               value={uploadSettings.title}

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -15,6 +15,8 @@ import {
   ytUploadCaption,
   getPersoFileUrl,
   getTranslatedSrt,
+  translateMetadata,
+  type MetadataTranslation,
 } from '@/lib/api-client'
 import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
@@ -47,7 +49,7 @@ export function UploadStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
-  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus } = uploadSettings
+  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus, metadataLanguage } = uploadSettings
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
@@ -57,6 +59,56 @@ export function UploadStep() {
   const autoUploadTriggered = useRef(false)
   const autoChainTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  // ─── Metadata translations (Gemini) ─────────────────────────────────
+  // Upload Step에 진입한 시점의 (title, description, metadataLanguage, selectedLanguages) 조합으로
+  // 한 번 번역해두고 캐시. 모든 언어별 업로드와 localizations에서 공용으로 쓴다.
+  // 실패해도 fallback으로 원문이 들어가도록 처리되어 업로드를 막지 않는다.
+  const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
+  const translatePromiseRef = useRef<Promise<Record<string, MetadataTranslation>> | null>(null)
+  const ensureTranslations = useCallback(async (): Promise<Record<string, MetadataTranslation>> => {
+    if (Object.keys(translations).length > 0) return translations
+    if (translatePromiseRef.current) return translatePromiseRef.current
+
+    const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
+    if (!baseTitle || selectedLanguages.length === 0) return {}
+
+    const p = (async () => {
+      try {
+        const result = await translateMetadata({
+          title: baseTitle,
+          description: settingsDescription || '',
+          sourceLang: metadataLanguage || 'ko',
+          targetLangs: selectedLanguages,
+        })
+        setTranslations(result)
+        return result
+      } catch (err) {
+        // 실패 시 모든 언어를 원문으로 fallback. 사용자에게는 toast로 1회 안내.
+        const fallback: Record<string, MetadataTranslation> = {}
+        for (const code of selectedLanguages) {
+          fallback[code] = { title: baseTitle, description: settingsDescription || '' }
+        }
+        setTranslations(fallback)
+        addToast({
+          type: 'warning',
+          title: '메타데이터 번역 실패',
+          message: err instanceof Error ? err.message : '원문으로 업로드합니다',
+        })
+        return fallback
+      } finally {
+        translatePromiseRef.current = null
+      }
+    })()
+    translatePromiseRef.current = p
+    return p
+  }, [translations, settingsTitle, videoMeta?.title, settingsDescription, metadataLanguage, selectedLanguages, addToast])
+
+  // 사용자가 제목/설명을 다시 만지면 캐시 무효화.
+  useEffect(() => {
+    setTranslations({})
+    translatePromiseRef.current = null
+  }, [settingsTitle, settingsDescription, metadataLanguage])
 
   // Original video upload state (for upload + originalWithMultiAudio)
   const [originalUploadState, setOriginalUploadState] = useState<{
@@ -69,17 +121,25 @@ export function UploadStep() {
   const multiAudioVideoId =
     originalUploadState.videoId || channelVideoId || null
 
+  /** 번역되었거나 원문인 description에 공통 footer(원본 링크)를 붙여 준다. */
+  const applyDescriptionFooter = useCallback(
+    (desc: string) => {
+      if (attachOriginalLink && originalYouTubeUrl) {
+        return `${desc}\n\n원본 영상: ${originalYouTubeUrl}`
+      }
+      return desc
+    },
+    [attachOriginalLink, originalYouTubeUrl],
+  )
+
   const buildDescription = useCallback(
     (langName: string) => {
       const base = settingsDescription?.trim()
         ? settingsDescription
         : `${videoMeta?.title || 'Video'} - ${langName} 더빙 by Dubtube AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
-      if (attachOriginalLink && originalYouTubeUrl) {
-        return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
-      }
-      return base
+      return applyDescriptionFooter(base)
     },
-    [settingsDescription, videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
+    [settingsDescription, videoMeta?.title, applyDescriptionFooter],
   )
 
   const handleNewDubbing = () => reset()
@@ -91,12 +151,23 @@ export function UploadStep() {
 
     setOriginalUploadState({ status: 'uploading' })
     try {
+      // 다국어 자막 모드는 영상 1개에 localizations 맵을 함께 보내 YouTube가 시청자
+      // 로케일에 맞춰 제목·설명을 보여주도록 한다.
+      const allTranslations = await ensureTranslations()
+      const localizations: Record<string, { title: string; description: string }> = {}
+      for (const code of selectedLanguages) {
+        const t = allTranslations[code]
+        if (t) localizations[code] = { title: t.title, description: t.description }
+      }
+
       const result = await ytUploadVideo({
         videoUrl: originalVideoUrl,
         title: settingsTitle?.trim() || videoMeta?.title || 'Original Video',
         description: settingsDescription || '',
         tags: settingsTags,
         privacyStatus,
+        language: metadataLanguage,
+        localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
       setOriginalUploadState({ status: 'done', videoId: result.videoId })
       addToast({
@@ -111,7 +182,7 @@ export function UploadStep() {
       addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
       return null
     }
-  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast])
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
 
   // ─── Audio → Studio helper ──────────────────────────────────────────
   const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {
@@ -217,8 +288,13 @@ export function UploadStep() {
 
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
+
+      // 번역된 제목·설명을 가져와 그 언어 영상의 메타로 사용한다.
+      const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
+      const ytTitle = `${titlePrefix}${translated.title}`
+      const ytDescription = applyDescriptionFooter(translated.description)
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
@@ -227,7 +303,7 @@ export function UploadStep() {
       const result = await ytUploadVideo({
         videoUrl,
         title: ytTitle,
-        description: buildDescription(lang.name),
+        description: ytDescription,
         tags: langTags,
         privacyStatus,
         language: langCode,
@@ -292,7 +368,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription, projectMap, spaceSeq])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsDescription, settingsTags, privacyStatus, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
 
   // ─── Queue upload (background — survives tab close) ─────────────────
   const queueYouTubeUpload = useCallback(async (langCode: string) => {
@@ -310,8 +386,10 @@ export function UploadStep() {
       const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
+      const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
+      const ytTitle = `${titlePrefix}${translated.title}`
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
@@ -326,7 +404,7 @@ export function UploadStep() {
           langCode,
           videoUrl,
           title: ytTitle,
-          description: buildDescription(lang.name),
+          description: applyDescriptionFooter(translated.description),
           tags: langTags,
           privacyStatus,
           language: langCode,
@@ -351,7 +429,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 큐 등록 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsTags, privacyStatus, buildDescription])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsDescription, settingsTags, privacyStatus, ensureTranslations, applyDescriptionFooter])
 
   const completedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -348,7 +348,7 @@ export function VideoInputStep() {
 
       <div className="flex justify-end">
         <Button onClick={nextStep} disabled={!videoMeta || loading}>
-          다음: 언어 선택
+          다음: 결과물 선택
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -117,6 +117,9 @@ interface DubbingState {
   privacyOverridden: boolean
   /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
   metadataLanguageOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 Shorts 토글을 직접 변경했는지 여부.
+   * true이면 videoMeta 갱신 시 자동 감지가 uploadAsShort를 덮어쓰지 않는다. */
+  uploadAsShortOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
@@ -155,6 +158,7 @@ const initialState = {
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
   metadataLanguageOverridden: false,
+  uploadAsShortOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -230,7 +234,10 @@ export const useDubbingStore = create<DubbingState>((set) => ({
   setDbJobId: (id) => set({ dbJobId: id }),
   setIsShort: (v) => set((s) => ({
     isShort: v,
-    uploadSettings: { ...s.uploadSettings, uploadAsShort: v },
+    // 사용자가 토글을 직접 만진 적이 있으면 그 선택을 보존한다.
+    uploadSettings: s.uploadAsShortOverridden
+      ? s.uploadSettings
+      : { ...s.uploadSettings, uploadAsShort: v },
   })),
 
   setDeliverableMode: (mode) => set({ deliverableMode: mode }),
@@ -242,6 +249,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
       patch.privacyStatus !== undefined ? true : s.privacyOverridden,
     metadataLanguageOverridden:
       patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
+    uploadAsShortOverridden:
+      patch.uploadAsShort !== undefined ? true : s.uploadAsShortOverridden,
   })),
 
   syncPrivacyFromGlobalDefault: () => set((s) => {

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -15,14 +15,23 @@ import type {
   PrivacyStatus,
 } from '../types/dubbing.types'
 
-// YouTube 설정 페이지의 기본 공개 설정을 그때그때 가져온다.
-// SSR 단계에서는 localStorage가 없으므로 fallback 'private'.
+// YouTube 설정 페이지의 기본값을 그때그때 가져온다.
+// SSR 단계에서는 localStorage가 없으므로 fallback 사용.
 const readDefaultPrivacy = (): PrivacyStatus => {
   if (typeof window === 'undefined') return 'private'
   try {
     return useYouTubeSettingsStore.getState().defaultPrivacy
   } catch {
     return 'private'
+  }
+}
+
+const readDefaultLanguage = (): string => {
+  if (typeof window === 'undefined') return 'ko'
+  try {
+    return useYouTubeSettingsStore.getState().defaultLanguage
+  } catch {
+    return 'ko'
   }
 }
 
@@ -34,6 +43,7 @@ const buildDefaultUploadSettings = (): UploadSettings => ({
   description: '',
   tags: ['Dubtube', 'AI더빙', 'dubbed'],
   privacyStatus: readDefaultPrivacy(),
+  metadataLanguage: readDefaultLanguage(),
 })
 
 interface DubbingState {
@@ -105,9 +115,12 @@ interface DubbingState {
   /** Wizard 세션 내에서 사용자가 privacyStatus를 직접 변경했는지 여부.
    * true이면 YouTube 설정 페이지의 글로벌 기본값으로 덮어쓰지 않는다. */
   privacyOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
+  metadataLanguageOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
+  syncMetadataLanguageFromGlobalDefault: () => void
 
   // Glossary
   glossary: GlossaryEntry[]
@@ -141,6 +154,7 @@ const initialState = {
   copyrightAcknowledged: false,
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
+  metadataLanguageOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -226,6 +240,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     uploadSettings: { ...s.uploadSettings, ...patch },
     privacyOverridden:
       patch.privacyStatus !== undefined ? true : s.privacyOverridden,
+    metadataLanguageOverridden:
+      patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
   })),
 
   syncPrivacyFromGlobalDefault: () => set((s) => {
@@ -234,6 +250,15 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     if (s.uploadSettings.privacyStatus === next) return s
     return {
       uploadSettings: { ...s.uploadSettings, privacyStatus: next },
+    }
+  }),
+
+  syncMetadataLanguageFromGlobalDefault: () => set((s) => {
+    if (s.metadataLanguageOverridden) return s
+    const next = readDefaultLanguage()
+    if (s.uploadSettings.metadataLanguage === next) return s
+    return {
+      uploadSettings: { ...s.uploadSettings, metadataLanguage: next },
     }
   }),
 

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -12,6 +12,11 @@ export interface UploadSettings {
   description: string
   tags: string[]
   privacyStatus: PrivacyStatus
+  /**
+   * 사용자가 작성한 제목/설명의 언어. 다른 대상 언어로 자동 번역하는 기준.
+   * 마이페이지의 `defaultLanguage`로 초기화되며 더빙별로 override 가능.
+   */
+  metadataLanguage: string
 }
 
 export type JobStatus = 'idle' | 'transcribing' | 'translating' | 'synthesizing' | 'lip-syncing' | 'merging' | 'completed' | 'failed'

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -30,3 +30,4 @@ export {
   ytFetchMyVideos,
   ytFetchAnalytics,
 } from './youtube'
+export { translateMetadata, type MetadataTranslation } from './translate'

--- a/src/lib/api-client/translate.ts
+++ b/src/lib/api-client/translate.ts
@@ -1,0 +1,21 @@
+import { json } from './shared'
+
+export interface MetadataTranslation {
+  title: string
+  description: string
+}
+
+export async function translateMetadata(params: {
+  title: string
+  description: string
+  sourceLang: string
+  targetLangs: string[]
+}): Promise<Record<string, MetadataTranslation>> {
+  const res = await fetch('/api/translate/metadata', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  })
+  const data = await json<{ translations: Record<string, MetadataTranslation> }>(res)
+  return data.translations
+}

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -18,6 +18,8 @@ export async function ytUploadVideo(params: {
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
   language?: string
+  /** BCP-47 language code → { title, description } 맵. snippet.localizations로 전달. */
+  localizations?: Record<string, { title: string; description: string }>
 }): Promise<YouTubeUploadResult> {
   const form = new FormData()
   if (params.videoUrl) {
@@ -31,6 +33,9 @@ export async function ytUploadVideo(params: {
   if (params.categoryId) form.append('categoryId', params.categoryId)
   if (params.privacyStatus) form.append('privacyStatus', params.privacyStatus)
   if (params.language) form.append('language', params.language)
+  if (params.localizations && Object.keys(params.localizations).length > 0) {
+    form.append('localizations', JSON.stringify(params.localizations))
+  }
 
   const res = await fetch(`${YT}/upload`, {
     method: 'POST',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -21,6 +21,7 @@ const serverSchema = z.object({
   TURSO_URL: z.string().min(1, "TURSO_URL is required"),
   TURSO_AUTH_TOKEN: z.string().min(1, "TURSO_AUTH_TOKEN is required"),
   GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
+  GEMINI_API_KEY: z.string().min(1).optional(),
 });
 
 const clientSchema = z.object({
@@ -60,6 +61,7 @@ export function getServerEnv(): ServerEnv {
     TURSO_URL: process.env.TURSO_URL,
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   });
 
   if (!parsed.success) {

--- a/src/lib/translate/gemini.ts
+++ b/src/lib/translate/gemini.ts
@@ -2,8 +2,9 @@ import 'server-only'
 
 import { getServerEnv } from '@/lib/env'
 
+// gemini-2.0-flash는 신규 키로 사용 불가(NOT_FOUND). 2.5 Flash 사용.
 const GEMINI_ENDPOINT =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
 
 export interface MetadataTranslation {
   title: string

--- a/src/lib/translate/gemini.ts
+++ b/src/lib/translate/gemini.ts
@@ -1,0 +1,150 @@
+import 'server-only'
+
+import { getServerEnv } from '@/lib/env'
+
+const GEMINI_ENDPOINT =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+
+export interface MetadataTranslation {
+  title: string
+  description: string
+}
+
+export interface TranslateMetadataInput {
+  /** 사용자가 작성한 원본 제목. */
+  title: string
+  /** 사용자가 작성한 원본 설명. */
+  description: string
+  /** 위 텍스트의 작성 언어 (ISO 639-1, 예: 'ko'). 'auto'가 들어오면 Gemini가 추론. */
+  sourceLang: string
+  /** 번역해야 하는 대상 언어 코드 배열. sourceLang과 동일한 코드는 그대로 통과. */
+  targetLangs: string[]
+}
+
+export class TranslateError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message)
+    this.name = 'TranslateError'
+  }
+}
+
+/**
+ * 한 번의 Gemini 호출로 여러 대상 언어의 제목/설명을 번역해 받는다.
+ * 결과는 { [langCode]: { title, description } } 형태의 plain object.
+ *
+ * 동일 코드(sourceLang)는 번역 없이 원문 그대로 채움 — Gemini round-trip 절약.
+ */
+export async function translateMetadata(
+  input: TranslateMetadataInput,
+): Promise<Record<string, MetadataTranslation>> {
+  const { title, description, sourceLang, targetLangs } = input
+
+  const result: Record<string, MetadataTranslation> = {}
+  const langsToTranslate = targetLangs.filter((l) => l !== sourceLang)
+
+  // sourceLang과 동일한 언어는 번역 없이 통과.
+  for (const code of targetLangs) {
+    if (code === sourceLang) {
+      result[code] = { title, description }
+    }
+  }
+
+  if (langsToTranslate.length === 0) return result
+
+  const env = getServerEnv()
+  if (!env.GEMINI_API_KEY) {
+    throw new TranslateError(
+      'GEMINI_NOT_CONFIGURED',
+      'GEMINI_API_KEY is not set on the server',
+    )
+  }
+
+  const prompt = buildPrompt({
+    title,
+    description,
+    sourceLang,
+    targetLangs: langsToTranslate,
+  })
+
+  const res = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(env.GEMINI_API_KEY)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        temperature: 0.2,
+      },
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TranslateError(
+      'GEMINI_REQUEST_FAILED',
+      `Gemini ${res.status}: ${body.slice(0, 500)}`,
+    )
+  }
+
+  const data = (await res.json()) as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+  }
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text
+  if (!text) {
+    throw new TranslateError('GEMINI_EMPTY_RESPONSE', 'Gemini returned no text')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new TranslateError('GEMINI_INVALID_JSON', `Could not parse: ${text.slice(0, 300)}`)
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new TranslateError('GEMINI_INVALID_SHAPE', 'Response is not an object')
+  }
+
+  for (const code of langsToTranslate) {
+    const entry = (parsed as Record<string, unknown>)[code]
+    if (!entry || typeof entry !== 'object') {
+      // 누락된 언어는 원문 fallback. 이렇게 하면 부분 실패 시에도 업로드는 진행 가능.
+      result[code] = { title, description }
+      continue
+    }
+    const e = entry as { title?: unknown; description?: unknown }
+    result[code] = {
+      title: typeof e.title === 'string' && e.title.trim().length > 0 ? e.title : title,
+      description: typeof e.description === 'string' ? e.description : description,
+    }
+  }
+
+  return result
+}
+
+function buildPrompt(args: {
+  title: string
+  description: string
+  sourceLang: string
+  targetLangs: string[]
+}): string {
+  const sourceHint =
+    args.sourceLang === 'auto'
+      ? 'Detect the source language automatically.'
+      : `The source language is "${args.sourceLang}".`
+
+  return [
+    'You are a YouTube metadata translator for a multilingual creator tool.',
+    'Translate the given title and description into each target language.',
+    'Preserve emojis, hashtags, URLs, @mentions, and line breaks. Keep the tone friendly and SEO-aware.',
+    'Do not add explanations or quotes around the output. Output strict JSON only.',
+    sourceHint,
+    `Target language codes (ISO 639-1 / BCP47-like): ${JSON.stringify(args.targetLangs)}.`,
+    'Respond with a JSON object where each key is a target code and the value is an object with "title" and "description".',
+    'Example shape: {"ja":{"title":"...","description":"..."},"es":{"title":"...","description":"..."}}',
+    '',
+    `INPUT_TITLE: ${args.title}`,
+    'INPUT_DESCRIPTION:',
+    args.description,
+  ].join('\n')
+}

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -40,6 +40,14 @@ export const videosQuerySchema = z.object({
     .pipe(z.number().int().min(1).max(50)),
 })
 
+const localizationsRecordSchema = z.record(
+  z.string().min(1),
+  z.object({
+    title: z.string().min(1).max(2000),
+    description: z.string().max(20000).default(''),
+  }),
+)
+
 export const uploadFormSchema = z.object({
   title: z.string().default(''),
   description: z.string().default(''),
@@ -50,4 +58,16 @@ export const uploadFormSchema = z.object({
   categoryId: z.string().optional(),
   privacyStatus: z.enum(['public', 'unlisted', 'private']).optional(),
   language: z.string().optional(),
+  /** form에서는 JSON 문자열로 전달. */
+  localizations: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (!v) return undefined
+      try {
+        return localizationsRecordSchema.parse(JSON.parse(v))
+      } catch {
+        return undefined
+      }
+    }),
 })

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -5,6 +5,11 @@ import { YouTubeError } from '@/lib/youtube/error'
 
 const YOUTUBE_UPLOAD_BASE = 'https://www.googleapis.com/upload/youtube/v3'
 
+export interface YouTubeLocalization {
+  title: string
+  description: string
+}
+
 export interface YouTubeUploadInput {
   accessToken: string
   videoBlob: Blob
@@ -14,6 +19,11 @@ export interface YouTubeUploadInput {
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
   language?: string
+  /**
+   * BCP-47 언어 코드를 키로 한 추가 번역 맵.
+   * snippet.defaultLanguage가 함께 설정돼야 YouTube가 적용한다.
+   */
+  localizations?: Record<string, YouTubeLocalization>
 }
 
 export async function uploadVideoToYouTube(
@@ -28,9 +38,11 @@ export async function uploadVideoToYouTube(
     categoryId = '22',
     privacyStatus = 'private',
     language = 'en',
+    localizations,
   } = input
 
-  const metadata = {
+  const hasLocalizations = !!localizations && Object.keys(localizations).length > 0
+  const metadata: Record<string, unknown> = {
     snippet: {
       title,
       description,
@@ -44,9 +56,14 @@ export async function uploadVideoToYouTube(
       selfDeclaredMadeForKids: false,
     },
   }
+  if (hasLocalizations) {
+    metadata.localizations = localizations
+  }
+  // localizations가 있으면 part에 포함되도록 아래 URL에서 동적으로 합친다.
+  const parts = ['snippet', 'status', ...(hasLocalizations ? ['localizations'] : [])].join(',')
 
   const initRes = await fetch(
-    `${YOUTUBE_UPLOAD_BASE}/videos?uploadType=resumable&part=snippet,status`,
+    `${YOUTUBE_UPLOAD_BASE}/videos?uploadType=resumable&part=${parts}`,
     {
       method: 'POST',
       headers: {

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -7,8 +7,14 @@ import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 interface YouTubeSettingsState {
   defaultPrivacy: PrivacyStatus
   autoSubtitles: boolean
+  /**
+   * 사용자가 제목·설명을 작성할 기본 언어 (perso.ai 코드 기반).
+   * 업로드 시 이 언어로 작성된 텍스트를 기준 삼아 다른 대상 언어로 자동 번역한다.
+   */
+  defaultLanguage: string
   setDefaultPrivacy: (v: PrivacyStatus) => void
   setAutoSubtitles: (v: boolean) => void
+  setDefaultLanguage: (v: string) => void
 }
 
 export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
@@ -16,8 +22,10 @@ export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
     (set) => ({
       defaultPrivacy: 'private',
       autoSubtitles: true,
+      defaultLanguage: 'ko',
       setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
       setAutoSubtitles: (v) => set({ autoSubtitles: v }),
+      setDefaultLanguage: (v) => set({ defaultLanguage: v }),
     }),
     { name: 'dubtube-youtube-settings' },
   ),


### PR DESCRIPTION
Refs #193

## Summary
다국어 더빙 시 제목·설명도 각 언어로 자동 번역되어 함께 업로드되도록 한다. 일본 시청자에겐 일본어 제목, 스페인 시청자에겐 스페인어 제목이 노출 — SEO/CTR 향상.

## Highlights
- **Gemini 2.0 Flash 번역 서비스** (`src/lib/translate/gemini.ts`): 한 번 호출로 여러 대상 언어를 JSON 모드로 받아 옴. 부분 실패는 원문 fallback.
- **기본 작성 언어 설정** (`/youtube` 페이지의 "기본 작성 언어" Select, zustand persist). 더빙별 override 가능.
- **새 더빙 영상**: 언어별 영상마다 그 언어로 번역된 title/description 사용. `[Korean]` 식 prefix 제거.
- **원본+자막 (upload mode)**: 원본 영상 1회 업로드에 `videos.insert.localizations` 맵 첨부. 시청자 로케일에 맞게 표시.
- **사용자 안내**: UploadSettingsStep에 자동 번역되어 업로드된다는 안내문 명시.

## API 변경
- 신규 `POST /api/translate/metadata` (세션 인증 필요)
- `POST /api/youtube/upload`: form에 optional `localizations`(JSON 문자열) 추가

## 환경 변수
- 신규 `GEMINI_API_KEY` (optional). 비어 있으면 자동 번역만 비활성화되고 원문 그대로 업로드.

## Test plan
- [ ] `/youtube` 페이지에서 "기본 작성 언어" 변경 → localStorage `dubtube-youtube-settings` 반영
- [ ] 더빙 시작 후 Upload Settings 단계에서 작성 언어 override → 마이페이지 값과 분리 동작
- [ ] 새 더빙 영상 업로드: 일본어 대상 영상 제목이 일본어로 올라가는지 (YouTube Studio 확인)
- [ ] 원본+자막 (upload mode): 단일 영상 메타에 `localizations` 들어가는지 (Studio > 자막/번역 메뉴 또는 `youtube-data-api videos.list?part=localizations`)
- [ ] Gemini 키 없을 때: 토스트로 안내, 원문 그대로 업로드 (실패해도 업로드는 성공)
- [ ] 제목/설명 변경 후 다시 업로드: 캐시 무효화 → 재번역
- [ ] 세션 없는 상태에서 `/api/translate/metadata` 호출 → 401

## Notes / Out of scope
- **originalWithMultiAudio + channel 모드** (이미 YouTube에 있는 내 채널 영상에 자막만 추가하는 흐름)는 별도 endpoint(`videos.update?part=snippet,localizations`)가 필요해 다음 PR로 분리.
- UploadSettingsStep의 미리보기 카드에 번역 결과를 미리 보여 주는 건 추후 enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)