### PR TITLE
[codex] Add Toss payments and credit ledger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,9 @@ TURSO_AUTH_TOKEN=
 # Gemini (메타데이터 다국어 번역용 — Gemini Flash REST API)
 GEMINI_API_KEY=
 
+# Toss Payments (국내 KRW 결제)
+TOSS_SECRET_KEY=
+TOSS_API_BASE_URL=https://api.tosspayments.com
+
 # Chrome Extension (chrome://extensions에서 확장 로드 후 ID 확인)
 NEXT_PUBLIC_EXTENSION_ID=

--- a/src/app/(app)/billing/fail/page.tsx
+++ b/src/app/(app)/billing/fail/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+import { XCircle } from 'lucide-react'
+import { Button, Card, CardTitle } from '@/components/ui'
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] ?? null : value ?? null
+}
+
+export default async function BillingFailPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const params = await searchParams
+  const code = getParam(params.code)
+  const message = getParam(params.message)
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <Card>
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-xl bg-red-50 p-3 dark:bg-red-950/30">
+            <XCircle className="h-6 w-6 text-red-500" />
+          </div>
+          <div>
+            <CardTitle>결제가 완료되지 않았습니다</CardTitle>
+            <p className="mt-1 text-sm text-surface-500">
+              {message || '결제가 취소되었거나 실패했습니다.'}
+            </p>
+            {code && <p className="mt-1 text-xs text-surface-400">오류 코드: {code}</p>}
+          </div>
+        </div>
+        <Link href="/billing">
+          <Button>다시 시도하기</Button>
+        </Link>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/billing/page.tsx
+++ b/src/app/(app)/billing/page.tsx
@@ -5,31 +5,36 @@ import { CreditCard, Coins, ArrowRight, Loader2, Check } from 'lucide-react'
 import { Card, CardTitle, Button } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { CREDIT_PACKS } from '@/features/billing/constants/plans'
-import { formatCurrency } from '@/utils/formatters'
+import { formatKrw } from '@/utils/formatters'
 import { useDashboardSummary } from '@/hooks/useDashboardData'
-import { useQueryClient } from '@tanstack/react-query'
-import { useAuthStore } from '@/stores/authStore'
-import { dbMutation } from '@/lib/api/dbMutation'
 
 export default function BillingPage() {
   const [selectedPack, setSelectedPack] = useState<number | null>(null)
   const [isCharging, setIsCharging] = useState(false)
   const [charged, setCharged] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const { data: summary, isLoading } = useDashboardSummary()
-  const queryClient = useQueryClient()
-  const user = useAuthStore((s) => s.user)
 
   const handleCharge = async () => {
-    if (!selectedPack || !user) return
+    if (!selectedPack) return
     setIsCharging(true)
+    setError(null)
     try {
-      await dbMutation({ type: 'addCredits', payload: { userId: user.uid, minutes: selectedPack } })
-      await queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] })
+      const res = await fetch('/api/billing/toss/create-payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minutes: selectedPack }),
+        cache: 'no-store',
+      })
+      const body = await res.json().catch(() => null)
+      if (!body?.ok || !body.data?.checkoutUrl) {
+        throw new Error(body?.error?.message || '결제창 생성에 실패했습니다.')
+      }
       setCharged(true)
-      setTimeout(() => {
-        setCharged(false)
-        setSelectedPack(null)
-      }, 2000)
+      window.location.href = body.data.checkoutUrl
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '결제창 생성에 실패했습니다.')
+      setCharged(false)
     } finally {
       setIsCharging(false)
     }
@@ -62,7 +67,7 @@ export default function BillingPage() {
               )}
             </div>
           </div>
-          <p className="text-sm text-surface-400">1분 = $1</p>
+          <p className="text-sm text-surface-400">국내 결제는 KRW 기준으로 처리됩니다</p>
         </div>
       </Card>
 
@@ -73,7 +78,7 @@ export default function BillingPage() {
           <CardTitle>시간 충전</CardTitle>
         </div>
         <p className="mb-4 text-sm text-surface-500 dark:text-surface-400">
-          1분 더빙 = $1. 만료 없음.
+          충전한 시간은 만료 없이 사용할 수 있습니다.
         </p>
 
         <div className="grid gap-3 sm:grid-cols-4">
@@ -91,11 +96,17 @@ export default function BillingPage() {
               <p className="text-2xl font-bold text-surface-900 dark:text-white">{pack.minutes}분</p>
               <p className="text-xs text-surface-500 mb-2">{pack.label}</p>
               <p className="text-lg font-semibold text-surface-900 dark:text-white">
-                {formatCurrency(pack.price)}
+                {formatKrw(pack.priceKrw)}
               </p>
             </button>
           ))}
         </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+            {error}
+          </div>
+        )}
 
         {selectedPack && (
           <Button className="mt-4" onClick={handleCharge} disabled={isCharging || charged}>
@@ -106,7 +117,7 @@ export default function BillingPage() {
             ) : (
               <CreditCard className="h-4 w-4" />
             )}
-            {charged ? '충전 완료!' : `${selectedPack}분 충전 (${formatCurrency(selectedPack)})`}
+            {charged ? '결제창으로 이동 중...' : `${selectedPack}분 충전`}
             {!isCharging && !charged && <ArrowRight className="h-4 w-4" />}
           </Button>
         )}

--- a/src/app/(app)/billing/success/BillingSuccessClient.tsx
+++ b/src/app/(app)/billing/success/BillingSuccessClient.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Check, Loader2, XCircle } from 'lucide-react'
+import { Button, Card, CardTitle } from '@/components/ui'
+
+interface Props {
+  paymentKey: string | null
+  orderId: string | null
+  amount: string | null
+}
+
+type Status = 'confirming' | 'done' | 'error'
+
+export function BillingSuccessClient({ paymentKey, orderId, amount }: Props) {
+  const hasRequiredParams = Boolean(paymentKey && orderId && amount)
+  const [status, setStatus] = useState<Status>(hasRequiredParams ? 'confirming' : 'error')
+  const [message, setMessage] = useState(
+    hasRequiredParams ? '결제를 승인하고 크레딧을 충전하는 중입니다.' : '결제 승인에 필요한 값이 없습니다.',
+  )
+
+  useEffect(() => {
+    if (!paymentKey || !orderId || !amount) return
+
+    let cancelled = false
+    async function confirm() {
+      try {
+        const res = await fetch('/api/billing/toss/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ paymentKey, orderId, amount }),
+          cache: 'no-store',
+        })
+        const body = await res.json().catch(() => null)
+        if (!body?.ok) {
+          throw new Error(body?.error?.message || '결제 승인에 실패했습니다.')
+        }
+        if (!cancelled) {
+          setStatus('done')
+          setMessage(`${body.data.minutes}분이 충전되었습니다.`)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setStatus('error')
+          setMessage(err instanceof Error ? err.message : '결제 승인에 실패했습니다.')
+        }
+      }
+    }
+
+    confirm()
+    return () => {
+      cancelled = true
+    }
+  }, [paymentKey, orderId, amount])
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <Card>
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-xl bg-surface-100 p-3 dark:bg-surface-800">
+            {status === 'confirming' ? (
+              <Loader2 className="h-6 w-6 animate-spin text-brand-500" />
+            ) : status === 'done' ? (
+              <Check className="h-6 w-6 text-emerald-500" />
+            ) : (
+              <XCircle className="h-6 w-6 text-red-500" />
+            )}
+          </div>
+          <div>
+            <CardTitle>{status === 'done' ? '충전 완료' : status === 'error' ? '결제 확인 실패' : '결제 확인 중'}</CardTitle>
+            <p className="mt-1 text-sm text-surface-500">{message}</p>
+          </div>
+        </div>
+        <Link href="/billing">
+          <Button>결제 페이지로 돌아가기</Button>
+        </Link>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/billing/success/page.tsx
+++ b/src/app/(app)/billing/success/page.tsx
@@ -1,0 +1,20 @@
+import { BillingSuccessClient } from './BillingSuccessClient'
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] ?? null : value ?? null
+}
+
+export default async function BillingSuccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const params = await searchParams
+  return (
+    <BillingSuccessClient
+      paymentKey={getParam(params.paymentKey)}
+      orderId={getParam(params.orderId)}
+      amount={getParam(params.amount)}
+    />
+  )
+}

--- a/src/app/api/billing/toss/confirm/route.ts
+++ b/src/app/api/billing/toss/confirm/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { apiFail, apiFailFromError, apiOk } from '@/lib/api/response'
+import { confirmTossPaymentBodySchema } from '@/lib/validators/billing'
+import {
+  getPaymentOrderByOrderId,
+  grantPaidCredits,
+  updatePaymentOrderStatus,
+} from '@/lib/db/queries'
+import { confirmTossPayment } from '@/lib/toss/client'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = confirmTossPaymentBodySchema.safeParse(await req.json().catch(() => null))
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', parsed.error.issues.map((i) => i.message).join('; '), 400)
+  }
+
+  const { paymentKey, orderId, amount } = parsed.data
+  const order = await getPaymentOrderByOrderId(orderId)
+  if (!order) {
+    return apiFail('ORDER_NOT_FOUND', 'Payment order not found', 404)
+  }
+  if (order.user_id !== auth.session.uid) {
+    return apiFail('FORBIDDEN', 'You do not own this payment order', 403)
+  }
+  if (Number(order.amount) !== amount) {
+    await updatePaymentOrderStatus(orderId, 'amount_mismatch', { paymentKey, amount })
+    return apiFail('AMOUNT_MISMATCH', 'Payment amount does not match the order', 400)
+  }
+  if (order.status === 'paid') {
+    return apiOk({ minutes: Number(order.pack_minutes), alreadyPaid: true })
+  }
+
+  try {
+    const payment = await confirmTossPayment({ paymentKey, orderId, amount })
+    if (payment.status !== 'DONE') {
+      await updatePaymentOrderStatus(orderId, `toss_${payment.status ?? 'unknown'}`, payment)
+      return apiFail('PAYMENT_NOT_DONE', 'Payment has not completed yet', 409, { status: payment.status })
+    }
+
+    const result = await grantPaidCredits({
+      userId: auth.session.uid,
+      orderId,
+      paymentKey,
+      minutes: Number(order.pack_minutes),
+      rawPayment: payment,
+    })
+    return apiOk({ minutes: Number(order.pack_minutes), ...result })
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}

--- a/src/app/api/billing/toss/create-payment/route.ts
+++ b/src/app/api/billing/toss/create-payment/route.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'crypto'
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { apiFail, apiFailFromError, apiOk } from '@/lib/api/response'
+import { getCreditPack } from '@/features/billing/constants/plans'
+import {
+  createPaymentOrder,
+  updatePaymentOrderCheckout,
+  updatePaymentOrderStatus,
+} from '@/lib/db/queries'
+import { createTossPayment } from '@/lib/toss/client'
+import { createTossPaymentBodySchema } from '@/lib/validators/billing'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function createOrderId() {
+  const compactUuid = randomUUID().replace(/-/g, '').slice(0, 20)
+  return `DT-${Date.now()}-${compactUuid}`
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  const parsed = createTossPaymentBodySchema.safeParse(await req.json().catch(() => null))
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', parsed.error.issues.map((i) => i.message).join('; '), 400)
+  }
+
+  const pack = getCreditPack(parsed.data.minutes)
+  if (!pack) {
+    return apiFail('INVALID_CREDIT_PACK', 'Unsupported credit pack', 400)
+  }
+
+  const orderId = createOrderId()
+  const orderName = `Dubtube ${pack.minutes}분 크레딧`
+  const origin = req.nextUrl.origin
+
+  try {
+    await createPaymentOrder({
+      orderId,
+      userId: auth.session.uid,
+      packMinutes: pack.minutes,
+      amount: pack.priceKrw,
+      currency: 'KRW',
+      orderName,
+    })
+
+    const payment = await createTossPayment({
+      amount: pack.priceKrw,
+      orderId,
+      orderName,
+      successUrl: `${origin}/billing/success`,
+      failUrl: `${origin}/billing/fail`,
+      customerEmail: auth.session.email,
+    })
+
+    const checkoutUrl = payment.checkout?.url
+    if (!checkoutUrl) {
+      await updatePaymentOrderStatus(orderId, 'checkout_failed', payment)
+      return apiFail('TOSS_CHECKOUT_URL_MISSING', 'Toss did not return a checkout URL', 502)
+    }
+
+    await updatePaymentOrderCheckout(orderId, checkoutUrl, payment)
+    return apiOk({ checkoutUrl, orderId, amount: pack.priceKrw, minutes: pack.minutes })
+  } catch (err) {
+    await updatePaymentOrderStatus(orderId, 'checkout_failed').catch(() => {})
+    return apiFailFromError(err)
+  }
+}

--- a/src/app/api/billing/toss/toss-routes.test.ts
+++ b/src/app/api/billing/toss/toss-routes.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries', () => ({
+  createPaymentOrder: vi.fn(),
+  updatePaymentOrderCheckout: vi.fn(),
+  updatePaymentOrderStatus: vi.fn(),
+  getPaymentOrderByOrderId: vi.fn(),
+  grantPaidCredits: vi.fn(async () => ({ granted: true, idempotent: false })),
+}))
+
+vi.mock('@/lib/toss/client', () => ({
+  createTossPayment: vi.fn(async () => ({
+    orderId: 'DT-1',
+    orderName: 'Dubtube 10분 크레딧',
+    checkout: { url: 'https://pay.toss.test/checkout' },
+  })),
+  confirmTossPayment: vi.fn(async () => ({
+    paymentKey: 'pay_1',
+    orderId: 'DT-1',
+    orderName: 'Dubtube 10분 크레딧',
+    status: 'DONE',
+  })),
+  retrieveTossPayment: vi.fn(async () => ({
+    paymentKey: 'pay_1',
+    orderId: 'DT-1',
+    orderName: 'Dubtube 10분 크레딧',
+    status: 'DONE',
+    totalAmount: 10000,
+  })),
+}))
+
+import { requireSession } from '@/lib/auth/session'
+import {
+  createPaymentOrder,
+  getPaymentOrderByOrderId,
+  grantPaidCredits,
+  updatePaymentOrderCheckout,
+  updatePaymentOrderStatus,
+} from '@/lib/db/queries'
+import { createTossPayment, confirmTossPayment, retrieveTossPayment } from '@/lib/toss/client'
+
+const mockRequireSession = vi.mocked(requireSession)
+const mockCreatePaymentOrder = vi.mocked(createPaymentOrder)
+const mockUpdatePaymentOrderCheckout = vi.mocked(updatePaymentOrderCheckout)
+const mockUpdatePaymentOrderStatus = vi.mocked(updatePaymentOrderStatus)
+const mockGetPaymentOrderByOrderId = vi.mocked(getPaymentOrderByOrderId)
+const mockGrantPaidCredits = vi.mocked(grantPaidCredits)
+const mockCreateTossPayment = vi.mocked(createTossPayment)
+const mockConfirmTossPayment = vi.mocked(confirmTossPayment)
+const mockRetrieveTossPayment = vi.mocked(retrieveTossPayment)
+
+function auth(uid = 'user1') {
+  mockRequireSession.mockResolvedValueOnce({
+    ok: true,
+    session: { uid, email: `${uid}@example.com` },
+  })
+}
+
+function noAuth() {
+  mockRequireSession.mockResolvedValueOnce({
+    ok: false,
+    response: Response.json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing token' } }, { status: 401 }),
+  })
+}
+
+function order(overrides: Partial<Awaited<ReturnType<typeof getPaymentOrderByOrderId>>> = {}) {
+  return {
+    order_id: 'DT-100',
+    user_id: 'user1',
+    pack_minutes: 10,
+    amount: 10000,
+    currency: 'KRW',
+    status: 'checkout_created',
+    payment_key: null,
+    checkout_url: 'https://pay.toss.test/checkout',
+    order_name: 'Dubtube 10분 크레딧',
+    raw_json: null,
+    ...overrides,
+  }
+}
+
+describe('/api/billing/toss/create-payment', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./create-payment/route'))
+  })
+
+  it('requires an authenticated session', async () => {
+    noAuth()
+    const req = new NextRequest('http://localhost/api/billing/toss/create-payment', {
+      method: 'POST',
+      body: JSON.stringify({ minutes: 10 }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects unsupported credit packs', async () => {
+    auth()
+    const req = new NextRequest('http://localhost/api/billing/toss/create-payment', {
+      method: 'POST',
+      body: JSON.stringify({ minutes: 999 }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    expect(mockCreateTossPayment).not.toHaveBeenCalled()
+  })
+
+  it('creates a Toss checkout and stores the order', async () => {
+    auth()
+    const req = new NextRequest('http://localhost/api/billing/toss/create-payment', {
+      method: 'POST',
+      body: JSON.stringify({ minutes: 10 }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.checkoutUrl).toBe('https://pay.toss.test/checkout')
+    expect(mockCreatePaymentOrder).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user1',
+      packMinutes: 10,
+      amount: 10000,
+      currency: 'KRW',
+    }))
+    expect(mockUpdatePaymentOrderCheckout).toHaveBeenCalled()
+  })
+})
+
+describe('/api/billing/toss/confirm', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./confirm/route'))
+  })
+
+  it('rejects amount mismatches before confirming with Toss', async () => {
+    auth()
+    mockGetPaymentOrderByOrderId.mockResolvedValueOnce(order())
+    const req = new NextRequest('http://localhost/api/billing/toss/confirm', {
+      method: 'POST',
+      body: JSON.stringify({ paymentKey: 'pay_1', orderId: 'DT-100', amount: 1 }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    expect(mockConfirmTossPayment).not.toHaveBeenCalled()
+    expect(mockUpdatePaymentOrderStatus).toHaveBeenCalledWith('DT-100', 'amount_mismatch', expect.anything())
+  })
+
+  it('confirms payment and grants credits idempotently', async () => {
+    auth()
+    mockGetPaymentOrderByOrderId.mockResolvedValueOnce(order())
+    const req = new NextRequest('http://localhost/api/billing/toss/confirm', {
+      method: 'POST',
+      body: JSON.stringify({ paymentKey: 'pay_1', orderId: 'DT-100', amount: 10000 }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.minutes).toBe(10)
+    expect(mockConfirmTossPayment).toHaveBeenCalledWith({ paymentKey: 'pay_1', orderId: 'DT-100', amount: 10000 })
+    expect(mockGrantPaidCredits).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user1',
+      orderId: 'DT-100',
+      paymentKey: 'pay_1',
+      minutes: 10,
+    }))
+  })
+})
+
+describe('/api/billing/toss/webhook', () => {
+  let POST: (req: NextRequest) => Promise<Response>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ;({ POST } = await import('./webhook/route'))
+  })
+
+  it('verifies DONE payments with Toss before granting credits', async () => {
+    mockGetPaymentOrderByOrderId.mockResolvedValueOnce(order())
+    const req = new NextRequest('http://localhost/api/billing/toss/webhook', {
+      method: 'POST',
+      body: JSON.stringify({
+        eventType: 'PAYMENT_STATUS_CHANGED',
+        data: { orderId: 'DT-100', paymentKey: 'pay_1', status: 'DONE' },
+      }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    expect(mockRetrieveTossPayment).toHaveBeenCalledWith('pay_1')
+    expect(mockGrantPaidCredits).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user1',
+      orderId: 'DT-100',
+      minutes: 10,
+    }))
+  })
+})

--- a/src/app/api/billing/toss/webhook/route.ts
+++ b/src/app/api/billing/toss/webhook/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server'
+import { apiFail, apiFailFromError, apiOk } from '@/lib/api/response'
+import { getPaymentOrderByOrderId, grantPaidCredits, updatePaymentOrderStatus } from '@/lib/db/queries'
+import { retrieveTossPayment } from '@/lib/toss/client'
+import { tossWebhookSchema } from '@/lib/validators/billing'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function getString(value: unknown) {
+  return typeof value === 'string' ? value : null
+}
+
+function getNumber(value: unknown) {
+  return typeof value === 'number' ? value : Number(value)
+}
+
+export async function POST(req: NextRequest) {
+  const parsed = tossWebhookSchema.safeParse(await req.json().catch(() => null))
+  if (!parsed.success) {
+    return apiFail('BAD_REQUEST', parsed.error.issues.map((i) => i.message).join('; '), 400)
+  }
+
+  const { eventType, data = {} } = parsed.data
+  if (eventType !== 'PAYMENT_STATUS_CHANGED') {
+    return apiOk({ received: true, ignored: true })
+  }
+
+  const orderId = getString(data.orderId)
+  const paymentKey = getString(data.paymentKey)
+  const status = getString(data.status)
+  if (!orderId || !paymentKey) {
+    return apiOk({ received: true, ignored: true })
+  }
+
+  const order = await getPaymentOrderByOrderId(orderId)
+  if (!order) {
+    return apiOk({ received: true, ignored: true })
+  }
+
+  try {
+    await updatePaymentOrderStatus(orderId, `webhook_${status ?? 'unknown'}`, parsed.data)
+    if (status !== 'DONE') {
+      return apiOk({ received: true, status })
+    }
+
+    const payment = await retrieveTossPayment(paymentKey)
+    const paidAmount = getNumber(payment.totalAmount ?? payment.amount)
+    if (paidAmount !== Number(order.amount) || payment.status !== 'DONE') {
+      await updatePaymentOrderStatus(orderId, 'webhook_verification_failed', payment)
+      return apiOk({ received: true, verified: false })
+    }
+
+    const result = await grantPaidCredits({
+      userId: order.user_id,
+      orderId,
+      paymentKey,
+      minutes: Number(order.pack_minutes),
+      rawPayment: payment,
+    })
+    return apiOk({ received: true, ...result })
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -6,10 +6,13 @@ import {
   updateJobLanguageProgress,
   updateJobLanguageCompleted,
   updateJobStatus,
+  updateJobLanguageProjects,
   createYouTubeUpload,
   updateJobLanguageYouTube,
   deductUserMinutes,
-  addUserCredits,
+  reserveJobCredits,
+  releaseJobCredits,
+  finalizeJobCredits,
   deleteDubbingJob,
   createUploadQueueItem,
 } from '@/lib/db/queries'
@@ -99,6 +102,11 @@ export async function POST(req: NextRequest) {
         await updateJobLanguageYouTube(jobId, langCode, youtubeVideoId)
         return apiOk({ jobId, langCode })
       }
+      case 'updateJobLanguageProjects': {
+        const { jobId, languages } = action.payload
+        await updateJobLanguageProjects(jobId, languages)
+        return apiOk({ jobId })
+      }
       case 'deductUserMinutes': {
         const { userId, jobId: deductJobId, minutes: clientMinutes } = action.payload
         const deductDb = getDb()
@@ -112,10 +120,20 @@ export async function POST(req: NextRequest) {
         await deductUserMinutes(userId, minutes)
         return apiOk({ userId, minutes })
       }
-      case 'addCredits': {
-        const { userId, minutes } = action.payload
-        await addUserCredits(userId, minutes)
-        return apiOk({ userId, minutes })
+      case 'reserveJobCredits': {
+        const { jobId: reserveJobId } = action.payload
+        const result = await reserveJobCredits(auth.session.uid, reserveJobId)
+        return apiOk(result)
+      }
+      case 'releaseJobCredits': {
+        const { jobId: releaseJobId, reason } = action.payload
+        const result = await releaseJobCredits(auth.session.uid, releaseJobId, reason)
+        return apiOk(result)
+      }
+      case 'finalizeJobCredits': {
+        const { jobId: finalizeJobId } = action.payload
+        const result = await finalizeJobCredits(auth.session.uid, finalizeJobId)
+        return apiOk(result)
       }
       case 'queueYouTubeUpload': {
         const id = await createUploadQueueItem(action.payload)

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/lib/youtube/route-helpers', async (importOriginal) => {
         )
       }
     }),
+    withTokenRetry: vi.fn(async (_req: Request, fn: (accessToken: string) => Promise<unknown>) => fn('mock-token')),
     ytOk: vi.fn(),
     ytFail: vi.fn(),
   }

--- a/src/features/billing/constants/plans.ts
+++ b/src/features/billing/constants/plans.ts
@@ -1,12 +1,17 @@
 export interface CreditPack {
   minutes: number
   price: number
+  priceKrw: number
   label: string
 }
 
 export const CREDIT_PACKS: CreditPack[] = [
-  { minutes: 10, price: 10, label: '10분' },
-  { minutes: 30, price: 30, label: '30분' },
-  { minutes: 60, price: 60, label: '1시간' },
-  { minutes: 120, price: 120, label: '2시간' },
+  { minutes: 10, price: 10, priceKrw: 10000, label: '10분' },
+  { minutes: 30, price: 30, priceKrw: 30000, label: '30분' },
+  { minutes: 60, price: 60, priceKrw: 60000, label: '1시간' },
+  { minutes: 120, price: 120, priceKrw: 120000, label: '2시간' },
 ]
+
+export function getCreditPack(minutes: number) {
+  return CREDIT_PACKS.find((pack) => pack.minutes === minutes) ?? null
+}

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, ExternalLink, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
+import { Download, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
@@ -66,12 +66,22 @@ export function UploadStep() {
   // 실패해도 fallback으로 원문이 들어가도록 처리되어 업로드를 막지 않는다.
   const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
   const translatePromiseRef = useRef<Promise<Record<string, MetadataTranslation>> | null>(null)
+  const translationCacheKeyRef = useRef<string | null>(null)
   const ensureTranslations = useCallback(async (): Promise<Record<string, MetadataTranslation>> => {
-    if (Object.keys(translations).length > 0) return translations
+    const cacheKey = JSON.stringify({
+      title: settingsTitle?.trim() || videoMeta?.title || '',
+      description: settingsDescription || '',
+      metadataLanguage,
+      selectedLanguages,
+    })
+    if (translationCacheKeyRef.current === cacheKey && Object.keys(translations).length > 0) {
+      return translations
+    }
     if (translatePromiseRef.current) return translatePromiseRef.current
 
     const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
     if (!baseTitle || selectedLanguages.length === 0) return {}
+    translationCacheKeyRef.current = cacheKey
 
     const p = (async () => {
       try {
@@ -104,12 +114,6 @@ export function UploadStep() {
     return p
   }, [translations, settingsTitle, videoMeta?.title, settingsDescription, metadataLanguage, selectedLanguages, addToast])
 
-  // 사용자가 제목/설명을 다시 만지면 캐시 무효화.
-  useEffect(() => {
-    setTranslations({})
-    translatePromiseRef.current = null
-  }, [settingsTitle, settingsDescription, metadataLanguage])
-
   // Original video upload state (for upload + originalWithMultiAudio)
   const [originalUploadState, setOriginalUploadState] = useState<{
     status: 'idle' | 'uploading' | 'done' | 'skipped'
@@ -130,16 +134,6 @@ export function UploadStep() {
       return desc
     },
     [attachOriginalLink, originalYouTubeUrl],
-  )
-
-  const buildDescription = useCallback(
-    (langName: string) => {
-      const base = settingsDescription?.trim()
-        ? settingsDescription
-        : `${videoMeta?.title || 'Video'} - ${langName} 더빙 by Dubtube AI\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
-      return applyDescriptionFooter(base)
-    },
-    [settingsDescription, videoMeta?.title, applyDescriptionFooter],
   )
 
   const handleNewDubbing = () => reset()
@@ -182,7 +176,7 @@ export function UploadStep() {
       addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
       return null
     }
-  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta?.title, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
 
   // ─── Audio → Studio helper ──────────────────────────────────────────
   const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -18,7 +18,7 @@ import {
 } from '@/lib/api-client'
 import type { DownloadTarget } from '@/lib/perso/types'
 import type { LanguageProgress } from '../types/dubbing.types'
-import { dbMutation } from '@/lib/api/dbMutation'
+import { dbMutation, dbMutationStrict } from '@/lib/api/dbMutation'
 
 const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
@@ -66,13 +66,13 @@ async function saveJobToDb(
   projectMap: Record<string, number>,
   lipSyncEnabled: boolean,
   sourceLanguage: string,
-): Promise<number | null> {
+): Promise<number> {
   const userId = useAuthStore.getState().user?.uid
   const videoMeta = store.getState().videoMeta
   const isShort = store.getState().isShort
-  if (!userId) return null
+  if (!userId) throw new Error('로그인이 필요합니다')
 
-  const result = await dbMutation<{ jobId: number }>({
+  const result = await dbMutationStrict<{ jobId: number }>({
     type: 'createDubbingJobWithLanguages',
     payload: {
       job: {
@@ -89,8 +89,6 @@ async function saveJobToDb(
       languages: selectedLanguages.map((code) => ({ code, projectSeq: projectMap[code] || 0 })),
     },
   })
-  if (!result?.jobId) return null
-
   store.getState().setDbJobId(result.jobId)
   return result.jobId
 }
@@ -181,9 +179,7 @@ async function pollLanguage(
 
   const userId = useAuthStore.getState().user?.uid
   if (userId && dbJobId && !alreadyFinalized) {
-    const durationMs = store.getState().videoMeta?.durationMs || 0
-    const minutesUsed = Math.max(1, Math.ceil(durationMs / 60_000))
-    await dbMutation({ type: 'deductUserMinutes', payload: { userId, minutes: minutesUsed, jobId: dbJobId } })
+    await dbMutationStrict({ type: 'finalizeJobCredits', payload: { jobId: dbJobId } })
   }
   if (dbJobId) {
     await dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: newStatus } })
@@ -226,6 +222,7 @@ async function cancelAllProjects(
 
   const dbJobId = store.getState().dbJobId
   if (dbJobId) {
+    dbMutation({ type: 'releaseJobCredits', payload: { jobId: dbJobId, reason: 'user_cancelled' } }).catch(() => {})
     dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: 'failed' } }).catch(() => {})
   }
   store.getState().setJobStatus('failed')
@@ -322,26 +319,6 @@ export function usePersoFlow() {
     const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, sourceLanguage, numberOfSpeakers } = store.getState()
     if (!spaceSeq || !mediaSeq) throw new Error('Missing space or media')
 
-    // Credit check before starting
-    const currentUser = useAuthStore.getState().user
-    if (currentUser) {
-      const res = await fetch(`/api/dashboard/summary?uid=${currentUser.uid}`)
-      const json = await res.json()
-      if (json.ok) {
-        const creditsRemaining = Number(json.data.credits_remaining) || 0
-        const durationMs = store.getState().videoMeta?.durationMs || 0
-        const estimatedMinutes = Math.max(1, Math.ceil(durationMs / 60_000))
-        if (estimatedMinutes > creditsRemaining) {
-          addToast({
-            type: 'error',
-            title: '크레딧 부족',
-            message: `필요: ${estimatedMinutes}분, 잔여: ${creditsRemaining}분. 충전 후 다시 시도하세요.`,
-          })
-          throw new Error('Insufficient credits')
-        }
-      }
-    }
-
     addToast({ type: 'info', title: 'Submitting dubbing job...', message: `${selectedLanguages.length} languages` })
 
     try {
@@ -350,6 +327,17 @@ export function usePersoFlow() {
       } catch {
         // Already initialized
       }
+
+      const pendingProjectMap = Object.fromEntries(selectedLanguages.map((lang) => [lang, 0]))
+      const dbJobId = await saveJobToDb(
+        mediaSeq,
+        spaceSeq,
+        selectedLanguages,
+        pendingProjectMap,
+        lipSyncEnabled,
+        sourceLanguage,
+      )
+      await dbMutationStrict({ type: 'reserveJobCredits', payload: { jobId: dbJobId } })
 
       const result = await submitTranslation(spaceSeq, {
         mediaSeq,
@@ -380,17 +368,24 @@ export function usePersoFlow() {
       store.getState().setLanguageProgress(initialProgress)
       store.getState().setJobStatus('transcribing')
 
-      try {
-        await saveJobToDb(mediaSeq, spaceSeq, selectedLanguages, projectMap, lipSyncEnabled, sourceLanguage)
-      } catch {
-        // DB save is best-effort
-      }
+      await dbMutationStrict({
+        type: 'updateJobLanguageProjects',
+        payload: {
+          jobId: dbJobId,
+          languages: selectedLanguages.map((code) => ({ code, projectSeq: projectMap[code] || 0 })),
+        },
+      })
 
       addToast({ type: 'success', title: '더빙 시작됨', message: `${projectIds.length}개 프로젝트 생성` })
       return projectMap
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Submission failed'
       addToast({ type: 'error', title: 'Dubbing Error', message: msg })
+      const dbJobId = store.getState().dbJobId
+      if (dbJobId) {
+        dbMutation({ type: 'releaseJobCredits', payload: { jobId: dbJobId, reason: 'submission_failed' } }).catch(() => {})
+        dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: 'failed' } }).catch(() => {})
+      }
       store.getState().setJobStatus('failed')
       throw err
     }

--- a/src/lib/api/dbMutation.ts
+++ b/src/lib/api/dbMutation.ts
@@ -19,3 +19,19 @@ export async function dbMutation<T = unknown>(
     return null
   }
 }
+
+export async function dbMutationStrict<T = unknown>(
+  action: { type: string; payload: Record<string, unknown> },
+): Promise<T> {
+  const res = await fetch('/api/dashboard/mutations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(action),
+    cache: 'no-store',
+  })
+  const body = await res.json().catch(() => null)
+  if (!body || !body.ok) {
+    throw new Error(body?.error?.message || `${action.type} failed with ${res.status}`)
+  }
+  return body.data as T
+}

--- a/src/lib/db/queries/credits.ts
+++ b/src/lib/db/queries/credits.ts
@@ -1,0 +1,404 @@
+import 'server-only'
+
+import type { Client, Transaction } from '@libsql/client'
+import { getDb } from '@/lib/db/client'
+
+type DbExecutor = Pick<Client | Transaction, 'execute'>
+
+export interface CreditBalance {
+  total: number
+  reserved: number
+  available: number
+}
+
+export interface PaymentOrder {
+  order_id: string
+  user_id: string
+  pack_minutes: number
+  amount: number
+  currency: string
+  status: string
+  payment_key: string | null
+  checkout_url: string | null
+  order_name: string
+  raw_json: string | null
+}
+
+let creditTablesReady = false
+
+export async function ensureCreditTables() {
+  if (creditTablesReady) return
+  const db = getDb()
+  await db.batch([
+    {
+      sql: `CREATE TABLE IF NOT EXISTS payment_orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        order_id TEXT NOT NULL UNIQUE,
+        user_id TEXT NOT NULL,
+        pack_minutes INTEGER NOT NULL,
+        amount INTEGER NOT NULL,
+        currency TEXT NOT NULL DEFAULT 'KRW',
+        status TEXT NOT NULL DEFAULT 'created',
+        payment_key TEXT,
+        checkout_url TEXT,
+        order_name TEXT NOT NULL,
+        raw_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_payment_orders_user_created
+        ON payment_orders (user_id, created_at DESC)`,
+      args: [],
+    },
+    {
+      sql: `CREATE TABLE IF NOT EXISTS credit_transactions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        amount_minutes INTEGER NOT NULL,
+        balance_delta_minutes INTEGER NOT NULL DEFAULT 0,
+        reserved_delta_minutes INTEGER NOT NULL DEFAULT 0,
+        reference_type TEXT,
+        reference_id TEXT,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        metadata_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_credit_transactions_user_created
+        ON credit_transactions (user_id, created_at DESC)`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_credit_transactions_reference
+        ON credit_transactions (reference_type, reference_id)`,
+      args: [],
+    },
+  ])
+  creditTablesReady = true
+}
+
+async function withWriteTransaction<T>(fn: (tx: Transaction) => Promise<T>) {
+  await ensureCreditTables()
+  const tx = await getDb().transaction('write')
+  try {
+    const result = await fn(tx)
+    await tx.commit()
+    return result
+  } catch (err) {
+    await tx.rollback().catch(() => {})
+    throw err
+  } finally {
+    tx.close()
+  }
+}
+
+function asNumber(value: unknown) {
+  return Number(value ?? 0)
+}
+
+async function getCreditBalanceWithExecutor(userId: string, db: DbExecutor): Promise<CreditBalance> {
+  const user = await db.execute({
+    sql: 'SELECT COALESCE(credits_remaining, 0) as total FROM users WHERE id = ?',
+    args: [userId],
+  })
+  const reserved = await db.execute({
+    sql: `SELECT COALESCE(SUM(reserved_delta_minutes), 0) as reserved
+          FROM credit_transactions
+          WHERE user_id = ?`,
+    args: [userId],
+  })
+
+  const total = asNumber(user.rows[0]?.total)
+  const reservedMinutes = asNumber(reserved.rows[0]?.reserved)
+  return {
+    total,
+    reserved: reservedMinutes,
+    available: Math.max(0, total - reservedMinutes),
+  }
+}
+
+async function getJobCreditEstimate(jobId: number, db: DbExecutor) {
+  const result = await db.execute({
+    sql: `SELECT dj.user_id, dj.video_duration_ms,
+          COUNT(jl.language_code) as language_count,
+          SUM(CASE WHEN jl.status = 'completed' THEN 1 ELSE 0 END) as completed_count
+          FROM dubbing_jobs dj
+          LEFT JOIN job_languages jl ON jl.job_id = dj.id
+          WHERE dj.id = ?
+          GROUP BY dj.id`,
+    args: [jobId],
+  })
+  const row = result.rows[0]
+  if (!row) {
+    const err = new Error('Job not found') as Error & { status?: number; code?: string }
+    err.status = 404
+    err.code = 'JOB_NOT_FOUND'
+    throw err
+  }
+
+  const perLanguageMinutes = Math.max(1, Math.ceil(asNumber(row.video_duration_ms) / 60_000))
+  const languageCount = Math.max(1, asNumber(row.language_count))
+  return {
+    userId: String(row.user_id),
+    perLanguageMinutes,
+    languageCount,
+    completedCount: asNumber(row.completed_count),
+    estimatedMinutes: perLanguageMinutes * languageCount,
+  }
+}
+
+async function getReservedForJob(jobId: number, db: DbExecutor) {
+  const result = await db.execute({
+    sql: `SELECT COALESCE(SUM(reserved_delta_minutes), 0) as reserved
+          FROM credit_transactions
+          WHERE reference_type = 'dubbing_job' AND reference_id = ?`,
+    args: [String(jobId)],
+  })
+  return asNumber(result.rows[0]?.reserved)
+}
+
+async function hasCreditTransaction(idempotencyKey: string, db: DbExecutor) {
+  const result = await db.execute({
+    sql: 'SELECT id FROM credit_transactions WHERE idempotency_key = ?',
+    args: [idempotencyKey],
+  })
+  return Boolean(result.rows[0])
+}
+
+function insufficientCredits(available: number, required: number) {
+  const err = new Error(`Insufficient credits: required ${required}, available ${available}`) as Error & {
+    status?: number
+    code?: string
+    details?: unknown
+  }
+  err.status = 402
+  err.code = 'INSUFFICIENT_CREDITS'
+  err.details = { available, required }
+  return err
+}
+
+export async function getUserAvailableCredits(userId: string) {
+  await ensureCreditTables()
+  return getCreditBalanceWithExecutor(userId, getDb())
+}
+
+export async function createPaymentOrder(order: {
+  orderId: string
+  userId: string
+  packMinutes: number
+  amount: number
+  currency: string
+  orderName: string
+}) {
+  await ensureCreditTables()
+  await getDb().execute({
+    sql: `INSERT INTO payment_orders
+          (provider, order_id, user_id, pack_minutes, amount, currency, status, order_name)
+          VALUES ('toss', ?, ?, ?, ?, ?, 'created', ?)`,
+    args: [
+      order.orderId,
+      order.userId,
+      order.packMinutes,
+      order.amount,
+      order.currency,
+      order.orderName,
+    ],
+  })
+}
+
+export async function updatePaymentOrderCheckout(orderId: string, checkoutUrl: string, raw: unknown) {
+  await ensureCreditTables()
+  await getDb().execute({
+    sql: `UPDATE payment_orders
+          SET status = 'checkout_created', checkout_url = ?, raw_json = ?, updated_at = datetime('now')
+          WHERE order_id = ?`,
+    args: [checkoutUrl, JSON.stringify(raw), orderId],
+  })
+}
+
+export async function updatePaymentOrderStatus(orderId: string, status: string, raw?: unknown) {
+  await ensureCreditTables()
+  await getDb().execute({
+    sql: `UPDATE payment_orders
+          SET status = ?, raw_json = COALESCE(?, raw_json), updated_at = datetime('now')
+          WHERE order_id = ?`,
+    args: [status, raw === undefined ? null : JSON.stringify(raw), orderId],
+  })
+}
+
+export async function getPaymentOrderByOrderId(orderId: string): Promise<PaymentOrder | null> {
+  await ensureCreditTables()
+  const result = await getDb().execute({
+    sql: `SELECT order_id, user_id, pack_minutes, amount, currency, status,
+          payment_key, checkout_url, order_name, raw_json
+          FROM payment_orders WHERE order_id = ?`,
+    args: [orderId],
+  })
+  const row = result.rows[0]
+  return row ? ({ ...row } as unknown as PaymentOrder) : null
+}
+
+export async function grantPaidCredits(args: {
+  userId: string
+  orderId: string
+  paymentKey: string
+  minutes: number
+  rawPayment: unknown
+}) {
+  return withWriteTransaction(async (tx) => {
+    const key = `grant:toss:${args.orderId}`
+    if (await hasCreditTransaction(key, tx)) {
+      return { granted: false, idempotent: true }
+    }
+
+    await tx.execute({
+      sql: `UPDATE users
+            SET credits_remaining = credits_remaining + ?, updated_at = datetime('now')
+            WHERE id = ?`,
+      args: [args.minutes, args.userId],
+    })
+    await tx.execute({
+      sql: `INSERT INTO credit_transactions
+            (user_id, type, amount_minutes, balance_delta_minutes, reserved_delta_minutes,
+             reference_type, reference_id, idempotency_key, metadata_json)
+            VALUES (?, 'grant', ?, ?, 0, 'payment_order', ?, ?, ?)`,
+      args: [
+        args.userId,
+        args.minutes,
+        args.minutes,
+        args.orderId,
+        key,
+        JSON.stringify({ provider: 'toss', paymentKey: args.paymentKey }),
+      ],
+    })
+    await tx.execute({
+      sql: `UPDATE payment_orders
+            SET status = 'paid', payment_key = ?, raw_json = ?, updated_at = datetime('now')
+            WHERE order_id = ?`,
+      args: [args.paymentKey, JSON.stringify(args.rawPayment), args.orderId],
+    })
+    return { granted: true, idempotent: false }
+  })
+}
+
+export async function reserveJobCredits(userId: string, jobId: number) {
+  return withWriteTransaction(async (tx) => {
+    const key = `reserve:job:${jobId}`
+    if (await hasCreditTransaction(key, tx)) {
+      return { reserved: 0, idempotent: true }
+    }
+
+    const estimate = await getJobCreditEstimate(jobId, tx)
+    if (estimate.userId !== userId) {
+      const err = new Error('You do not own this job') as Error & { status?: number; code?: string }
+      err.status = 403
+      err.code = 'FORBIDDEN'
+      throw err
+    }
+
+    const balance = await getCreditBalanceWithExecutor(userId, tx)
+    if (balance.available < estimate.estimatedMinutes) {
+      throw insufficientCredits(balance.available, estimate.estimatedMinutes)
+    }
+
+    await tx.execute({
+      sql: `INSERT INTO credit_transactions
+            (user_id, type, amount_minutes, balance_delta_minutes, reserved_delta_minutes,
+             reference_type, reference_id, idempotency_key, metadata_json)
+            VALUES (?, 'reserve', ?, 0, ?, 'dubbing_job', ?, ?, ?)`,
+      args: [
+        userId,
+        estimate.estimatedMinutes,
+        estimate.estimatedMinutes,
+        String(jobId),
+        key,
+        JSON.stringify({
+          perLanguageMinutes: estimate.perLanguageMinutes,
+          languageCount: estimate.languageCount,
+        }),
+      ],
+    })
+    return { reserved: estimate.estimatedMinutes, idempotent: false }
+  })
+}
+
+export async function releaseJobCredits(userId: string, jobId: number, reason: string) {
+  return withWriteTransaction(async (tx) => {
+    const reserved = await getReservedForJob(jobId, tx)
+    if (reserved <= 0) {
+      return { released: 0, idempotent: true }
+    }
+
+    const key = `release:job:${jobId}:${reason}`
+    if (await hasCreditTransaction(key, tx)) {
+      return { released: 0, idempotent: true }
+    }
+
+    await tx.execute({
+      sql: `INSERT INTO credit_transactions
+            (user_id, type, amount_minutes, balance_delta_minutes, reserved_delta_minutes,
+             reference_type, reference_id, idempotency_key, metadata_json)
+            VALUES (?, 'release', ?, 0, ?, 'dubbing_job', ?, ?, ?)`,
+      args: [userId, reserved, -reserved, String(jobId), key, JSON.stringify({ reason })],
+    })
+    return { released: reserved, idempotent: false }
+  })
+}
+
+export async function finalizeJobCredits(userId: string, jobId: number) {
+  return withWriteTransaction(async (tx) => {
+    const key = `finalize:job:${jobId}`
+    if (await hasCreditTransaction(key, tx)) {
+      return { consumed: 0, released: 0, idempotent: true }
+    }
+
+    const estimate = await getJobCreditEstimate(jobId, tx)
+    if (estimate.userId !== userId) {
+      const err = new Error('You do not own this job') as Error & { status?: number; code?: string }
+      err.status = 403
+      err.code = 'FORBIDDEN'
+      throw err
+    }
+
+    const reserved = await getReservedForJob(jobId, tx)
+    if (reserved <= 0) {
+      return { consumed: 0, released: 0, idempotent: true }
+    }
+
+    const consumed = Math.min(reserved, estimate.perLanguageMinutes * estimate.completedCount)
+    await tx.execute({
+      sql: `UPDATE users
+            SET credits_remaining = MAX(0, credits_remaining - ?), updated_at = datetime('now')
+            WHERE id = ?`,
+      args: [consumed, userId],
+    })
+    await tx.execute({
+      sql: `INSERT INTO credit_transactions
+            (user_id, type, amount_minutes, balance_delta_minutes, reserved_delta_minutes,
+             reference_type, reference_id, idempotency_key, metadata_json)
+            VALUES (?, ?, ?, ?, ?, 'dubbing_job', ?, ?, ?)`,
+      args: [
+        userId,
+        consumed > 0 ? 'consume' : 'release',
+        consumed,
+        -consumed,
+        -reserved,
+        String(jobId),
+        key,
+        JSON.stringify({
+          completedCount: estimate.completedCount,
+          languageCount: estimate.languageCount,
+          releasedUnused: reserved - consumed,
+        }),
+      ],
+    })
+    return { consumed, released: reserved - consumed, idempotent: false }
+  })
+}

--- a/src/lib/db/queries/dashboard.ts
+++ b/src/lib/db/queries/dashboard.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { getDb } from '@/lib/db/client'
+import { ensureCreditTables } from './credits'
 import type {
   DashboardSummary,
   DubbingJob,
@@ -38,13 +39,20 @@ export async function getUserDubbingJobs(userId: string, limit = 10): Promise<Du
 }
 
 export async function getUserSummary(userId: string): Promise<DashboardSummary | null> {
+  await ensureCreditTables()
   const db = getDb()
   const result = await db.execute({
     sql: `SELECT
           COUNT(DISTINCT dj.id) as total_jobs,
           COALESCE(SUM(dj.video_duration_ms), 0) / 60000 as total_minutes,
           COUNT(DISTINCT CASE WHEN dj.status = 'processing' THEN dj.id END) as active_jobs,
-          (SELECT credits_remaining FROM users WHERE id = ?) as credits_remaining
+          (SELECT MAX(
+            0,
+            COALESCE(u.credits_remaining, 0) -
+              COALESCE((SELECT SUM(ct.reserved_delta_minutes)
+                        FROM credit_transactions ct
+                        WHERE ct.user_id = u.id), 0)
+          ) FROM users u WHERE u.id = ?) as credits_remaining
           FROM dubbing_jobs dj
           WHERE dj.user_id = ?`,
     args: [userId, userId],

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -9,9 +9,23 @@ export {
 } from './users'
 
 export {
+  ensureCreditTables,
+  getUserAvailableCredits,
+  createPaymentOrder,
+  updatePaymentOrderCheckout,
+  updatePaymentOrderStatus,
+  getPaymentOrderByOrderId,
+  grantPaidCredits,
+  reserveJobCredits,
+  releaseJobCredits,
+  finalizeJobCredits,
+} from './credits'
+
+export {
   createDubbingJob,
   createJobLanguages,
   createDubbingJobWithLanguages,
+  updateJobLanguageProjects,
   updateJobLanguageProgress,
   updateJobLanguageCompleted,
   updateJobStatus,

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -69,6 +69,20 @@ export async function createDubbingJobWithLanguages(
   return Number(results[0].lastInsertRowid)
 }
 
+export async function updateJobLanguageProjects(
+  jobId: number,
+  languages: { code: string; projectSeq: number }[],
+) {
+  if (languages.length === 0) return
+  const db = getDb()
+  await db.batch(
+    languages.map((lang) => ({
+      sql: 'UPDATE job_languages SET project_seq = ? WHERE job_id = ? AND language_code = ?',
+      args: [lang.projectSeq, jobId, lang.code],
+    })),
+  )
+}
+
 export async function updateJobLanguageProgress(
   jobId: number,
   langCode: string,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -22,6 +22,8 @@ const serverSchema = z.object({
   TURSO_AUTH_TOKEN: z.string().min(1, "TURSO_AUTH_TOKEN is required"),
   GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
   GEMINI_API_KEY: z.string().min(1).optional(),
+  TOSS_SECRET_KEY: z.string().min(1).optional(),
+  TOSS_API_BASE_URL: z.string().url().optional(),
 });
 
 const clientSchema = z.object({
@@ -62,6 +64,8 @@ export function getServerEnv(): ServerEnv {
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    TOSS_SECRET_KEY: process.env.TOSS_SECRET_KEY,
+    TOSS_API_BASE_URL: process.env.TOSS_API_BASE_URL,
   });
 
   if (!parsed.success) {

--- a/src/lib/toss/client.ts
+++ b/src/lib/toss/client.ts
@@ -1,0 +1,121 @@
+import 'server-only'
+
+import { getServerEnv } from '@/lib/env'
+
+const DEFAULT_METHOD = 'CARD'
+
+export interface TossPayment {
+  paymentKey?: string
+  orderId: string
+  orderName: string
+  status?: string
+  totalAmount?: number
+  amount?: number
+  currency?: string
+  method?: string | null
+  checkout?: {
+    url?: string
+  }
+  [key: string]: unknown
+}
+
+export class TossApiError extends Error {
+  status: number
+  code: string
+  details: unknown
+
+  constructor(status: number, code: string, message: string, details: unknown = null) {
+    super(message)
+    this.name = 'TossApiError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+function getTossConfig() {
+  const env = getServerEnv()
+  if (!env.TOSS_SECRET_KEY) {
+    throw new TossApiError(503, 'TOSS_NOT_CONFIGURED', 'Toss Payments secret key is not configured')
+  }
+  return {
+    baseUrl: (env.TOSS_API_BASE_URL ?? 'https://api.tosspayments.com').replace(/\/$/, ''),
+    secretKey: env.TOSS_SECRET_KEY,
+  }
+}
+
+function authHeader(secretKey: string) {
+  return `Basic ${Buffer.from(`${secretKey}:`).toString('base64')}`
+}
+
+async function tossRequest<T>(
+  path: string,
+  init: RequestInit & { idempotencyKey?: string } = {},
+): Promise<T> {
+  const { baseUrl, secretKey } = getTossConfig()
+  const headers = new Headers(init.headers)
+  headers.set('Authorization', authHeader(secretKey))
+  headers.set('Content-Type', 'application/json')
+  headers.set('Accept-Language', 'ko-KR')
+  if (init.idempotencyKey) {
+    headers.set('Idempotency-Key', init.idempotencyKey)
+  }
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers,
+    cache: 'no-store',
+  })
+  const body = await res.json().catch(() => null)
+  if (!res.ok) {
+    const code = typeof body?.code === 'string' ? body.code : 'TOSS_API_ERROR'
+    const message = typeof body?.message === 'string' ? body.message : `Toss API failed with ${res.status}`
+    throw new TossApiError(res.status, code, message, body)
+  }
+  return body as T
+}
+
+export function createTossPayment(args: {
+  amount: number
+  orderId: string
+  orderName: string
+  successUrl: string
+  failUrl: string
+  customerEmail?: string | null
+  customerName?: string | null
+}) {
+  return tossRequest<TossPayment>('/v1/payments', {
+    method: 'POST',
+    idempotencyKey: `create-${args.orderId}`,
+    body: JSON.stringify({
+      method: DEFAULT_METHOD,
+      amount: args.amount,
+      currency: 'KRW',
+      orderId: args.orderId,
+      orderName: args.orderName,
+      successUrl: args.successUrl,
+      failUrl: args.failUrl,
+      flowMode: 'DEFAULT',
+      customerEmail: args.customerEmail ?? undefined,
+      customerName: args.customerName ?? undefined,
+    }),
+  })
+}
+
+export function confirmTossPayment(args: {
+  paymentKey: string
+  orderId: string
+  amount: number
+}) {
+  return tossRequest<TossPayment>('/v1/payments/confirm', {
+    method: 'POST',
+    idempotencyKey: `confirm-${args.orderId}`,
+    body: JSON.stringify(args),
+  })
+}
+
+export function retrieveTossPayment(paymentKey: string) {
+  return tossRequest<TossPayment>(`/v1/payments/${encodeURIComponent(paymentKey)}`, {
+    method: 'GET',
+  })
+}

--- a/src/lib/validators/billing.ts
+++ b/src/lib/validators/billing.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const createTossPaymentBodySchema = z.object({
+  minutes: z.number().int().positive(),
+})
+
+export const confirmTossPaymentBodySchema = z.object({
+  paymentKey: z.string().min(1).max(200),
+  orderId: z.string().min(6).max(64).regex(/^[A-Za-z0-9_-]+$/),
+  amount: z.coerce.number().int().positive(),
+})
+
+export const tossWebhookSchema = z.object({
+  eventType: z.string().min(1),
+  createdAt: z.string().optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
+})

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -103,13 +103,33 @@ const deductUserMinutesSchema = z.object({
   }),
 })
 
-const CREDIT_PACK_MAX = 120 // must match max value in CREDIT_PACKS
-
-const addCreditsSchema = z.object({
-  type: z.literal('addCredits'),
+const reserveJobCreditsSchema = z.object({
+  type: z.literal('reserveJobCredits'),
   payload: z.object({
-    userId: z.string().min(1),
-    minutes: z.number().int().positive().max(CREDIT_PACK_MAX),
+    jobId: z.number().int(),
+  }),
+})
+
+const releaseJobCreditsSchema = z.object({
+  type: z.literal('releaseJobCredits'),
+  payload: z.object({
+    jobId: z.number().int(),
+    reason: z.string().min(1).max(80).default('manual_release'),
+  }),
+})
+
+const finalizeJobCreditsSchema = z.object({
+  type: z.literal('finalizeJobCredits'),
+  payload: z.object({
+    jobId: z.number().int(),
+  }),
+})
+
+const updateJobLanguageProjectsSchema = z.object({
+  type: z.literal('updateJobLanguageProjects'),
+  payload: z.object({
+    jobId: z.number().int(),
+    languages: z.array(z.object({ code: z.string().min(1), projectSeq: z.number().int() })).min(1),
   }),
 })
 
@@ -154,7 +174,10 @@ export const mutationActionSchema = z.discriminatedUnion('type', [
   createYouTubeUploadSchema,
   updateJobLanguageYouTubeSchema,
   deductUserMinutesSchema,
-  addCreditsSchema,
+  reserveJobCreditsSchema,
+  releaseJobCreditsSchema,
+  finalizeJobCreditsSchema,
+  updateJobLanguageProjectsSchema,
   deleteDubbingJobSchema,
   queueYouTubeUploadSchema,
 ])
@@ -178,8 +201,6 @@ export function getUserIdFromAction(action: MutationAction): string | null {
       return action.payload.userId
     case 'deductUserMinutes':
       return action.payload.userId
-    case 'addCredits':
-      return action.payload.userId
     default:
       return null
   }
@@ -201,6 +222,14 @@ export function getJobIdFromAction(action: MutationAction): number | null {
     case 'deleteDubbingJob':
       return action.payload.jobId
     case 'deductUserMinutes':
+      return action.payload.jobId
+    case 'reserveJobCredits':
+      return action.payload.jobId
+    case 'releaseJobCredits':
+      return action.payload.jobId
+    case 'finalizeJobCredits':
+      return action.payload.jobId
+    case 'updateJobLanguageProjects':
       return action.payload.jobId
     case 'queueYouTubeUpload':
       return action.payload.jobId

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -107,9 +107,12 @@ describe('fetchChannelStatistics', () => {
     })
   })
 
-  it('returns null on non-ok response', async () => {
+  it('throws on non-ok response', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 401))
-    expect(await fetchChannelStatistics('tok')).toBeNull()
+    await expect(fetchChannelStatistics('tok')).rejects.toMatchObject({
+      status: 401,
+      code: 'CHANNEL_FETCH_FAILED',
+    })
   })
 
   it('returns null when no channel items', async () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -10,6 +10,10 @@ export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)
 }
 
+export function formatKrw(amount: number): string {
+  return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount)
+}
+
 export function formatNumber(num: number): string {
   if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`
   if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`

--- a/src/utils/srt.ts
+++ b/src/utils/srt.ts
@@ -28,7 +28,7 @@ export function parseSRT(text: string): SrtCue[] {
     const lines = block.split('\n')
     if (lines.length < 2) continue
     // 1번 줄이 인덱스가 아닐 수도 있어 timing 라인을 직접 찾는다
-    let timingIdx = lines[0].includes('-->') ? 0 : 1
+    const timingIdx = lines[0].includes('-->') ? 0 : 1
     if (timingIdx >= lines.length) continue
     const timing = lines[timingIdx].match(
       /(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})\s*-->\s*(\d{1,2}:\d{2}:\d{2}[,.]\d{1,3})/,


### PR DESCRIPTION
## Summary
- Add Toss Payments checkout, confirmation, and payment-status webhook routes for KRW credit packs.
- Replace client-side credit grants with payment-order-backed credit transactions.
- Add credit reservation/finalization/release actions for dubbing jobs so in-progress jobs lock available credits and failed languages release unused minutes.
- Add billing success/fail screens and route tests for the Toss flow.
- Clean up existing lint/test failures found during QA.

Closes #200.

## Environment
Set these before testing real payments:
- TOSS_SECRET_KEY
- TOSS_API_BASE_URL=https://api.tosspayments.com

## QA
- npx tsc --noEmit
- npm run lint
- npm test
- npm run build
- cd extension && npm run lint
- cd extension && npm test