### PR TITLE
chore(dubbing): 처리 중 안내 멘트 정리

### DIFF
--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -42,7 +42,7 @@ function getProgressLabel(lp: { progressReason: string; progress: number }) {
 }
 
 export function ProcessingStep() {
-  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted } = useDubbingStore()
+  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted, deliverableMode } = useDubbingStore()
   const { submitDubbing, startPolling, stopPolling, cancelAll } = usePersoFlow()
   const [cancelling, setCancelling] = useState(false)
   const submittedRef = useRef(isSubmitted)
@@ -94,7 +94,9 @@ export function ProcessingStep() {
         <p className="mt-1 text-surface-500">
           {allCompleted
             ? '모든 언어 처리가 완료되었습니다.'
-            : 'Perso.ai가 전사, 번역, 더빙 오디오를 생성하고 있습니다. 몇 분 정도 소요됩니다.'}
+            : deliverableMode === 'originalWithMultiAudio'
+              ? 'AI가 전사, 번역, 자막 생성을 진행하고 있습니다.'
+              : 'AI가 전사, 번역, 더빙 오디오를 생성하고 있습니다. 몇 분 정도 소요됩니다.'}
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
영상 처리 단계의 안내 문구를 결과물 모드에 맞게 분기하고 브랜드 노출 정리.

- 더빙 영상: \"AI가 전사, 번역, 더빙 오디오를 생성하고 있습니다. 몇 분 정도 소요됩니다.\"
- 자막 모드(originalWithMultiAudio): \"AI가 전사, 번역, 자막 생성을 진행하고 있습니다.\"

기존: \"Perso.ai가 전사, 번역, 더빙 오디오를 생성하고 있습니다...\" (모드 무관 단일 문구).

## Test plan
- [ ] 새 더빙 영상 모드로 진행 → 더빙 오디오 안내문 노출
- [ ] 자막 모드로 진행 → 자막 안내문 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)