### PR TITLE
release: develop → main (위자드 UX, 자동 번역, 자동 취소 fix 등 8건)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,8 @@ SESSION_SECRET=
 TURSO_URL=
 TURSO_AUTH_TOKEN=
 
+# Gemini (메타데이터 다국어 번역용 — Gemini Flash REST API)
+GEMINI_API_KEY=
+
 # Chrome Extension (chrome://extensions에서 확장 로드 후 ID 확인)
 NEXT_PUBLIC_EXTENSION_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "recharts": "^3.8.1",
         "server-only": "^0.0.1",
         "tailwind-merge": "^3.5.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -37,7 +37,7 @@
         "eslint-config-next": "16.2.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.5.0",
-        "jsdom": "^29.1.0",
+        "jsdom": "^29.1.1",
         "lighthouse": "^13.1.0",
         "tailwindcss": "^4.2.3",
         "typescript": "^6.0.3",
@@ -7620,9 +7620,9 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
-      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11414,9 +11414,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "recharts": "^3.8.1",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.5.0",
-    "zod": "^4.3.6",
+    "zod": "^4.4.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "eslint-config-next": "16.2.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0",
-    "jsdom": "^29.1.0",
+    "jsdom": "^29.1.1",
     "lighthouse": "^13.1.0",
     "tailwindcss": "^4.2.3",
     "typescript": "^6.0.3",

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from 
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import { SUPPORTED_LANGUAGES } from '@/utils/languages'
 import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 export default function YouTubeSettingsPage() {
@@ -15,6 +16,8 @@ export default function YouTubeSettingsPage() {
   const setDefaultVisibility = useYouTubeSettingsStore((s) => s.setDefaultPrivacy)
   const autoSubtitles = useYouTubeSettingsStore((s) => s.autoSubtitles)
   const setAutoSubtitles = useYouTubeSettingsStore((s) => s.setAutoSubtitles)
+  const defaultLanguage = useYouTubeSettingsStore((s) => s.defaultLanguage)
+  const setDefaultLanguage = useYouTubeSettingsStore((s) => s.setDefaultLanguage)
 
   const { data: channel, isLoading: channelLoading } = useChannelStats()
   const isConnected = !!channel
@@ -127,6 +130,19 @@ export default function YouTubeSettingsPage() {
           />
           <p className="-mt-3 text-xs text-surface-400">
             새 더빙 시작 시 이 값이 기본값으로 적용됩니다. 각 더빙 별로 변경할 수 있습니다.
+          </p>
+
+          <Select
+            label="기본 작성 언어"
+            value={defaultLanguage}
+            onChange={(e) => setDefaultLanguage(e.target.value)}
+            options={SUPPORTED_LANGUAGES.map((l) => ({
+              value: l.code,
+              label: `${l.flag} ${l.name} (${l.nativeName})`,
+            }))}
+          />
+          <p className="-mt-3 text-xs text-surface-400">
+            업로드 제목·설명을 이 언어로 작성한다고 간주합니다. 다른 대상 언어들은 Gemini로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.
           </p>
 
           <div className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">

--- a/src/app/api/translate/metadata/route.ts
+++ b/src/app/api/translate/metadata/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireSession } from '@/lib/auth/session'
+import { translateMetadata, TranslateError } from '@/lib/translate/gemini'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+const bodySchema = z.object({
+  title: z.string().min(1).max(2000),
+  description: z.string().max(20000).default(''),
+  sourceLang: z.string().min(1),
+  targetLangs: z.array(z.string().min(1)).min(1).max(50),
+})
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  let parsed: z.infer<typeof bodySchema>
+  try {
+    parsed = bodySchema.parse(await req.json())
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: 'INVALID_BODY',
+          message: err instanceof z.ZodError ? err.issues[0]?.message ?? 'Invalid body' : 'Invalid body',
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const translations = await translateMetadata(parsed)
+    return NextResponse.json({ ok: true, data: { translations } })
+  } catch (err) {
+    if (err instanceof TranslateError) {
+      const status = err.code === 'GEMINI_NOT_CONFIGURED' ? 503 : 502
+      return NextResponse.json(
+        { ok: false, error: { code: err.code, message: err.message } },
+        { status },
+      )
+    }
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: 'TRANSLATE_FAILED',
+          message: err instanceof Error ? err.message : 'Unknown error',
+        },
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/youtube/upload/route.ts
+++ b/src/app/api/youtube/upload/route.ts
@@ -29,6 +29,7 @@ export async function POST(req: NextRequest) {
       categoryId: (form.get('categoryId') as string) || undefined,
       privacyStatus: (form.get('privacyStatus') as string) || undefined,
       language: (form.get('language') as string) || undefined,
+      localizations: (form.get('localizations') as string) || undefined,
     }
     const fields = uploadFormSchema.parse(rawFields)
 
@@ -63,6 +64,7 @@ export async function POST(req: NextRequest) {
       categoryId: fields.categoryId,
       privacyStatus: fields.privacyStatus,
       language: fields.language,
+      localizations: fields.localizations,
     })
   })
 }

--- a/src/features/dubbing/components/DubbingWizard.tsx
+++ b/src/features/dubbing/components/DubbingWizard.tsx
@@ -13,8 +13,8 @@ import { UploadStep } from './steps/UploadStep'
 
 const steps = [
   { num: 1, label: '영상' },
-  { num: 2, label: '언어' },
-  { num: 3, label: '결과물' },
+  { num: 2, label: '결과물' },
+  { num: 3, label: '언어' },
   { num: 4, label: '업로드 설정' },
   { num: 5, label: '확인' },
   { num: 6, label: '처리' },
@@ -71,8 +71,8 @@ export function DubbingWizard() {
       {/* Step content */}
       <div className="animate-fade-in">
         {currentStep === 1 && <VideoInputStep />}
-        {currentStep === 2 && <LanguageSelectStep />}
-        {currentStep === 3 && <OutputModeStep />}
+        {currentStep === 2 && <OutputModeStep />}
+        {currentStep === 3 && <LanguageSelectStep />}
         {currentStep === 4 && <UploadSettingsStep />}
         {currentStep === 5 && <TranslationEditStep />}
         {currentStep === 6 && <ProcessingStep />}

--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -1,22 +1,61 @@
 'use client'
 
-import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, ArrowRight, Check, Search, X } from 'lucide-react'
 import { Button, Card, Toggle, Tooltip } from '@/components/ui'
 import { cn } from '@/utils/cn'
-import { SUPPORTED_LANGUAGES } from '@/utils/languages'
+import {
+  REGION_LABELS,
+  SUPPORTED_LANGUAGES,
+  getLanguageByCode,
+  type LanguageRegion,
+} from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
+
+type RegionFilter = 'all' | LanguageRegion
+
+const REGION_TABS: { id: RegionFilter; label: string }[] = [
+  { id: 'all', label: '전체' },
+  { id: 'popular', label: REGION_LABELS.popular },
+  { id: 'asia', label: REGION_LABELS.asia },
+  { id: 'europe', label: REGION_LABELS.europe },
+  { id: 'middle-east', label: REGION_LABELS['middle-east'] },
+]
 
 export function LanguageSelectStep() {
   const {
-    sourceLanguage,
-    setSourceLanguage,
     selectedLanguages,
     toggleLanguage,
     lipSyncEnabled,
     setLipSync,
+    deliverableMode,
     prevStep,
     nextStep,
   } = useDubbingStore()
+
+  const [region, setRegion] = useState<RegionFilter>('popular')
+  const [query, setQuery] = useState('')
+
+  // 원본 영상에 자막/오디오 트랙만 추가하는 모드는 비디오 픽셀을 건드리지 않으므로
+  // 립싱크가 적용될 곳이 없다. 스텝을 오가며 stale 상태가 남는 것을 막기 위해 강제 reset.
+  const lipSyncApplicable = deliverableMode !== 'originalWithMultiAudio'
+  useEffect(() => {
+    if (!lipSyncApplicable && lipSyncEnabled) setLipSync(false)
+  }, [lipSyncApplicable, lipSyncEnabled, setLipSync])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return SUPPORTED_LANGUAGES.filter((l) => {
+      if (q) {
+        return (
+          l.code.toLowerCase().includes(q) ||
+          l.name.toLowerCase().includes(q) ||
+          l.nativeName.toLowerCase().includes(q)
+        )
+      }
+      return region === 'all' ? true : l.region === region
+    })
+  }, [region, query])
 
   const estimatedCredits = selectedLanguages.length * 15 + (lipSyncEnabled ? selectedLanguages.length * 8 : 0)
 
@@ -25,77 +64,125 @@ export function LanguageSelectStep() {
       <div className="text-center">
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">대상 언어 선택</h2>
         <p className="mt-1 text-surface-500">
-          더빙할 언어를 최대 10개까지 선택하세요 ({selectedLanguages.length}/10 선택됨)
+          더빙할 언어를 선택하세요 ({selectedLanguages.length}개 선택됨)
         </p>
       </div>
 
-      {/* Source language selector */}
-      <Card>
-        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
-          원본 영상 언어
-        </label>
-        <select
-          value={sourceLanguage}
-          onChange={(e) => setSourceLanguage(e.target.value)}
-          className="w-full rounded-md border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
-        >
-          <option value="auto">🌐 자동 감지 (권장)</option>
-          {SUPPORTED_LANGUAGES.map((lang) => (
-            <option key={lang.code} value={lang.code}>
-              {lang.flag} {lang.name} ({lang.nativeName})
-            </option>
-          ))}
-        </select>
-        <p className="mt-2 text-xs text-surface-500">
-          자동 감지를 사용하면 Perso AI가 영상 음성에서 언어를 자동으로 판별합니다.
-          정확한 언어를 알고 있다면 직접 선택하는 편이 안정적입니다.
-        </p>
-      </Card>
+      {/* Selected chips */}
+      {selectedLanguages.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedLanguages.map((code) => {
+            const lang = getLanguageByCode(code)
+            if (!lang) return null
+            return (
+              <button
+                key={code}
+                onClick={() => toggleLanguage(code)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-brand-500 bg-brand-50 px-3 py-1 text-sm font-medium text-brand-700 transition hover:bg-brand-100 dark:bg-brand-900/30 dark:text-brand-200 dark:hover:bg-brand-900/50"
+              >
+                <span>{lang.flag}</span>
+                <span>{lang.name}</span>
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )
+          })}
+        </div>
+      )}
 
-      {/* Language grid — exclude the current source language */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
-        {SUPPORTED_LANGUAGES.filter((l) => l.code !== sourceLanguage).map((lang) => {
-          const isSelected = selectedLanguages.includes(lang.code)
-          return (
+      {/* Search + region tabs */}
+      <div className="space-y-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="언어 검색 (예: Korean, 한국어, ko)"
+            className="w-full rounded-md border border-surface-300 bg-white py-2 pl-9 pr-9 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+          />
+          {query && (
             <button
-              key={lang.code}
-              onClick={() => toggleLanguage(lang.code)}
-              className={cn(
-                'relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-all cursor-pointer',
-                isSelected
-                  ? 'border-brand-500 bg-brand-50 shadow-md shadow-brand-500/10 dark:bg-brand-900/20'
-                  : 'border-surface-200 bg-white hover:border-surface-300 dark:border-surface-800 dark:bg-surface-900 dark:hover:border-surface-700',
-              )}
+              onClick={() => setQuery('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-400 hover:text-surface-600"
             >
-              {isSelected && (
-                <div className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-white">
-                  <Check className="h-3 w-3" />
-                </div>
-              )}
-              <span className="text-2xl">{lang.flag}</span>
-              <span className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</span>
-              <span className="text-xs text-surface-400">{lang.nativeName}</span>
+              <X className="h-4 w-4" />
             </button>
-          )
-        })}
-      </div>
-
-      {/* Options */}
-      <Card>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-surface-900 dark:text-white">립싱크</span>
-              <Tooltip content="AI가 더빙 오디오에 맞춰 입 모양을 조절합니다. 실사 영상에 최적화.">
-                <span className="cursor-help text-xs text-surface-400">(?)</span>
-              </Tooltip>
-            </div>
-            <p className="text-xs text-surface-500 mt-0.5">언어당 크레딧 50% 추가</p>
-          </div>
-          <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
+          )}
         </div>
 
-        <div className="mt-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+        {!query && (
+          <div className="flex flex-wrap gap-2">
+            {REGION_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setRegion(tab.id)}
+                className={cn(
+                  'rounded-full px-3 py-1 text-sm font-medium transition',
+                  region === tab.id
+                    ? 'bg-brand-500 text-white'
+                    : 'bg-surface-100 text-surface-700 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700',
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Language grid */}
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-sm text-surface-500">
+          검색 결과가 없습니다
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+          {filtered.map((lang) => {
+            const isSelected = selectedLanguages.includes(lang.code)
+            return (
+              <button
+                key={lang.code}
+                onClick={() => toggleLanguage(lang.code)}
+                className={cn(
+                  'relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-all cursor-pointer',
+                  isSelected
+                    ? 'border-brand-500 bg-brand-50 shadow-md shadow-brand-500/10 dark:bg-brand-900/20'
+                    : 'border-surface-200 bg-white hover:border-surface-300 dark:border-surface-800 dark:bg-surface-900 dark:hover:border-surface-700',
+                )}
+              >
+                {isSelected && (
+                  <div className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-brand-500 text-white">
+                    <Check className="h-3 w-3" />
+                  </div>
+                )}
+                <span className="text-2xl">{lang.flag}</span>
+                <span className="text-sm font-medium text-surface-900 dark:text-white">{lang.name}</span>
+                <span className="text-xs text-surface-400">{lang.nativeName}</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Dub options */}
+      <Card>
+        <p className="mb-3 text-sm font-semibold text-surface-900 dark:text-white">더빙 옵션</p>
+        {lipSyncApplicable && (
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-surface-900 dark:text-white">립싱크</span>
+                <Tooltip content="AI가 더빙 오디오에 맞춰 입 모양을 조절합니다. 실사 영상에 최적화.">
+                  <span className="cursor-help text-xs text-surface-400">(?)</span>
+                </Tooltip>
+              </div>
+              <p className="text-xs text-surface-500 mt-0.5">언어당 크레딧 50% 추가</p>
+            </div>
+            <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
+          </div>
+        )}
+
+        <div className={cn('rounded-lg bg-surface-50 p-3 dark:bg-surface-800', lipSyncApplicable && 'mt-4')}>
           <div className="flex items-center justify-between text-sm">
             <span className="text-surface-600 dark:text-surface-400">예상 크레딧</span>
             <span className="font-bold text-surface-900 dark:text-white">{estimatedCredits} 크레딧</span>
@@ -109,7 +196,7 @@ export function LanguageSelectStep() {
           이전
         </Button>
         <Button onClick={nextStep} disabled={selectedLanguages.length === 0}>
-          다음: 설정 확인
+          {deliverableMode === 'downloadOnly' ? '다음: 번역 확인' : '다음: 업로드 설정'}
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -29,14 +29,14 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '기존 영상에 자막 추가',
-      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다. 오디오 트랙도 선택 가능합니다.',
+      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다.',
     })
   } else if (sourceType === 'upload') {
     options.push({
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '원본 업로드 + 자막 추가',
-      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다. 오디오 트랙도 선택 가능합니다.',
+      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다.',
     })
   }
 
@@ -128,7 +128,7 @@ export function OutputModeStep() {
           이전
         </Button>
         <Button onClick={nextStep}>
-          {deliverableMode === 'downloadOnly' ? '다음: 설정 확인' : '다음: 업로드 설정'}
+          다음: 언어 선택
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -42,7 +42,7 @@ function getProgressLabel(lp: { progressReason: string; progress: number }) {
 }
 
 export function ProcessingStep() {
-  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted } = useDubbingStore()
+  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted, deliverableMode } = useDubbingStore()
   const { submitDubbing, startPolling, stopPolling, cancelAll } = usePersoFlow()
   const [cancelling, setCancelling] = useState(false)
   const submittedRef = useRef(isSubmitted)
@@ -94,7 +94,9 @@ export function ProcessingStep() {
         <p className="mt-1 text-surface-500">
           {allCompleted
             ? '모든 언어 처리가 완료되었습니다.'
-            : 'Perso.ai가 전사, 번역, 더빙 오디오를 생성하고 있습니다. 몇 분 정도 소요됩니다.'}
+            : deliverableMode === 'originalWithMultiAudio'
+              ? 'AI가 전사, 번역, 자막 생성을 진행하고 있습니다.'
+              : 'AI가 전사, 번역, 더빙 오디오를 생성하고 있습니다. 몇 분 정도 소요됩니다.'}
         </p>
       </div>
 

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -102,18 +102,20 @@ export function TranslationEditStep() {
               ))}
             </div>
             <p className="mt-2 text-xs text-surface-400">
-              영상에 등장하는 화자 수를 선택하세요. 정확하게 설정하면 Perso AI가 화자별로 음성을 분리해 더빙합니다.
+              영상에 등장하는 화자 수를 선택하세요.
             </p>
           </div>
 
-          {/* Lip sync */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <div>
-              <span className="text-sm text-surface-600 dark:text-surface-400">립싱크</span>
-              <p className="text-xs text-surface-400 mt-0.5">더빙 오디오에 맞춰 입 모양을 조절합니다</p>
+          {/* Lip sync — 원본+자막 모드는 비디오 픽셀을 건드리지 않으므로 미노출 */}
+          {deliverableMode !== 'originalWithMultiAudio' && (
+            <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+              <div>
+                <span className="text-sm text-surface-600 dark:text-surface-400">립싱크</span>
+                <p className="text-xs text-surface-400 mt-0.5">더빙 오디오에 맞춰 입 모양을 조절합니다</p>
+              </div>
+              <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
             </div>
-            <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
-          </div>
+          )}
 
           {/* Deliverable mode */}
           <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
@@ -144,7 +146,9 @@ export function TranslationEditStep() {
         <div>
           <p className="text-sm font-medium text-blue-900 dark:text-blue-300">처리 과정</p>
           <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
-            Perso.ai가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 오디오를 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 보통 3-10분입니다.
+            {deliverableMode === 'originalWithMultiAudio'
+              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
+              : 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 영상을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'}
           </p>
         </div>
       </Card>

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -147,7 +147,7 @@ export function TranslationEditStep() {
           <p className="text-sm font-medium text-blue-900 dark:text-blue-300">처리 과정</p>
           <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
             {deliverableMode === 'originalWithMultiAudio'
-              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
+              ? 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 자막을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'
               : 'AI가 자동으로 영상을 전사하고, 선택한 모든 언어로 번역한 뒤, 보이스 클론으로 더빙 영상을 생성합니다. 처리 완료 후 번역을 수정할 수 있습니다. 처리 시간은 영상 길이에 따라 달라집니다.'}
           </p>
         </div>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
@@ -46,16 +46,23 @@ export function UploadSettingsStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
+  // 영상 정보로 제목/설명을 초기 1회 채워준다. 사용자가 빈 값으로 지웠을 때
+  // 다시 채워 넣지 않도록 videoMeta.id 단위로 한 번만 실행. (deps에 입력값을
+  // 넣으면 사용자가 지울 때마다 재초기화돼 빈 값이 유지되지 않는다.)
+  const initializedForVideoIdRef = useRef<string | null>(null)
   useEffect(() => {
+    if (!videoMeta?.title) return
+    if (initializedForVideoIdRef.current === videoMeta.id) return
+    initializedForVideoIdRef.current = videoMeta.id
+
+    const { title, description } = useDubbingStore.getState().uploadSettings
     const patch: Partial<typeof uploadSettings> = {}
-    if (!uploadSettings.title && videoMeta?.title) {
-      patch.title = videoMeta.title
-    }
-    if (!uploadSettings.description && videoMeta?.title) {
+    if (!title) patch.title = videoMeta.title
+    if (!description) {
       patch.description = `${videoMeta.title} - Dubtube AI 더빙\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
     }
     if (Object.keys(patch).length > 0) setUploadSettings(patch)
-  }, [videoMeta?.title, uploadSettings.title, uploadSettings.description, setUploadSettings])
+  }, [videoMeta?.id, videoMeta?.title, setUploadSettings])
 
   const firstLangName = useMemo(() => {
     const first = selectedLanguages[0]
@@ -230,11 +237,11 @@ export function UploadSettingsStep() {
             (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')) && (
             <ToggleRow
               icon={<Zap className="h-4 w-4 text-brand-500" />}
-              label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
-              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다."
+              label={isShort ? 'Shorts 해시태그 붙이기 (자동 감지됨)' : 'Shorts 해시태그 붙이기'}
+              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다. 최종 Shorts 분류는 영상 비율·길이에 따라 YouTube가 결정합니다."
               active={uploadSettings.uploadAsShort}
-              activeLabel="Shorts ON"
-              inactiveLabel="Shorts OFF"
+              activeLabel="ON"
+              inactiveLabel="OFF"
               onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
             />
           )}

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
-import { getLanguageByCode } from '@/utils/languages'
+import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
@@ -13,6 +13,11 @@ const PRIVACY_OPTIONS: { value: PrivacyStatus; label: string }[] = [
   { value: 'unlisted', label: '일부 공개' },
   { value: 'public', label: '공개' },
 ]
+
+const LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((l) => ({
+  value: l.code,
+  label: `${l.flag} ${l.name} (${l.nativeName})`,
+}))
 
 export function UploadSettingsStep() {
   const {
@@ -24,14 +29,16 @@ export function UploadSettingsStep() {
     uploadSettings,
     setUploadSettings,
     syncPrivacyFromGlobalDefault,
+    syncMetadataLanguageFromGlobalDefault,
     prevStep,
     nextStep,
   } = useDubbingStore()
 
-  // YouTube 설정 페이지의 기본 공개 설정과 동기화 (사용자 override 없을 때만).
+  // YouTube 설정 페이지의 기본값과 동기화 (사용자 override 없을 때만).
   useEffect(() => {
     syncPrivacyFromGlobalDefault()
-  }, [syncPrivacyFromGlobalDefault])
+    syncMetadataLanguageFromGlobalDefault()
+  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault])
 
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null
@@ -100,8 +107,20 @@ export function UploadSettingsStep() {
       {deliverableMode === 'newDubbedVideos' && (
         <Card>
           <CardTitle>제목 · 설명 · 태그</CardTitle>
-          <p className="mt-1 mb-4 text-xs text-surface-500">각 언어별로 제목 앞에 [언어명]이 자동 추가됩니다.</p>
+          <p className="mt-1 mb-4 text-xs text-surface-500">
+            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 각 대상 언어로 자동 번역되어 업로드됩니다.
+          </p>
           <div className="space-y-4">
+            <Select
+              label="제목·설명 작성 언어"
+              value={uploadSettings.metadataLanguage}
+              onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
+              options={LANGUAGE_OPTIONS}
+            />
+            <p className="-mt-2 text-xs text-surface-400">
+              마이페이지의 기본 작성 언어를 따르며, 여기에서 더빙별로 변경할 수 있습니다.
+            </p>
+
             <Input
               label="제목 (공통)"
               value={uploadSettings.title}
@@ -148,9 +167,16 @@ export function UploadSettingsStep() {
         <Card>
           <CardTitle>원본 영상 업로드 설정</CardTitle>
           <p className="mt-1 mb-4 text-xs text-surface-500">
-            원본 영상이 YouTube에 먼저 업로드된 후, 더빙 오디오 트랙이 자동 추가됩니다.
+            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 선택한 대상 언어로 자동 번역되어 YouTube `localizations`에 함께 등록됩니다.
           </p>
           <div className="space-y-4">
+            <Select
+              label="제목·설명 작성 언어"
+              value={uploadSettings.metadataLanguage}
+              onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
+              options={LANGUAGE_OPTIONS}
+            />
+
             <Input
               label="제목"
               value={uploadSettings.title}

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo } from 'react'
-import { ArrowLeft, ArrowRight, Link2, Upload, Zap } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
 import { getLanguageByCode } from '@/utils/languages'
@@ -91,7 +91,7 @@ export function UploadSettingsStep() {
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">업로드 설정</h2>
         <p className="mt-1 text-surface-500">
           {isMultiAudio
-            ? '원본 영상에 오디오 트랙을 추가합니다. 기본 설정을 확인하세요.'
+            ? '원본 영상에 자막을 추가합니다. 기본 설정을 확인하세요.'
             : '처리 완료 후 YouTube에 어떻게 업로드할지 미리 설정하세요.'}
         </p>
       </div>
@@ -198,7 +198,10 @@ export function UploadSettingsStep() {
             onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
           />
 
-          {deliverableMode === 'newDubbedVideos' && (
+          {/* Shorts 토글: 새로 영상을 YouTube에 올리는 케이스에만 노출.
+              channel 모드는 이미 업로드된 영상이라 Shorts 분류가 고정됨. */}
+          {(deliverableMode === 'newDubbedVideos' ||
+            (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')) && (
             <ToggleRow
               icon={<Zap className="h-4 w-4 text-brand-500" />}
               label={isShort ? 'Shorts로 업로드 (자동 감지됨)' : 'Shorts로 업로드'}
@@ -219,6 +222,20 @@ export function UploadSettingsStep() {
               activeLabel="첨부 ON"
               inactiveLabel="첨부 OFF"
               onToggle={() => setUploadSettings({ attachOriginalLink: !uploadSettings.attachOriginalLink })}
+            />
+          )}
+
+          {/* 다국어 오디오 트랙: 자막 모드에서만 노출. 실서비스 검증 전이라 비활성. */}
+          {isMultiAudio && (
+            <ToggleRow
+              icon={<Languages className="h-4 w-4 text-surface-400" />}
+              label="다국어 오디오 트랙 추가"
+              description="번역된 더빙 오디오를 YouTube 다국어 오디오 트랙으로 함께 추가합니다. 추후 기능이 추가될 예정입니다."
+              active={false}
+              activeLabel="ON"
+              inactiveLabel="준비 중"
+              onToggle={() => {}}
+              disabled
             />
           )}
         </div>
@@ -263,27 +280,38 @@ interface ToggleRowProps {
   activeLabel: string
   inactiveLabel: string
   onToggle: () => void
+  disabled?: boolean
 }
 
-function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle }: ToggleRowProps) {
+function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle, disabled }: ToggleRowProps) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
+    <div className={`flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 ${disabled ? 'opacity-60' : ''}`}>
       <div className="flex min-w-0 items-start gap-2">
         <div className="mt-0.5 flex-shrink-0">{icon}</div>
         <div className="min-w-0">
-          <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
+            {disabled && (
+              <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                준비 중
+              </span>
+            )}
+          </div>
           {description && (
-            <p className="mt-0.5 truncate text-xs text-surface-400">{description}</p>
+            <p className={`mt-0.5 text-xs text-surface-400 ${disabled ? '' : 'truncate'}`}>{description}</p>
           )}
         </div>
       </div>
       <button
         type="button"
-        onClick={onToggle}
-        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all cursor-pointer ${
-          active
-            ? 'bg-brand-500 text-white'
-            : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'
+        onClick={disabled ? undefined : onToggle}
+        disabled={disabled}
+        className={`flex-shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-all ${
+          disabled
+            ? 'bg-surface-200 text-surface-400 dark:bg-surface-700 dark:text-surface-500 cursor-not-allowed'
+            : `cursor-pointer ${active
+              ? 'bg-brand-500 text-white'
+              : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-400'}`
         }`}
       >
         {active ? activeLabel : inactiveLabel}

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -15,6 +15,8 @@ import {
   ytUploadCaption,
   getPersoFileUrl,
   getTranslatedSrt,
+  translateMetadata,
+  type MetadataTranslation,
 } from '@/lib/api-client'
 import { toBcp47 } from '@/utils/languages'
 import { dbMutation } from '@/lib/api/dbMutation'
@@ -47,7 +49,7 @@ export function UploadStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
-  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus } = uploadSettings
+  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus, metadataLanguage } = uploadSettings
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
@@ -57,6 +59,56 @@ export function UploadStep() {
   const autoUploadTriggered = useRef(false)
   const autoChainTriggered = useRef(false)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  // ─── Metadata translations (Gemini) ─────────────────────────────────
+  // Upload Step에 진입한 시점의 (title, description, metadataLanguage, selectedLanguages) 조합으로
+  // 한 번 번역해두고 캐시. 모든 언어별 업로드와 localizations에서 공용으로 쓴다.
+  // 실패해도 fallback으로 원문이 들어가도록 처리되어 업로드를 막지 않는다.
+  const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
+  const translatePromiseRef = useRef<Promise<Record<string, MetadataTranslation>> | null>(null)
+  const ensureTranslations = useCallback(async (): Promise<Record<string, MetadataTranslation>> => {
+    if (Object.keys(translations).length > 0) return translations
+    if (translatePromiseRef.current) return translatePromiseRef.current
+
+    const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
+    if (!baseTitle || selectedLanguages.length === 0) return {}
+
+    const p = (async () => {
+      try {
+        const result = await translateMetadata({
+          title: baseTitle,
+          description: settingsDescription || '',
+          sourceLang: metadataLanguage || 'ko',
+          targetLangs: selectedLanguages,
+        })
+        setTranslations(result)
+        return result
+      } catch (err) {
+        // 실패 시 모든 언어를 원문으로 fallback. 사용자에게는 toast로 1회 안내.
+        const fallback: Record<string, MetadataTranslation> = {}
+        for (const code of selectedLanguages) {
+          fallback[code] = { title: baseTitle, description: settingsDescription || '' }
+        }
+        setTranslations(fallback)
+        addToast({
+          type: 'warning',
+          title: '메타데이터 번역 실패',
+          message: err instanceof Error ? err.message : '원문으로 업로드합니다',
+        })
+        return fallback
+      } finally {
+        translatePromiseRef.current = null
+      }
+    })()
+    translatePromiseRef.current = p
+    return p
+  }, [translations, settingsTitle, videoMeta?.title, settingsDescription, metadataLanguage, selectedLanguages, addToast])
+
+  // 사용자가 제목/설명을 다시 만지면 캐시 무효화.
+  useEffect(() => {
+    setTranslations({})
+    translatePromiseRef.current = null
+  }, [settingsTitle, settingsDescription, metadataLanguage])
 
   // Original video upload state (for upload + originalWithMultiAudio)
   const [originalUploadState, setOriginalUploadState] = useState<{
@@ -69,17 +121,25 @@ export function UploadStep() {
   const multiAudioVideoId =
     originalUploadState.videoId || channelVideoId || null
 
+  /** 번역되었거나 원문인 description에 공통 footer(원본 링크)를 붙여 준다. */
+  const applyDescriptionFooter = useCallback(
+    (desc: string) => {
+      if (attachOriginalLink && originalYouTubeUrl) {
+        return `${desc}\n\n원본 영상: ${originalYouTubeUrl}`
+      }
+      return desc
+    },
+    [attachOriginalLink, originalYouTubeUrl],
+  )
+
   const buildDescription = useCallback(
     (langName: string) => {
       const base = settingsDescription?.trim()
         ? settingsDescription
         : `${videoMeta?.title || 'Video'} - ${langName} 더빙 by Dubtube AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
-      if (attachOriginalLink && originalYouTubeUrl) {
-        return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
-      }
-      return base
+      return applyDescriptionFooter(base)
     },
-    [settingsDescription, videoMeta?.title, attachOriginalLink, originalYouTubeUrl],
+    [settingsDescription, videoMeta?.title, applyDescriptionFooter],
   )
 
   const handleNewDubbing = () => reset()
@@ -91,12 +151,23 @@ export function UploadStep() {
 
     setOriginalUploadState({ status: 'uploading' })
     try {
+      // 다국어 자막 모드는 영상 1개에 localizations 맵을 함께 보내 YouTube가 시청자
+      // 로케일에 맞춰 제목·설명을 보여주도록 한다.
+      const allTranslations = await ensureTranslations()
+      const localizations: Record<string, { title: string; description: string }> = {}
+      for (const code of selectedLanguages) {
+        const t = allTranslations[code]
+        if (t) localizations[code] = { title: t.title, description: t.description }
+      }
+
       const result = await ytUploadVideo({
         videoUrl: originalVideoUrl,
         title: settingsTitle?.trim() || videoMeta?.title || 'Original Video',
         description: settingsDescription || '',
         tags: settingsTags,
         privacyStatus,
+        language: metadataLanguage,
+        localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
       setOriginalUploadState({ status: 'done', videoId: result.videoId })
       addToast({
@@ -111,7 +182,7 @@ export function UploadStep() {
       addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
       return null
     }
-  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast])
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
 
   // ─── Audio → Studio helper ──────────────────────────────────────────
   const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {
@@ -217,8 +288,13 @@ export function UploadStep() {
 
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
+
+      // 번역된 제목·설명을 가져와 그 언어 영상의 메타로 사용한다.
+      const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
+      const ytTitle = `${titlePrefix}${translated.title}`
+      const ytDescription = applyDescriptionFooter(translated.description)
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
@@ -227,7 +303,7 @@ export function UploadStep() {
       const result = await ytUploadVideo({
         videoUrl,
         title: ytTitle,
-        description: buildDescription(lang.name),
+        description: ytDescription,
         tags: langTags,
         privacyStatus,
         language: langCode,
@@ -292,7 +368,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsTags, privacyStatus, buildDescription, projectMap, spaceSeq])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsDescription, settingsTags, privacyStatus, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
 
   // ─── Queue upload (background — survives tab close) ─────────────────
   const queueYouTubeUpload = useCallback(async (langCode: string) => {
@@ -310,8 +386,10 @@ export function UploadStep() {
       const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
       const titlePrefix = uploadAsShort ? '#Shorts ' : ''
+      const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const ytTitle = `${titlePrefix}[${lang.name}] ${baseTitle}`
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
+      const ytTitle = `${titlePrefix}${translated.title}`
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
@@ -326,7 +404,7 @@ export function UploadStep() {
           langCode,
           videoUrl,
           title: ytTitle,
-          description: buildDescription(lang.name),
+          description: applyDescriptionFooter(translated.description),
           tags: langTags,
           privacyStatus,
           language: langCode,
@@ -351,7 +429,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 큐 등록 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsTags, privacyStatus, buildDescription])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsDescription, settingsTags, privacyStatus, ensureTranslations, applyDescriptionFooter])
 
   const completedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -348,7 +348,7 @@ export function VideoInputStep() {
 
       <div className="flex justify-end">
         <Button onClick={nextStep} disabled={!videoMeta || loading}>
-          다음: 언어 선택
+          다음: 결과물 선택
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
-import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap, Loader2 } from 'lucide-react'
+import { Link2, Upload, Film, ArrowRight, Play, FileVideo, Zap, Loader2, Search, Lock, Info } from 'lucide-react'
 
 function YouTubeLogo({ className }: { className?: string }) {
   return (
@@ -34,7 +34,19 @@ export function VideoInputStep() {
 
   const { data: channel, isLoading: channelLoading } = useChannelStats()
   const isConnected = !!channel
-  const { data: myVideos = [], isLoading: myVideosLoading } = useMyVideos(10)
+  const { data: myVideos = [], isLoading: myVideosLoading } = useMyVideos(50)
+  const [videoSearch, setVideoSearch] = useState('')
+
+  const publicVideos = useMemo(
+    () => myVideos.filter((v) => v.privacyStatus === 'public'),
+    [myVideos],
+  )
+  const filteredVideos = useMemo(() => {
+    const q = videoSearch.trim().toLowerCase()
+    if (!q) return publicVideos
+    return publicVideos.filter((v) => v.title.toLowerCase().includes(q))
+  }, [publicVideos, videoSearch])
+  const hiddenCount = myVideos.length - publicVideos.length
 
   const handleMyVideoSelect = async (videoId: string) => {
     const videoUrl = `https://www.youtube.com/watch?v=${videoId}`
@@ -110,7 +122,10 @@ export function VideoInputStep() {
         <p className="mt-1 text-surface-500">YouTube URL을 붙여넣거나 영상 파일을 업로드하세요</p>
       </div>
 
-      <Tabs defaultValue={searchParams.get('url') ? 'url' : 'upload'}>
+      <Tabs
+        defaultValue={searchParams.get('url') ? 'url' : 'upload'}
+        onChange={() => setError(null)}
+      >
         <TabsList className="mx-auto w-fit">
           <TabsTrigger value="upload">
             <span className="flex items-center gap-1.5"><Upload className="h-4 w-4" /> 업로드</span>
@@ -125,6 +140,10 @@ export function VideoInputStep() {
 
         <TabsContent value="url" className="mt-6">
           <Card>
+            <div className="mb-3 flex items-start gap-2 rounded-lg bg-blue-50 p-2.5 text-xs text-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+              <Info className="h-4 w-4 shrink-0 mt-0.5" />
+              <p>공개 영상만 가져올 수 있습니다. 비공개·일부공개 영상은 외부 다운로드가 막혀 있어 가져올 수 없으니, YouTube에서 공개로 변경하거나 영상 파일을 직접 업로드해 주세요.</p>
+            </div>
             <div className="flex gap-2">
               <Input
                 placeholder="YouTube URL 또는 영상 직접 링크 (.mp4, .mov, .webm)"
@@ -211,48 +230,78 @@ export function VideoInputStep() {
               <Film className="mx-auto h-10 w-10 text-surface-400" />
               <p className="mt-3 text-sm text-surface-500">채널에 업로드된 영상이 없습니다</p>
             </Card>
+          ) : publicVideos.length === 0 ? (
+            <Card className="py-12 text-center">
+              <Lock className="mx-auto h-10 w-10 text-surface-400" />
+              <p className="mt-3 text-sm text-surface-500">공개된 영상이 없습니다</p>
+              <p className="mt-1 text-xs text-surface-400">
+                비공개·일부공개 영상은 외부 다운로드가 막혀 가져올 수 없습니다.<br />
+                YouTube에서 공개로 변경하거나 영상 파일을 직접 업로드해 주세요.
+              </p>
+            </Card>
           ) : (
             <Card>
-              <div className="space-y-2">
-                {myVideos.map((video) => (
-                  <div
-                    key={video.videoId}
-                    className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
-                  >
-                    <div className="flex items-center gap-3 min-w-0 flex-1">
-                      {video.thumbnail ? (
-                        <Image
-                          src={video.thumbnail}
-                          alt={video.title}
-                          width={64}
-                          height={36}
-                          className="rounded object-cover shrink-0"
-                        />
-                      ) : (
-                        <div className="flex h-9 w-16 shrink-0 items-center justify-center rounded bg-surface-100 dark:bg-surface-800">
-                          <YouTubeLogo className="h-5 w-7" />
-                        </div>
-                      )}
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
-                        <p className="text-xs text-surface-500">
-                          {new Date(video.publishedAt).toLocaleDateString('ko-KR')}
-                        </p>
-                      </div>
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="shrink-0 ml-3"
-                      loading={loading}
-                      disabled={loading}
-                      onClick={() => handleMyVideoSelect(video.videoId)}
-                    >
-                      선택
-                    </Button>
-                  </div>
-                ))}
+              <div className="relative mb-3">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" />
+                <input
+                  type="text"
+                  value={videoSearch}
+                  onChange={(e) => setVideoSearch(e.target.value)}
+                  placeholder="영상 제목으로 검색"
+                  className="w-full rounded-md border border-surface-300 bg-white py-2 pl-9 pr-3 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-900 dark:text-white"
+                />
               </div>
+
+              <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
+                {filteredVideos.length === 0 ? (
+                  <p className="py-8 text-center text-sm text-surface-500">검색 결과가 없습니다</p>
+                ) : (
+                  filteredVideos.map((video) => (
+                    <div
+                      key={video.videoId}
+                      className="flex items-center justify-between rounded-lg border border-surface-200 p-3 transition-colors hover:bg-surface-50 dark:border-surface-800 dark:hover:bg-surface-800/50"
+                    >
+                      <div className="flex items-center gap-3 min-w-0 flex-1">
+                        {video.thumbnail ? (
+                          <Image
+                            src={video.thumbnail}
+                            alt={video.title}
+                            width={64}
+                            height={36}
+                            className="rounded object-cover shrink-0"
+                          />
+                        ) : (
+                          <div className="flex h-9 w-16 shrink-0 items-center justify-center rounded bg-surface-100 dark:bg-surface-800">
+                            <YouTubeLogo className="h-5 w-7" />
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-surface-900 dark:text-white">{video.title}</p>
+                          <p className="text-xs text-surface-500">
+                            {new Date(video.publishedAt).toLocaleDateString('ko-KR')}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 ml-3"
+                        loading={loading}
+                        disabled={loading}
+                        onClick={() => handleMyVideoSelect(video.videoId)}
+                      >
+                        선택
+                      </Button>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {hiddenCount > 0 && !videoSearch && (
+                <p className="mt-3 text-xs text-surface-400">
+                  비공개·일부공개 영상 {hiddenCount}개는 외부 다운로드가 막혀 표시되지 않습니다.
+                </p>
+              )}
               {error && !loading && (
                 <p className="mt-3 text-sm text-red-500">{error}</p>
               )}

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -24,7 +24,6 @@ const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
 const POLL_BACKOFF = 1.5          // 매 폴링마다 1.5배씩 증가
 const POLL_FINALIZING = 2_000     // 100%인데 COMPLETED 아직 안 온 경우 빠르게 재확인
-const AUTO_CANCEL_TIMEOUT = 15 * 60_000 // 15분 경과 시 자동 취소
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -236,7 +235,6 @@ async function cancelAllProjects(
 export function usePersoFlow() {
   const addToast = useNotificationStore((s) => s.addToast)
   const pollTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
-  const timeoutTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const initSpace = useCallback(async () => {
     try {
@@ -404,13 +402,6 @@ export function usePersoFlow() {
 
     Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
-    if (timeoutTimer.current) clearTimeout(timeoutTimer.current)
-
-    timeoutTimer.current = setTimeout(() => {
-      Object.values(pollTimers.current).forEach(clearTimeout)
-      pollTimers.current = {}
-      cancelAllProjects(addToast, '15분 초과 — 자동 취소됨')
-    }, AUTO_CANCEL_TIMEOUT)
 
     function scheduleNext(langCode: string, projectSeq: number, interval: number) {
       pollTimers.current[langCode] = setTimeout(async () => {
@@ -436,10 +427,6 @@ export function usePersoFlow() {
   const stopPolling = useCallback(() => {
     Object.values(pollTimers.current).forEach(clearTimeout)
     pollTimers.current = {}
-    if (timeoutTimer.current) {
-      clearTimeout(timeoutTimer.current)
-      timeoutTimer.current = null
-    }
   }, [])
 
   const cancelAll = useCallback(async () => {

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -117,6 +117,9 @@ interface DubbingState {
   privacyOverridden: boolean
   /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
   metadataLanguageOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 Shorts 토글을 직접 변경했는지 여부.
+   * true이면 videoMeta 갱신 시 자동 감지가 uploadAsShort를 덮어쓰지 않는다. */
+  uploadAsShortOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
@@ -155,6 +158,7 @@ const initialState = {
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
   metadataLanguageOverridden: false,
+  uploadAsShortOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -230,7 +234,10 @@ export const useDubbingStore = create<DubbingState>((set) => ({
   setDbJobId: (id) => set({ dbJobId: id }),
   setIsShort: (v) => set((s) => ({
     isShort: v,
-    uploadSettings: { ...s.uploadSettings, uploadAsShort: v },
+    // 사용자가 토글을 직접 만진 적이 있으면 그 선택을 보존한다.
+    uploadSettings: s.uploadAsShortOverridden
+      ? s.uploadSettings
+      : { ...s.uploadSettings, uploadAsShort: v },
   })),
 
   setDeliverableMode: (mode) => set({ deliverableMode: mode }),
@@ -242,6 +249,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
       patch.privacyStatus !== undefined ? true : s.privacyOverridden,
     metadataLanguageOverridden:
       patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
+    uploadAsShortOverridden:
+      patch.uploadAsShort !== undefined ? true : s.uploadAsShortOverridden,
   })),
 
   syncPrivacyFromGlobalDefault: () => set((s) => {

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -15,14 +15,23 @@ import type {
   PrivacyStatus,
 } from '../types/dubbing.types'
 
-// YouTube 설정 페이지의 기본 공개 설정을 그때그때 가져온다.
-// SSR 단계에서는 localStorage가 없으므로 fallback 'private'.
+// YouTube 설정 페이지의 기본값을 그때그때 가져온다.
+// SSR 단계에서는 localStorage가 없으므로 fallback 사용.
 const readDefaultPrivacy = (): PrivacyStatus => {
   if (typeof window === 'undefined') return 'private'
   try {
     return useYouTubeSettingsStore.getState().defaultPrivacy
   } catch {
     return 'private'
+  }
+}
+
+const readDefaultLanguage = (): string => {
+  if (typeof window === 'undefined') return 'ko'
+  try {
+    return useYouTubeSettingsStore.getState().defaultLanguage
+  } catch {
+    return 'ko'
   }
 }
 
@@ -34,6 +43,7 @@ const buildDefaultUploadSettings = (): UploadSettings => ({
   description: '',
   tags: ['Dubtube', 'AI더빙', 'dubbed'],
   privacyStatus: readDefaultPrivacy(),
+  metadataLanguage: readDefaultLanguage(),
 })
 
 interface DubbingState {
@@ -105,9 +115,12 @@ interface DubbingState {
   /** Wizard 세션 내에서 사용자가 privacyStatus를 직접 변경했는지 여부.
    * true이면 YouTube 설정 페이지의 글로벌 기본값으로 덮어쓰지 않는다. */
   privacyOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
+  metadataLanguageOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
+  syncMetadataLanguageFromGlobalDefault: () => void
 
   // Glossary
   glossary: GlossaryEntry[]
@@ -141,6 +154,7 @@ const initialState = {
   copyrightAcknowledged: false,
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
+  metadataLanguageOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -226,6 +240,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     uploadSettings: { ...s.uploadSettings, ...patch },
     privacyOverridden:
       patch.privacyStatus !== undefined ? true : s.privacyOverridden,
+    metadataLanguageOverridden:
+      patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
   })),
 
   syncPrivacyFromGlobalDefault: () => set((s) => {
@@ -234,6 +250,15 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     if (s.uploadSettings.privacyStatus === next) return s
     return {
       uploadSettings: { ...s.uploadSettings, privacyStatus: next },
+    }
+  }),
+
+  syncMetadataLanguageFromGlobalDefault: () => set((s) => {
+    if (s.metadataLanguageOverridden) return s
+    const next = readDefaultLanguage()
+    if (s.uploadSettings.metadataLanguage === next) return s
+    return {
+      uploadSettings: { ...s.uploadSettings, metadataLanguage: next },
     }
   }),
 

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -12,6 +12,11 @@ export interface UploadSettings {
   description: string
   tags: string[]
   privacyStatus: PrivacyStatus
+  /**
+   * 사용자가 작성한 제목/설명의 언어. 다른 대상 언어로 자동 번역하는 기준.
+   * 마이페이지의 `defaultLanguage`로 초기화되며 더빙별로 override 가능.
+   */
+  metadataLanguage: string
 }
 
 export type JobStatus = 'idle' | 'transcribing' | 'translating' | 'synthesizing' | 'lip-syncing' | 'merging' | 'completed' | 'failed'

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -30,3 +30,4 @@ export {
   ytFetchMyVideos,
   ytFetchAnalytics,
 } from './youtube'
+export { translateMetadata, type MetadataTranslation } from './translate'

--- a/src/lib/api-client/translate.ts
+++ b/src/lib/api-client/translate.ts
@@ -1,0 +1,21 @@
+import { json } from './shared'
+
+export interface MetadataTranslation {
+  title: string
+  description: string
+}
+
+export async function translateMetadata(params: {
+  title: string
+  description: string
+  sourceLang: string
+  targetLangs: string[]
+}): Promise<Record<string, MetadataTranslation>> {
+  const res = await fetch('/api/translate/metadata', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  })
+  const data = await json<{ translations: Record<string, MetadataTranslation> }>(res)
+  return data.translations
+}

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -18,6 +18,8 @@ export async function ytUploadVideo(params: {
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
   language?: string
+  /** BCP-47 language code → { title, description } 맵. snippet.localizations로 전달. */
+  localizations?: Record<string, { title: string; description: string }>
 }): Promise<YouTubeUploadResult> {
   const form = new FormData()
   if (params.videoUrl) {
@@ -31,6 +33,9 @@ export async function ytUploadVideo(params: {
   if (params.categoryId) form.append('categoryId', params.categoryId)
   if (params.privacyStatus) form.append('privacyStatus', params.privacyStatus)
   if (params.language) form.append('language', params.language)
+  if (params.localizations && Object.keys(params.localizations).length > 0) {
+    form.append('localizations', JSON.stringify(params.localizations))
+  }
 
   const res = await fetch(`${YT}/upload`, {
     method: 'POST',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -21,6 +21,7 @@ const serverSchema = z.object({
   TURSO_URL: z.string().min(1, "TURSO_URL is required"),
   TURSO_AUTH_TOKEN: z.string().min(1, "TURSO_AUTH_TOKEN is required"),
   GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
+  GEMINI_API_KEY: z.string().min(1).optional(),
 });
 
 const clientSchema = z.object({
@@ -60,6 +61,7 @@ export function getServerEnv(): ServerEnv {
     TURSO_URL: process.env.TURSO_URL,
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   });
 
   if (!parsed.success) {

--- a/src/lib/translate/gemini.ts
+++ b/src/lib/translate/gemini.ts
@@ -2,8 +2,9 @@ import 'server-only'
 
 import { getServerEnv } from '@/lib/env'
 
+// gemini-2.0-flash는 신규 키로 사용 불가(NOT_FOUND). 2.5 Flash 사용.
 const GEMINI_ENDPOINT =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
 
 export interface MetadataTranslation {
   title: string

--- a/src/lib/translate/gemini.ts
+++ b/src/lib/translate/gemini.ts
@@ -1,0 +1,150 @@
+import 'server-only'
+
+import { getServerEnv } from '@/lib/env'
+
+const GEMINI_ENDPOINT =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+
+export interface MetadataTranslation {
+  title: string
+  description: string
+}
+
+export interface TranslateMetadataInput {
+  /** 사용자가 작성한 원본 제목. */
+  title: string
+  /** 사용자가 작성한 원본 설명. */
+  description: string
+  /** 위 텍스트의 작성 언어 (ISO 639-1, 예: 'ko'). 'auto'가 들어오면 Gemini가 추론. */
+  sourceLang: string
+  /** 번역해야 하는 대상 언어 코드 배열. sourceLang과 동일한 코드는 그대로 통과. */
+  targetLangs: string[]
+}
+
+export class TranslateError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message)
+    this.name = 'TranslateError'
+  }
+}
+
+/**
+ * 한 번의 Gemini 호출로 여러 대상 언어의 제목/설명을 번역해 받는다.
+ * 결과는 { [langCode]: { title, description } } 형태의 plain object.
+ *
+ * 동일 코드(sourceLang)는 번역 없이 원문 그대로 채움 — Gemini round-trip 절약.
+ */
+export async function translateMetadata(
+  input: TranslateMetadataInput,
+): Promise<Record<string, MetadataTranslation>> {
+  const { title, description, sourceLang, targetLangs } = input
+
+  const result: Record<string, MetadataTranslation> = {}
+  const langsToTranslate = targetLangs.filter((l) => l !== sourceLang)
+
+  // sourceLang과 동일한 언어는 번역 없이 통과.
+  for (const code of targetLangs) {
+    if (code === sourceLang) {
+      result[code] = { title, description }
+    }
+  }
+
+  if (langsToTranslate.length === 0) return result
+
+  const env = getServerEnv()
+  if (!env.GEMINI_API_KEY) {
+    throw new TranslateError(
+      'GEMINI_NOT_CONFIGURED',
+      'GEMINI_API_KEY is not set on the server',
+    )
+  }
+
+  const prompt = buildPrompt({
+    title,
+    description,
+    sourceLang,
+    targetLangs: langsToTranslate,
+  })
+
+  const res = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(env.GEMINI_API_KEY)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        temperature: 0.2,
+      },
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TranslateError(
+      'GEMINI_REQUEST_FAILED',
+      `Gemini ${res.status}: ${body.slice(0, 500)}`,
+    )
+  }
+
+  const data = (await res.json()) as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+  }
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text
+  if (!text) {
+    throw new TranslateError('GEMINI_EMPTY_RESPONSE', 'Gemini returned no text')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new TranslateError('GEMINI_INVALID_JSON', `Could not parse: ${text.slice(0, 300)}`)
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new TranslateError('GEMINI_INVALID_SHAPE', 'Response is not an object')
+  }
+
+  for (const code of langsToTranslate) {
+    const entry = (parsed as Record<string, unknown>)[code]
+    if (!entry || typeof entry !== 'object') {
+      // 누락된 언어는 원문 fallback. 이렇게 하면 부분 실패 시에도 업로드는 진행 가능.
+      result[code] = { title, description }
+      continue
+    }
+    const e = entry as { title?: unknown; description?: unknown }
+    result[code] = {
+      title: typeof e.title === 'string' && e.title.trim().length > 0 ? e.title : title,
+      description: typeof e.description === 'string' ? e.description : description,
+    }
+  }
+
+  return result
+}
+
+function buildPrompt(args: {
+  title: string
+  description: string
+  sourceLang: string
+  targetLangs: string[]
+}): string {
+  const sourceHint =
+    args.sourceLang === 'auto'
+      ? 'Detect the source language automatically.'
+      : `The source language is "${args.sourceLang}".`
+
+  return [
+    'You are a YouTube metadata translator for a multilingual creator tool.',
+    'Translate the given title and description into each target language.',
+    'Preserve emojis, hashtags, URLs, @mentions, and line breaks. Keep the tone friendly and SEO-aware.',
+    'Do not add explanations or quotes around the output. Output strict JSON only.',
+    sourceHint,
+    `Target language codes (ISO 639-1 / BCP47-like): ${JSON.stringify(args.targetLangs)}.`,
+    'Respond with a JSON object where each key is a target code and the value is an object with "title" and "description".',
+    'Example shape: {"ja":{"title":"...","description":"..."},"es":{"title":"...","description":"..."}}',
+    '',
+    `INPUT_TITLE: ${args.title}`,
+    'INPUT_DESCRIPTION:',
+    args.description,
+  ].join('\n')
+}

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -40,6 +40,14 @@ export const videosQuerySchema = z.object({
     .pipe(z.number().int().min(1).max(50)),
 })
 
+const localizationsRecordSchema = z.record(
+  z.string().min(1),
+  z.object({
+    title: z.string().min(1).max(2000),
+    description: z.string().max(20000).default(''),
+  }),
+)
+
 export const uploadFormSchema = z.object({
   title: z.string().default(''),
   description: z.string().default(''),
@@ -50,4 +58,16 @@ export const uploadFormSchema = z.object({
   categoryId: z.string().optional(),
   privacyStatus: z.enum(['public', 'unlisted', 'private']).optional(),
   language: z.string().optional(),
+  /** form에서는 JSON 문자열로 전달. */
+  localizations: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (!v) return undefined
+      try {
+        return localizationsRecordSchema.parse(JSON.parse(v))
+      } catch {
+        return undefined
+      }
+    }),
 })

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -135,16 +135,20 @@ describe('fetchChannelStatistics', () => {
 
 describe('fetchMyVideos', () => {
   it('returns mapped video items', async () => {
-    mockFetch.mockResolvedValueOnce(
-      jsonResponse({
-        items: [{
-          id: { videoId: 'v1' },
-          snippet: { title: 'T1', publishedAt: '2026-01-01', thumbnails: { medium: { url: 'http://thumb' } } },
-        }],
-      }),
-    )
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{
+            id: { videoId: 'v1' },
+            snippet: { title: 'T1', publishedAt: '2026-01-01', thumbnails: { medium: { url: 'http://thumb' } } },
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ id: 'v1', status: { privacyStatus: 'public' } }] }),
+      )
     const vids = await fetchMyVideos('tok', 5)
-    expect(vids).toEqual([{ videoId: 'v1', title: 'T1', thumbnail: 'http://thumb', publishedAt: '2026-01-01' }])
+    expect(vids).toEqual([{ videoId: 'v1', title: 'T1', thumbnail: 'http://thumb', publishedAt: '2026-01-01', privacyStatus: 'public' }])
   })
 
   it('returns empty array on non-ok response', async () => {
@@ -157,12 +161,12 @@ describe('fetchMyVideos', () => {
     expect(await fetchMyVideos('tok')).toEqual([])
   })
 
-  it('defaults missing snippet fields to empty strings', async () => {
-    mockFetch.mockResolvedValueOnce(
-      jsonResponse({ items: [{ id: { videoId: 'v1' } }] }),
-    )
+  it('defaults missing snippet fields and unknown privacy', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: { videoId: 'v1' } }] }))
+      .mockResolvedValueOnce(jsonResponse({ items: [] }))
     const vids = await fetchMyVideos('tok')
-    expect(vids).toEqual([{ videoId: 'v1', title: '', thumbnail: '', publishedAt: '' }])
+    expect(vids).toEqual([{ videoId: 'v1', title: '', thumbnail: '', publishedAt: '', privacyStatus: 'unknown' }])
   })
 })
 

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -95,10 +95,43 @@ export async function fetchMyVideos(
     }>
   }
 
-  return (data.items || []).map((item) => ({
+  const base = (data.items || []).map((item) => ({
     videoId: item.id.videoId,
     title: item.snippet?.title || '',
     thumbnail: item.snippet?.thumbnails?.medium?.url || '',
     publishedAt: item.snippet?.publishedAt || '',
   }))
+
+  // search.list는 status를 안 돌려주므로 videos.list로 privacyStatus 보강.
+  const privacyById = await fetchPrivacyStatuses(accessToken, base.map((v) => v.videoId))
+
+  return base.map((v) => ({
+    ...v,
+    privacyStatus: privacyById.get(v.videoId) ?? 'unknown',
+  }))
+}
+
+async function fetchPrivacyStatuses(
+  accessToken: string,
+  videoIds: string[],
+): Promise<Map<string, MyVideoItem['privacyStatus']>> {
+  const result = new Map<string, MyVideoItem['privacyStatus']>()
+  if (videoIds.length === 0) return result
+
+  const res = await fetch(
+    `${YOUTUBE_API_BASE}/youtube/v3/videos?part=status&id=${videoIds.join(',')}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) return result
+
+  const data = (await res.json()) as {
+    items?: Array<{ id: string; status?: { privacyStatus?: string } }>
+  }
+  for (const item of data.items || []) {
+    const p = item.status?.privacyStatus
+    if (p === 'public' || p === 'unlisted' || p === 'private') {
+      result.set(item.id, p)
+    }
+  }
+  return result
 }

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -29,6 +29,7 @@ export interface MyVideoItem {
   title: string
   thumbnail: string
   publishedAt: string
+  privacyStatus: 'public' | 'unlisted' | 'private' | 'unknown'
 }
 
 export interface AnalyticsDailyRow {

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -5,6 +5,11 @@ import { YouTubeError } from '@/lib/youtube/error'
 
 const YOUTUBE_UPLOAD_BASE = 'https://www.googleapis.com/upload/youtube/v3'
 
+export interface YouTubeLocalization {
+  title: string
+  description: string
+}
+
 export interface YouTubeUploadInput {
   accessToken: string
   videoBlob: Blob
@@ -14,6 +19,11 @@ export interface YouTubeUploadInput {
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
   language?: string
+  /**
+   * BCP-47 언어 코드를 키로 한 추가 번역 맵.
+   * snippet.defaultLanguage가 함께 설정돼야 YouTube가 적용한다.
+   */
+  localizations?: Record<string, YouTubeLocalization>
 }
 
 export async function uploadVideoToYouTube(
@@ -28,9 +38,11 @@ export async function uploadVideoToYouTube(
     categoryId = '22',
     privacyStatus = 'private',
     language = 'en',
+    localizations,
   } = input
 
-  const metadata = {
+  const hasLocalizations = !!localizations && Object.keys(localizations).length > 0
+  const metadata: Record<string, unknown> = {
     snippet: {
       title,
       description,
@@ -44,9 +56,14 @@ export async function uploadVideoToYouTube(
       selfDeclaredMadeForKids: false,
     },
   }
+  if (hasLocalizations) {
+    metadata.localizations = localizations
+  }
+  // localizations가 있으면 part에 포함되도록 아래 URL에서 동적으로 합친다.
+  const parts = ['snippet', 'status', ...(hasLocalizations ? ['localizations'] : [])].join(',')
 
   const initRes = await fetch(
-    `${YOUTUBE_UPLOAD_BASE}/videos?uploadType=resumable&part=snippet,status`,
+    `${YOUTUBE_UPLOAD_BASE}/videos?uploadType=resumable&part=${parts}`,
     {
       method: 'POST',
       headers: {

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -7,8 +7,14 @@ import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 interface YouTubeSettingsState {
   defaultPrivacy: PrivacyStatus
   autoSubtitles: boolean
+  /**
+   * 사용자가 제목·설명을 작성할 기본 언어 (perso.ai 코드 기반).
+   * 업로드 시 이 언어로 작성된 텍스트를 기준 삼아 다른 대상 언어로 자동 번역한다.
+   */
+  defaultLanguage: string
   setDefaultPrivacy: (v: PrivacyStatus) => void
   setAutoSubtitles: (v: boolean) => void
+  setDefaultLanguage: (v: string) => void
 }
 
 export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
@@ -16,8 +22,10 @@ export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
     (set) => ({
       defaultPrivacy: 'private',
       autoSubtitles: true,
+      defaultLanguage: 'ko',
       setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
       setAutoSubtitles: (v) => set({ autoSubtitles: v }),
+      setDefaultLanguage: (v) => set({ defaultLanguage: v }),
     }),
     { name: 'dubtube-youtube-settings' },
   ),

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -1,23 +1,61 @@
+export type LanguageRegion = 'popular' | 'asia' | 'europe' | 'middle-east'
+
 export interface Language {
   code: string // Perso API language code
   name: string
   nativeName: string
   flag: string
+  region: LanguageRegion
 }
 
-// Perso.ai uses ISO 639-1 codes
+export const REGION_LABELS: Record<LanguageRegion, string> = {
+  popular: '인기',
+  asia: '아시아',
+  europe: '유럽',
+  'middle-east': '중동',
+}
+
+// Perso.ai supported target languages (sourced from /video-translator/api/v1/languages).
+// Codes are mostly ISO 639-1 with a few exceptions (e.g. `fil` for Filipino).
 export const SUPPORTED_LANGUAGES: Language[] = [
-  { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
-  { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', flag: '🇮🇳' },
-  { code: 'pt', name: 'Portuguese (Brazil)', nativeName: 'Português', flag: '🇧🇷' },
-  { code: 'ja', name: 'Japanese', nativeName: '日本語', flag: '🇯🇵' },
-  { code: 'ko', name: 'Korean', nativeName: '한국어', flag: '🇰🇷' },
-  { code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷' },
-  { code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪' },
-  { code: 'ar', name: 'Arabic', nativeName: 'العربية', flag: '🇸🇦' },
-  { code: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia', flag: '🇮🇩' },
-  { code: 'zh', name: 'Chinese', nativeName: '中文', flag: '🇨🇳' },
-  { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸' },
+  // Popular — 사용 빈도 높은 메이저 언어
+  { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸', region: 'popular' },
+  { code: 'ko', name: 'Korean', nativeName: '한국어', flag: '🇰🇷', region: 'popular' },
+  { code: 'ja', name: 'Japanese', nativeName: '日本語', flag: '🇯🇵', region: 'popular' },
+  { code: 'zh', name: 'Chinese', nativeName: '中文', flag: '🇨🇳', region: 'popular' },
+  { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸', region: 'popular' },
+  { code: 'pt', name: 'Portuguese (Brazil)', nativeName: 'Português', flag: '🇧🇷', region: 'popular' },
+  { code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷', region: 'popular' },
+  { code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪', region: 'popular' },
+  // Asia
+  { code: 'hi', name: 'Hindi', nativeName: 'हिन्दी', flag: '🇮🇳', region: 'asia' },
+  { code: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia', flag: '🇮🇩', region: 'asia' },
+  { code: 'vi', name: 'Vietnamese', nativeName: 'Tiếng Việt', flag: '🇻🇳', region: 'asia' },
+  { code: 'th', name: 'Thai', nativeName: 'ไทย', flag: '🇹🇭', region: 'asia' },
+  { code: 'ms', name: 'Malay', nativeName: 'Bahasa Melayu', flag: '🇲🇾', region: 'asia' },
+  { code: 'fil', name: 'Filipino', nativeName: 'Filipino', flag: '🇵🇭', region: 'asia' },
+  { code: 'ta', name: 'Tamil', nativeName: 'தமிழ்', flag: '🇮🇳', region: 'asia' },
+  { code: 'kk', name: 'Kazakh', nativeName: 'Қазақ тілі', flag: '🇰🇿', region: 'asia' },
+  // Europe
+  { code: 'it', name: 'Italian', nativeName: 'Italiano', flag: '🇮🇹', region: 'europe' },
+  { code: 'nl', name: 'Dutch', nativeName: 'Nederlands', flag: '🇳🇱', region: 'europe' },
+  { code: 'ru', name: 'Russian', nativeName: 'Русский', flag: '🇷🇺', region: 'europe' },
+  { code: 'uk', name: 'Ukrainian', nativeName: 'Українська', flag: '🇺🇦', region: 'europe' },
+  { code: 'pl', name: 'Polish', nativeName: 'Polski', flag: '🇵🇱', region: 'europe' },
+  { code: 'cs', name: 'Czech', nativeName: 'Čeština', flag: '🇨🇿', region: 'europe' },
+  { code: 'sk', name: 'Slovak', nativeName: 'Slovenčina', flag: '🇸🇰', region: 'europe' },
+  { code: 'hu', name: 'Hungarian', nativeName: 'Magyar', flag: '🇭🇺', region: 'europe' },
+  { code: 'ro', name: 'Romanian', nativeName: 'Română', flag: '🇷🇴', region: 'europe' },
+  { code: 'bg', name: 'Bulgarian', nativeName: 'Български', flag: '🇧🇬', region: 'europe' },
+  { code: 'hr', name: 'Croatian', nativeName: 'Hrvatski', flag: '🇭🇷', region: 'europe' },
+  { code: 'el', name: 'Greek', nativeName: 'Ελληνικά', flag: '🇬🇷', region: 'europe' },
+  { code: 'sv', name: 'Swedish', nativeName: 'Svenska', flag: '🇸🇪', region: 'europe' },
+  { code: 'no', name: 'Norwegian', nativeName: 'Norsk', flag: '🇳🇴', region: 'europe' },
+  { code: 'da', name: 'Danish', nativeName: 'Dansk', flag: '🇩🇰', region: 'europe' },
+  { code: 'fi', name: 'Finnish', nativeName: 'Suomi', flag: '🇫🇮', region: 'europe' },
+  { code: 'tr', name: 'Turkish', nativeName: 'Türkçe', flag: '🇹🇷', region: 'europe' },
+  // Middle East
+  { code: 'ar', name: 'Arabic', nativeName: 'العربية', flag: '🇸🇦', region: 'middle-east' },
 ]
 
 export function getLanguageByCode(code: string): Language | undefined {


### PR DESCRIPTION
## Summary
develop에 누적된 변경을 main으로 릴리스.

### 포함된 PR
- #189 fix(dubbing): 15분 자동 취소 타이머 제거 — 다국어 자막 업로드 fail 원인
- #190 chore(deps): npm-minor-and-patch group bump
- #192 feat(dubbing): 위자드 UX 개편 — 다국어 확장, 영상 선택/단계 흐름, 립싱크 컨텍스트 (closes #191)
- #194 feat(dubbing): 업로드 메타데이터 자동 다국어 번역 + YouTube localizations (refs #193)
- #195 chore(dubbing): 처리 중 안내 멘트 정리

### Highlights
- **다국어 지원 확장**: perso 지원 11 → 34개 타깃 언어 노출. 검색·region 탭으로 고르기 쉽게.
- **위자드 흐름 정리**: 영상 → 결과물 → 언어 → 업로드 설정 → 확인 → 처리 → 결과로 step 순서 swap. 결과물 모드에 따라 립싱크/Shorts/자막 흐름 분기.
- **영상 선택 UX**: 비공개·일부공개 영상은 perso 외부 다운로드가 막혀 INVALID_YOUTUBE_URL을 유발하므로 리스트에서 제외. 검색 + 내부 스크롤 + 사전 안내 배너.
- **자동 번역**: Gemini 2.5 Flash로 제목·설명을 선택한 대상 언어로 번역해 함께 업로드. 새 더빙 영상은 언어별 영상에 그 언어 메타가, 자막 모드는 단일 영상에 \`localizations\` 맵이 들어감.
- **기본 작성 언어 설정**: 마이페이지에서 기본 작성 언어 저장, 더빙별로 override 가능.
- **버그 수정**: Shorts 토글이 videoMeta 갱신 시 자동 감지로 덮어써지던 문제, 제목/설명 비웠을 때 자동 재채움, perso의 15분 자동 취소 타이머가 다국어 자막 업로드를 실패시키던 문제.

### 환경 변수
- 신규 \`GEMINI_API_KEY\` (optional). 비어 있어도 자동 번역만 비활성화되고 원문 그대로 업로드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)