### PR TITLE
[codex] Enforce Perso resource ownership

### DIFF
--- a/src/app/api/perso/cancel/route.ts
+++ b/src/app/api/perso/cancel/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,6 +15,7 @@ export async function POST(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     return persoFetch<Record<string, unknown>>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/cancel`,
       { method: 'POST', baseURL: 'api' },

--- a/src/app/api/perso/download/route.ts
+++ b/src/app/api/perso/download/route.ts
@@ -4,6 +4,7 @@ import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 import { downloadTargetSchema } from '@/lib/validators/perso'
 import type { DownloadResponse } from '@/lib/perso/types'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -26,6 +27,7 @@ export async function GET(req: NextRequest) {
       })
     }
     const target = parsed.data
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
 
     return persoFetch<DownloadResponse>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`,

--- a/src/app/api/perso/external/upload/route.ts
+++ b/src/app/api/perso/external/upload/route.ts
@@ -4,6 +4,7 @@ import { persoFetch } from '@/lib/perso/client'
 import { handle, parseBody } from '@/lib/perso/route-helpers'
 import { externalUploadBodySchema } from '@/lib/validators/perso'
 import type { UploadVideoResponse } from '@/lib/perso/types'
+import { recordPersoMediaOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -15,7 +16,7 @@ export async function PUT(req: NextRequest) {
 
   return handle(async () => {
     const { spaceSeq, url, lang = 'ko' } = await parseBody(req, externalUploadBodySchema)
-    return persoFetch<UploadVideoResponse>(
+    const media = await persoFetch<UploadVideoResponse>(
       '/file/api/upload/video/external',
       {
         method: 'PUT',
@@ -24,5 +25,7 @@ export async function PUT(req: NextRequest) {
         timeoutMs: 300_000,
       },
     )
+    await recordPersoMediaOwner({ userId: auth.session.uid, spaceSeq, media, sourceType: 'external', fileUrl: url })
+    return media
   })
 }

--- a/src/app/api/perso/lipsync/route.ts
+++ b/src/app/api/perso/lipsync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,6 +15,7 @@ export async function POST(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     return persoFetch<unknown>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/lip-sync`,
       { method: 'POST', baseURL: 'api' },

--- a/src/app/api/perso/perso-ownership-routes.test.ts
+++ b/src/app/api/perso/perso-ownership-routes.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PersoError } from '@/lib/perso/errors'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(async () => ({
+    ok: true,
+    session: { uid: 'user1', email: 'user1@example.com' },
+  })),
+}))
+
+vi.mock('@/lib/perso/client', () => ({
+  persoFetch: vi.fn(async () => ({
+    seq: 10,
+    videoFilePath: '/video.mp4',
+    thumbnailFilePath: '/thumb.jpg',
+    size: 100,
+    durationMs: 1000,
+    originalName: 'video.mp4',
+  })),
+}))
+
+vi.mock('@/lib/perso/ownership', () => ({
+  assertPersoMediaOwner: vi.fn(),
+  assertPersoProjectOwner: vi.fn(),
+  recordPersoMediaOwner: vi.fn(),
+}))
+
+import { persoFetch } from '@/lib/perso/client'
+import {
+  assertPersoMediaOwner,
+  assertPersoProjectOwner,
+  recordPersoMediaOwner,
+} from '@/lib/perso/ownership'
+
+const mockPersoFetch = vi.mocked(persoFetch)
+const mockAssertMediaOwner = vi.mocked(assertPersoMediaOwner)
+const mockAssertProjectOwner = vi.mocked(assertPersoProjectOwner)
+const mockRecordMediaOwner = vi.mocked(recordPersoMediaOwner)
+
+describe('Perso routes — resource ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('checks project ownership before progress fetch', async () => {
+    const { GET } = await import('./progress/route')
+    const req = new NextRequest('http://localhost/api/perso/progress?projectSeq=7&spaceSeq=3')
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mockAssertProjectOwner).toHaveBeenCalledWith('user1', 7)
+    expect(mockPersoFetch).toHaveBeenCalled()
+  })
+
+  it('blocks project routes when ownership fails', async () => {
+    mockAssertProjectOwner.mockRejectedValueOnce(
+      new PersoError('PERSO_RESOURCE_FORBIDDEN', 'forbidden', 403),
+    )
+    const { GET } = await import('./project/route')
+    const req = new NextRequest('http://localhost/api/perso/project?projectSeq=7&spaceSeq=3')
+
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error.code).toBe('PERSO_RESOURCE_FORBIDDEN')
+    expect(mockPersoFetch).not.toHaveBeenCalled()
+  })
+
+  it('checks media ownership before translating', async () => {
+    const { POST } = await import('./translate/route')
+    const req = new NextRequest('http://localhost/api/perso/translate?spaceSeq=3', {
+      method: 'POST',
+      body: JSON.stringify({
+        mediaSeq: 10,
+        isVideoProject: true,
+        sourceLanguageCode: 'ko',
+        targetLanguageCodes: ['en'],
+        numberOfSpeakers: 1,
+        preferredSpeedType: 'GREEN',
+      }),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    expect(mockAssertMediaOwner).toHaveBeenCalledWith('user1', 10)
+  })
+
+  it('records media ownership after external upload', async () => {
+    const { PUT } = await import('./external/upload/route')
+    const req = new NextRequest('http://localhost/api/perso/external/upload', {
+      method: 'PUT',
+      body: JSON.stringify({ spaceSeq: 3, url: 'https://youtube.com/watch?v=abc' }),
+    })
+
+    const res = await PUT(req)
+
+    expect(res.status).toBe(200)
+    expect(mockRecordMediaOwner).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user1',
+      spaceSeq: 3,
+      sourceType: 'external',
+      fileUrl: 'https://youtube.com/watch?v=abc',
+    }))
+  })
+})

--- a/src/app/api/perso/perso-routes-auth.test.ts
+++ b/src/app/api/perso/perso-routes-auth.test.ts
@@ -16,6 +16,12 @@ vi.mock('@/lib/perso/client', () => ({
   persoFetch: vi.fn(async () => ({ ok: true })),
 }))
 
+vi.mock('@/lib/perso/ownership', () => ({
+  assertPersoMediaOwner: vi.fn(),
+  assertPersoProjectOwner: vi.fn(),
+  recordPersoMediaOwner: vi.fn(),
+}))
+
 import { requireSession } from '@/lib/auth/session'
 
 const mockSession = vi.mocked(requireSession)

--- a/src/app/api/perso/perso-zod-validation.test.ts
+++ b/src/app/api/perso/perso-zod-validation.test.ts
@@ -12,6 +12,12 @@ vi.mock('@/lib/perso/client', () => ({
   persoFetch: vi.fn(async () => ({ ok: true })),
 }))
 
+vi.mock('@/lib/perso/ownership', () => ({
+  assertPersoMediaOwner: vi.fn(),
+  assertPersoProjectOwner: vi.fn(),
+  recordPersoMediaOwner: vi.fn(),
+}))
+
 describe('Perso routes — zod body validation', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/app/api/perso/progress/route.ts
+++ b/src/app/api/perso/progress/route.ts
@@ -3,6 +3,7 @@ import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { ok, fail, requireIntParam } from '@/lib/perso/route-helpers'
 import type { ProgressResponse } from '@/lib/perso/types'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -19,6 +20,7 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
 
     const data = await persoFetch<ProgressResponse>(
       `/video-translator/api/v1/projects/${projectSeq}/space/${spaceSeq}/progress`,

--- a/src/app/api/perso/project/route.ts
+++ b/src/app/api/perso/project/route.ts
@@ -3,6 +3,7 @@ import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
 import type { ProjectDetail } from '@/lib/perso/types'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -15,6 +16,7 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     return persoFetch<ProjectDetail>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}`,
       { baseURL: 'api' },

--- a/src/app/api/perso/script/regenerate/route.ts
+++ b/src/app/api/perso/script/regenerate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
 import { handle, requireIntParam } from '@/lib/perso/route-helpers'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,6 +15,7 @@ export async function PATCH(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const audioSentenceSeq = requireIntParam(url, 'audioSentenceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     return persoFetch<unknown>(
       `/video-translator/api/v1/project/${projectSeq}/audio-sentence/${audioSentenceSeq}/generate-audio`,
       { method: 'PATCH', baseURL: 'api' },

--- a/src/app/api/perso/script/route.ts
+++ b/src/app/api/perso/script/route.ts
@@ -4,6 +4,7 @@ import { persoFetch } from '@/lib/perso/client'
 import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
 import { scriptPatchBodySchema } from '@/lib/validators/perso'
 import type { ScriptSentence } from '@/lib/perso/types'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 interface RawSentence {
   seq: number
@@ -37,6 +38,7 @@ export async function GET(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     const raw = await persoFetch<{ sentences?: RawSentence[] } | RawSentence[]>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/script`,
       { baseURL: 'api' },
@@ -58,6 +60,7 @@ export async function PATCH(req: NextRequest) {
     const url = new URL(req.url)
     const projectSeq = requireIntParam(url, 'projectSeq')
     const sentenceSeq = requireIntParam(url, 'sentenceSeq')
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
     const body = await parseBody(req, scriptPatchBodySchema)
     return persoFetch<unknown>(
       `/video-translator/api/v1/project/${projectSeq}/audio-sentence/${sentenceSeq}`,

--- a/src/app/api/perso/srt/route.ts
+++ b/src/app/api/perso/srt/route.ts
@@ -4,6 +4,7 @@ import { persoFetch } from '@/lib/perso/client'
 import { fail, requireIntParam } from '@/lib/perso/route-helpers'
 import { getPersoFileUrl } from '@/lib/api-client/perso'
 import type { DownloadResponse } from '@/lib/perso/types'
+import { assertPersoProjectOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -34,6 +35,7 @@ export async function GET(req: NextRequest) {
     const projectSeq = requireIntParam(url, 'projectSeq')
     const spaceSeq = requireIntParam(url, 'spaceSeq')
     const kind = url.searchParams.get('kind') === 'original' ? 'original' : 'translated'
+    await assertPersoProjectOwner(auth.session.uid, projectSeq)
 
     const data = await persoFetch<DownloadResponse>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`,

--- a/src/app/api/perso/translate/route.ts
+++ b/src/app/api/perso/translate/route.ts
@@ -5,6 +5,7 @@ import { PersoError } from '@/lib/perso/errors'
 import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
 import { translateBodySchema } from '@/lib/validators/perso'
 import type { TranslateResponse } from '@/lib/perso/types'
+import { assertPersoMediaOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -17,6 +18,7 @@ export async function POST(req: NextRequest) {
     const url = new URL(req.url)
     const spaceSeq = requireIntParam(url, 'spaceSeq')
     const body = await parseBody(req, translateBodySchema)
+    await assertPersoMediaOwner(auth.session.uid, body.mediaSeq)
 
     try {
       await persoFetch<unknown>(

--- a/src/app/api/perso/upload/register/route.ts
+++ b/src/app/api/perso/upload/register/route.ts
@@ -4,6 +4,7 @@ import { persoFetch } from '@/lib/perso/client'
 import { handle, parseBody } from '@/lib/perso/route-helpers'
 import { uploadRegisterBodySchema } from '@/lib/validators/perso'
 import type { UploadVideoResponse } from '@/lib/perso/types'
+import { recordPersoMediaOwner } from '@/lib/perso/ownership'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,10 +15,18 @@ export async function PUT(req: NextRequest) {
 
   return handle(async () => {
     const body = await parseBody(req, uploadRegisterBodySchema)
-    return persoFetch<UploadVideoResponse>('/file/api/upload/video', {
+    const media = await persoFetch<UploadVideoResponse>('/file/api/upload/video', {
       method: 'PUT',
       baseURL: 'file',
       body,
     })
+    await recordPersoMediaOwner({
+      userId: auth.session.uid,
+      spaceSeq: body.spaceSeq,
+      media,
+      sourceType: 'upload',
+      fileUrl: body.fileUrl,
+    })
+    return media
   })
 }

--- a/src/lib/perso/ownership.ts
+++ b/src/lib/perso/ownership.ts
@@ -1,0 +1,109 @@
+import 'server-only'
+
+import { getDb } from '@/lib/db/client'
+import { PersoError } from '@/lib/perso/errors'
+import type { UploadVideoResponse } from '@/lib/perso/types'
+
+let ownershipTablesReady = false
+
+async function ensureOwnershipTables() {
+  if (ownershipTablesReady) return
+  const db = getDb()
+  await db.batch([
+    {
+      sql: `CREATE TABLE IF NOT EXISTS perso_media_resources (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        space_seq INTEGER NOT NULL,
+        media_seq INTEGER NOT NULL UNIQUE,
+        source_type TEXT NOT NULL,
+        original_name TEXT,
+        file_url TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_perso_media_resources_user
+        ON perso_media_resources (user_id, created_at DESC)`,
+      args: [],
+    },
+  ])
+  ownershipTablesReady = true
+}
+
+function notFound() {
+  return new PersoError('PERSO_RESOURCE_NOT_FOUND', 'Perso resource not found', 404)
+}
+
+function forbidden() {
+  return new PersoError('PERSO_RESOURCE_FORBIDDEN', 'You do not own this Perso resource', 403)
+}
+
+export async function recordPersoMediaOwner(args: {
+  userId: string
+  spaceSeq: number
+  media: UploadVideoResponse
+  sourceType: 'external' | 'upload'
+  fileUrl?: string
+}) {
+  await ensureOwnershipTables()
+  await getDb().execute({
+    sql: `INSERT INTO perso_media_resources
+          (user_id, space_seq, media_seq, source_type, original_name, file_url, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+          ON CONFLICT(media_seq) DO UPDATE SET
+            user_id = excluded.user_id,
+            space_seq = excluded.space_seq,
+            source_type = excluded.source_type,
+            original_name = excluded.original_name,
+            file_url = excluded.file_url,
+            updated_at = datetime('now')`,
+    args: [
+      args.userId,
+      args.spaceSeq,
+      args.media.seq,
+      args.sourceType,
+      args.media.originalName || null,
+      args.fileUrl || args.media.videoFilePath || null,
+    ],
+  })
+}
+
+export async function assertPersoMediaOwner(userId: string, mediaSeq: number) {
+  await ensureOwnershipTables()
+  const db = getDb()
+  const resource = await db.execute({
+    sql: `SELECT user_id FROM perso_media_resources WHERE media_seq = ?`,
+    args: [mediaSeq],
+  })
+  const resourceOwner = resource.rows[0]?.user_id
+  if (resourceOwner) {
+    if (resourceOwner !== userId) throw forbidden()
+    return
+  }
+
+  const job = await db.execute({
+    sql: `SELECT user_id FROM dubbing_jobs WHERE media_seq = ? LIMIT 1`,
+    args: [mediaSeq],
+  })
+  const jobOwner = job.rows[0]?.user_id
+  if (!jobOwner) throw notFound()
+  if (jobOwner !== userId) throw forbidden()
+}
+
+export async function assertPersoProjectOwner(userId: string, projectSeq: number) {
+  const db = getDb()
+  const result = await db.execute({
+    sql: `SELECT dj.user_id
+          FROM job_languages jl
+          JOIN dubbing_jobs dj ON dj.id = jl.job_id
+          WHERE jl.project_seq = ?
+          LIMIT 1`,
+    args: [projectSeq],
+  })
+  const owner = result.rows[0]?.user_id
+  if (!owner) throw notFound()
+  if (owner !== userId) throw forbidden()
+}


### PR DESCRIPTION
## Summary
- Record Perso media ownership when external or direct uploads are registered.
- Check media ownership before starting translation.
- Check project ownership before progress, project detail, download, SRT, script edit/regenerate, cancel, and lip-sync calls.
- Add route tests for ownership checks and forbidden access.

Closes #201.

## QA
- npx tsc --noEmit
- npm run lint
- npm test
- npm run build
- cd extension && npm run lint
- cd extension && npm test