### PR TITLE
[codex] Add upload review and YouTube policy fields

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -25,6 +25,9 @@ interface UploadSettings {
   tags: string
   privacyStatus: PrivacyStatus
   shortsMode: ShortsMode
+  uploadCaptions: boolean
+  selfDeclaredMadeForKids: boolean
+  containsSyntheticMedia: boolean
 }
 
 const PRIVACY_OPTIONS = [
@@ -53,6 +56,9 @@ function buildDefaultSettings(item: CompletedJobLanguage, langName: string): Upl
     tags: `Dubtube, AI dubbing, ${langName}, dubbed`,
     privacyStatus: 'private',
     shortsMode: 'regular',
+    uploadCaptions: true,
+    selfDeclaredMadeForKids: false,
+    containsSyntheticMedia: true,
   }
 }
 
@@ -104,6 +110,36 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
           onChange={(e) => onChange({ ...settings, privacyStatus: e.target.value as PrivacyStatus })}
           options={PRIVACY_OPTIONS}
         />
+
+        <label className="flex items-start gap-3 rounded-lg bg-surface-50 p-3 text-sm text-surface-700 dark:bg-surface-800/50 dark:text-surface-300">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+            checked={settings.uploadCaptions}
+            onChange={(e) => onChange({ ...settings, uploadCaptions: e.target.checked })}
+          />
+          <span>Upload translated SRT captions with the video</span>
+        </label>
+
+        <label className="flex items-start gap-3 rounded-lg bg-surface-50 p-3 text-sm text-surface-700 dark:bg-surface-800/50 dark:text-surface-300">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+            checked={settings.selfDeclaredMadeForKids}
+            onChange={(e) => onChange({ ...settings, selfDeclaredMadeForKids: e.target.checked })}
+          />
+          <span>Made for kids</span>
+        </label>
+
+        <label className="flex items-start gap-3 rounded-lg bg-surface-50 p-3 text-sm text-surface-700 dark:bg-surface-800/50 dark:text-surface-300">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+            checked={settings.containsSyntheticMedia}
+            onChange={(e) => onChange({ ...settings, containsSyntheticMedia: e.target.checked })}
+          />
+          <span>Disclose AI-generated or synthetic media</span>
+        </label>
 
         <div>
           <label className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
@@ -237,6 +273,8 @@ function UploadRow({ item, userId }: UploadRowProps) {
           description: settings.description,
           tags: v.tags,
           privacyStatus: settings.privacyStatus,
+          selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
+          containsSyntheticMedia: settings.containsSyntheticMedia,
           language: item.language_code,
         })
 
@@ -262,7 +300,7 @@ function UploadRow({ item, userId }: UploadRowProps) {
         const r = await uploadOnce(v)
         results.push({ variant: v, videoId: r.videoId })
 
-        if (srtUrl) {
+        if (settings.uploadCaptions && srtUrl) {
           try {
             const srtRes = await fetch(srtUrl)
             const srtText = await srtRes.text()

--- a/src/app/api/youtube/upload/route.ts
+++ b/src/app/api/youtube/upload/route.ts
@@ -28,6 +28,8 @@ export async function POST(req: NextRequest) {
       tags: String(form.get('tags') || ''),
       categoryId: (form.get('categoryId') as string) || undefined,
       privacyStatus: (form.get('privacyStatus') as string) || undefined,
+      selfDeclaredMadeForKids: (form.get('selfDeclaredMadeForKids') as string) || undefined,
+      containsSyntheticMedia: (form.get('containsSyntheticMedia') as string) || undefined,
       language: (form.get('language') as string) || undefined,
       localizations: (form.get('localizations') as string) || undefined,
     }
@@ -63,6 +65,8 @@ export async function POST(req: NextRequest) {
       tags: fields.tags,
       categoryId: fields.categoryId,
       privacyStatus: fields.privacyStatus,
+      selfDeclaredMadeForKids: fields.selfDeclaredMadeForKids,
+      containsSyntheticMedia: fields.containsSyntheticMedia,
       language: fields.language,
       localizations: fields.localizations,
     })

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -82,6 +82,8 @@ describe('POST /api/youtube/upload', () => {
       ['description', 'Desc'],
       ['tags', 'a,b'],
       ['language', 'ko'],
+      ['selfDeclaredMadeForKids', 'false'],
+      ['containsSyntheticMedia', 'true'],
     ])
     const req = {
       url: 'http://localhost/api/youtube/upload',
@@ -98,6 +100,8 @@ describe('POST /api/youtube/upload', () => {
         accessToken: 'mock-token',
         title: 'Test',
         tags: ['a', 'b'],
+        selfDeclaredMadeForKids: false,
+        containsSyntheticMedia: true,
       }),
     )
   })

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useMemo, useRef } from 'react'
-import { ArrowLeft, ArrowRight, Languages, Link2, Upload, Zap } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Captions, Languages, Link2, ShieldCheck, Sparkles, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
 import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
+import { useAuthStore } from '@/stores/authStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
@@ -33,6 +34,7 @@ export function UploadSettingsStep() {
     prevStep,
     nextStep,
   } = useDubbingStore()
+  const user = useAuthStore((s) => s.user)
 
   // YouTube 설정 페이지의 기본값과 동기화 (사용자 override 없을 때만).
   useEffect(() => {
@@ -92,12 +94,18 @@ export function UploadSettingsStep() {
     setUploadSettings({ tags: parsed })
   }
 
-  const canContinue =
+  const isMultiAudio = deliverableMode === 'originalWithMultiAudio'
+  const uploadsVideoToYouTube =
+    deliverableMode === 'newDubbedVideos' ||
+    (isMultiAudio && videoSource?.type === 'upload')
+  const needsAutoUploadReview = uploadSettings.autoUpload
+  const baseCanContinue =
     deliverableMode === 'originalWithMultiAudio'
       ? true
       : uploadSettings.title.trim().length > 0
-
-  const isMultiAudio = deliverableMode === 'originalWithMultiAudio'
+  const canContinue = baseCanContinue && (!needsAutoUploadReview || uploadSettings.uploadReviewConfirmed)
+  const privacyLabel = PRIVACY_OPTIONS.find((o) => o.value === uploadSettings.privacyStatus)?.label ?? uploadSettings.privacyStatus
+  const targetChannelLabel = user?.email ?? 'Google 로그인 후 연결된 YouTube 채널'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -258,6 +266,42 @@ export function UploadSettingsStep() {
             />
           )}
 
+          {(deliverableMode === 'newDubbedVideos' || isMultiAudio) && (
+            <ToggleRow
+              icon={<Captions className="h-4 w-4 text-surface-400" />}
+              label={isMultiAudio ? '자막(SRT) 업로드' : '더빙 영상에 자막(SRT) 첨부'}
+              description={isMultiAudio ? '완료된 언어의 번역 자막을 대상 영상에 업로드합니다.' : '즉시 업로드와 예약 업로드 모두 번역 자막을 함께 처리합니다.'}
+              active={uploadSettings.uploadCaptions}
+              activeLabel="ON"
+              inactiveLabel="OFF"
+              onToggle={() => setUploadSettings({ uploadCaptions: !uploadSettings.uploadCaptions })}
+            />
+          )}
+
+          {uploadsVideoToYouTube && (
+            <>
+              <ToggleRow
+                icon={<ShieldCheck className="h-4 w-4 text-surface-400" />}
+                label="아동용으로 제작됨"
+                description="YouTube의 아동용 콘텐츠 신고값입니다. 기본값은 아니오입니다."
+                active={uploadSettings.selfDeclaredMadeForKids}
+                activeLabel="예"
+                inactiveLabel="아니오"
+                onToggle={() => setUploadSettings({ selfDeclaredMadeForKids: !uploadSettings.selfDeclaredMadeForKids })}
+              />
+
+              <ToggleRow
+                icon={<Sparkles className="h-4 w-4 text-amber-500" />}
+                label="AI 합성/변형 콘텐츠 공개"
+                description="AI 더빙 음성이 포함되므로 기본값은 공개 ON입니다."
+                active={uploadSettings.containsSyntheticMedia}
+                activeLabel="ON"
+                inactiveLabel="OFF"
+                onToggle={() => setUploadSettings({ containsSyntheticMedia: !uploadSettings.containsSyntheticMedia })}
+              />
+            </>
+          )}
+
           {/* 다국어 오디오 트랙: 자막 모드에서만 노출. 실서비스 검증 전이라 비활성. */}
           {isMultiAudio && (
             <ToggleRow
@@ -273,6 +317,39 @@ export function UploadSettingsStep() {
           )}
         </div>
       </Card>
+
+      {uploadSettings.autoUpload && (
+        <Card className="border-amber-200 bg-amber-50/40 dark:border-amber-900 dark:bg-amber-950/10">
+          <CardTitle>자동 업로드 최종 확인</CardTitle>
+          <div className="mt-4 grid gap-2 text-xs text-surface-600 dark:text-surface-300 sm:grid-cols-2">
+            <ReviewItem label="채널" value={targetChannelLabel} />
+            <ReviewItem label="공개 범위" value={privacyLabel} />
+            <ReviewItem label="Shorts" value={uploadSettings.uploadAsShort ? 'ON' : 'OFF'} />
+            <ReviewItem label="자막" value={uploadSettings.uploadCaptions ? '업로드' : '업로드 안 함'} />
+            <ReviewItem label="아동용" value={uploadSettings.selfDeclaredMadeForKids ? '예' : '아니오'} />
+            <ReviewItem label="AI 합성 공개" value={uploadSettings.containsSyntheticMedia ? 'ON' : 'OFF'} />
+            <ReviewItem
+              label="제목/설명 번역"
+              value={`${getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage} 기준 → ${selectedLanguages.length}개 언어`}
+            />
+            <ReviewItem
+              label="localizations"
+              value={deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload' ? 'YouTube localizations 포함' : '언어별 제목/설명 적용'}
+            />
+          </div>
+          <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border border-amber-200 bg-white/70 p-3 text-sm text-surface-700 dark:border-amber-900/70 dark:bg-surface-900/50 dark:text-surface-200">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+              checked={uploadSettings.uploadReviewConfirmed}
+              onChange={(e) => setUploadSettings({ uploadReviewConfirmed: e.target.checked })}
+            />
+            <span>
+              위 채널, 공개 범위, 제목/설명 번역, 자막, Shorts, 아동용, AI 합성 공개 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.
+            </span>
+          </label>
+        </Card>
+      )}
 
       {/* Preview — only for newDubbedVideos */}
       {deliverableMode === 'newDubbedVideos' && firstLangName && (
@@ -349,6 +426,15 @@ function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabe
       >
         {active ? activeLabel : inactiveLabel}
       </button>
+    </div>
+  )
+}
+
+function ReviewItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-white/70 px-3 py-2 dark:bg-surface-900/50">
+      <p className="text-[11px] font-medium text-surface-400">{label}</p>
+      <p className="mt-0.5 truncate text-surface-700 dark:text-surface-200">{value}</p>
     </div>
   )
 }

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -49,7 +49,20 @@ export function UploadStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
 
-  const { autoUpload, uploadAsShort, attachOriginalLink, title: settingsTitle, description: settingsDescription, tags: settingsTags, privacyStatus, metadataLanguage } = uploadSettings
+  const {
+    autoUpload,
+    uploadAsShort,
+    attachOriginalLink,
+    title: settingsTitle,
+    description: settingsDescription,
+    tags: settingsTags,
+    privacyStatus,
+    metadataLanguage,
+    uploadCaptions: shouldUploadCaptions,
+    selfDeclaredMadeForKids,
+    containsSyntheticMedia,
+    uploadReviewConfirmed,
+  } = uploadSettings
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
@@ -160,6 +173,8 @@ export function UploadStep() {
         description: settingsDescription || '',
         tags: settingsTags,
         privacyStatus,
+        selfDeclaredMadeForKids,
+        containsSyntheticMedia,
         language: metadataLanguage,
         localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
@@ -176,7 +191,7 @@ export function UploadStep() {
       addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
       return null
     }
-  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, selfDeclaredMadeForKids, containsSyntheticMedia, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
 
   // ─── Audio → Studio helper ──────────────────────────────────────────
   const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {
@@ -300,26 +315,30 @@ export function UploadStep() {
         description: ytDescription,
         tags: langTags,
         privacyStatus,
+        selfDeclaredMadeForKids,
+        containsSyntheticMedia,
         language: langCode,
       })
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 90 } }))
 
       // Upload SRT caption — use Perso's official translated SRT (audioScript target)
       setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 92 } }))
-      try {
-        const pSeq = projectMap[langCode]
-        if (pSeq && spaceSeq) {
-          const srtText = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
-          if (srtText.trim().length > 0) {
-            await ytUploadCaption({
-              videoId: result.videoId,
-              language: toBcp47(langCode),
-              name: `${lang.name} subtitles`,
-              srtContent: srtText,
-            })
+      if (shouldUploadCaptions) {
+        try {
+          const pSeq = projectMap[langCode]
+          if (pSeq && spaceSeq) {
+            const srtText = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+            if (srtText.trim().length > 0) {
+              await ytUploadCaption({
+                videoId: result.videoId,
+                language: toBcp47(langCode),
+                name: `${lang.name} subtitles`,
+                srtContent: srtText,
+              })
+            }
           }
-        }
-      } catch { /* caption upload is optional */ }
+        } catch { /* caption upload is optional */ }
+      }
 
       setYtUploads((prev) => ({
         ...prev,
@@ -362,7 +381,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsDescription, settingsTags, privacyStatus, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, containsSyntheticMedia, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
 
   // ─── Queue upload (background — survives tab close) ─────────────────
   const queueYouTubeUpload = useCallback(async (langCode: string) => {
@@ -389,6 +408,16 @@ export function UploadStep() {
         lang.name,
         ...(uploadAsShort ? ['Shorts'] : []),
       ]))
+      let srtContent: string | null = null
+      if (shouldUploadCaptions) {
+        const pSeq = projectMap[langCode]
+        if (pSeq && spaceSeq) {
+          try {
+            const srtText = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+            srtContent = srtText.trim().length > 0 ? srtText : null
+          } catch { /* queue caption is optional */ }
+        }
+      }
 
       await dbMutation({
         type: 'queueYouTubeUpload',
@@ -403,6 +432,12 @@ export function UploadStep() {
           privacyStatus,
           language: langCode,
           isShort: uploadAsShort,
+          uploadCaptions: shouldUploadCaptions,
+          captionLanguage: toBcp47(langCode),
+          captionName: `${lang.name} subtitles`,
+          srtContent,
+          selfDeclaredMadeForKids,
+          containsSyntheticMedia,
         },
       })
 
@@ -423,7 +458,7 @@ export function UploadStep() {
       }))
       addToast({ type: 'error', title: `${lang?.name} 큐 등록 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsDescription, settingsTags, privacyStatus, ensureTranslations, applyDescriptionFooter])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, containsSyntheticMedia, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
 
   const completedLangs = selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
@@ -494,6 +529,7 @@ export function UploadStep() {
   useEffect(() => {
     if (deliverableMode !== 'originalWithMultiAudio') return
     if (!autoUpload || !isAuthenticated) return
+    if (!uploadReviewConfirmed) return
     if (completedLangs.length === 0) return
     if (autoChainTriggered.current) return
     autoChainTriggered.current = true
@@ -507,23 +543,24 @@ export function UploadStep() {
         targetVideoId = await uploadOriginalToYouTube()
       }
 
-      if (targetVideoId) {
+      if (targetVideoId && shouldUploadCaptions) {
         await uploadCaptions(targetVideoId, completedLangs)
       }
     }
 
     chain()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deliverableMode, autoUpload, isAuthenticated, completedLangs.length])
+  }, [deliverableMode, autoUpload, isAuthenticated, uploadReviewConfirmed, completedLangs.length])
 
   // ─── Auto-upload: newDubbedVideos ────────────────────────────────────
   useEffect(() => {
     if (deliverableMode !== 'newDubbedVideos') return
+    if (!uploadReviewConfirmed) return
     if (autoUpload && isAuthenticated && completedLangs.length > 0 && !autoUploadTriggered.current && !anyUploading) {
       autoUploadTriggered.current = true
       handleUploadAll()
     }
-  }, [deliverableMode, autoUpload, isAuthenticated, completedLangs.length, anyUploading, handleUploadAll])
+  }, [deliverableMode, autoUpload, isAuthenticated, uploadReviewConfirmed, completedLangs.length, anyUploading, handleUploadAll])
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -805,6 +842,13 @@ export function UploadStep() {
                   Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
                   {' · '}
                   공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
+                </p>
+                <p>
+                  자막: <span className="font-medium text-surface-700 dark:text-surface-300">{shouldUploadCaptions ? 'ON' : 'OFF'}</span>
+                  {' · '}
+                  아동용: <span className="font-medium text-surface-700 dark:text-surface-300">{selfDeclaredMadeForKids ? '예' : '아니오'}</span>
+                  {' · '}
+                  AI 합성 공개: <span className="font-medium text-surface-700 dark:text-surface-300">{containsSyntheticMedia ? 'ON' : 'OFF'}</span>
                 </p>
                 {attachOriginalLink && originalYouTubeUrl && (
                   <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -43,8 +43,26 @@ const buildDefaultUploadSettings = (): UploadSettings => ({
   description: '',
   tags: ['Dubtube', 'AI더빙', 'dubbed'],
   privacyStatus: readDefaultPrivacy(),
+  uploadCaptions: true,
+  selfDeclaredMadeForKids: false,
+  containsSyntheticMedia: true,
+  uploadReviewConfirmed: false,
   metadataLanguage: readDefaultLanguage(),
 })
+
+const REVIEW_RESET_FIELDS: Array<keyof UploadSettings> = [
+  'autoUpload',
+  'uploadAsShort',
+  'attachOriginalLink',
+  'title',
+  'description',
+  'tags',
+  'privacyStatus',
+  'metadataLanguage',
+  'uploadCaptions',
+  'selfDeclaredMadeForKids',
+  'containsSyntheticMedia',
+]
 
 interface DubbingState {
   // Wizard navigation
@@ -237,28 +255,36 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     // 사용자가 토글을 직접 만진 적이 있으면 그 선택을 보존한다.
     uploadSettings: s.uploadAsShortOverridden
       ? s.uploadSettings
-      : { ...s.uploadSettings, uploadAsShort: v },
+      : { ...s.uploadSettings, uploadAsShort: v, uploadReviewConfirmed: false },
   })),
 
   setDeliverableMode: (mode) => set({ deliverableMode: mode }),
   setCopyrightAcknowledged: (v) => set({ copyrightAcknowledged: v }),
 
-  setUploadSettings: (patch) => set((s) => ({
-    uploadSettings: { ...s.uploadSettings, ...patch },
-    privacyOverridden:
-      patch.privacyStatus !== undefined ? true : s.privacyOverridden,
-    metadataLanguageOverridden:
-      patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
-    uploadAsShortOverridden:
-      patch.uploadAsShort !== undefined ? true : s.uploadAsShortOverridden,
-  })),
+  setUploadSettings: (patch) => set((s) => {
+    const shouldResetReview = REVIEW_RESET_FIELDS.some((field) => patch[field] !== undefined)
+    return {
+      uploadSettings: {
+        ...s.uploadSettings,
+        ...patch,
+        uploadReviewConfirmed:
+          patch.uploadReviewConfirmed ?? (shouldResetReview ? false : s.uploadSettings.uploadReviewConfirmed),
+      },
+      privacyOverridden:
+        patch.privacyStatus !== undefined ? true : s.privacyOverridden,
+      metadataLanguageOverridden:
+        patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
+      uploadAsShortOverridden:
+        patch.uploadAsShort !== undefined ? true : s.uploadAsShortOverridden,
+    }
+  }),
 
   syncPrivacyFromGlobalDefault: () => set((s) => {
     if (s.privacyOverridden) return s
     const next = readDefaultPrivacy()
     if (s.uploadSettings.privacyStatus === next) return s
     return {
-      uploadSettings: { ...s.uploadSettings, privacyStatus: next },
+      uploadSettings: { ...s.uploadSettings, privacyStatus: next, uploadReviewConfirmed: false },
     }
   }),
 
@@ -267,7 +293,7 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     const next = readDefaultLanguage()
     if (s.uploadSettings.metadataLanguage === next) return s
     return {
-      uploadSettings: { ...s.uploadSettings, metadataLanguage: next },
+      uploadSettings: { ...s.uploadSettings, metadataLanguage: next, uploadReviewConfirmed: false },
     }
   }),
 

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -12,6 +12,10 @@ export interface UploadSettings {
   description: string
   tags: string[]
   privacyStatus: PrivacyStatus
+  uploadCaptions: boolean
+  selfDeclaredMadeForKids: boolean
+  containsSyntheticMedia: boolean
+  uploadReviewConfirmed: boolean
   /**
    * 사용자가 작성한 제목/설명의 언어. 다른 대상 언어로 자동 번역하는 기준.
    * 마이페이지의 `defaultLanguage`로 초기화되며 더빙별로 override 가능.

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -296,6 +296,8 @@ describe('ytUploadVideo', () => {
       tags: ['a', 'b'],
       categoryId: '22',
       privacyStatus: 'unlisted',
+      selfDeclaredMadeForKids: false,
+      containsSyntheticMedia: true,
       language: 'ko',
     })
     expect(result.videoId).toBe('yt1')
@@ -305,6 +307,8 @@ describe('ytUploadVideo', () => {
     expect(body.get('tags')).toBe('a,b')
     expect(body.get('categoryId')).toBe('22')
     expect(body.get('privacyStatus')).toBe('unlisted')
+    expect(body.get('selfDeclaredMadeForKids')).toBe('false')
+    expect(body.get('containsSyntheticMedia')).toBe('true')
     expect(body.get('language')).toBe('ko')
   })
 
@@ -320,6 +324,8 @@ describe('ytUploadVideo', () => {
     const body = mockFetch.mock.calls[0][1].body as FormData
     expect(body.get('categoryId')).toBeNull()
     expect(body.get('privacyStatus')).toBeNull()
+    expect(body.get('selfDeclaredMadeForKids')).toBeNull()
+    expect(body.get('containsSyntheticMedia')).toBeNull()
     expect(body.get('language')).toBeNull()
   })
 })

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -17,6 +17,8 @@ export async function ytUploadVideo(params: {
   tags: string[]
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
+  selfDeclaredMadeForKids?: boolean
+  containsSyntheticMedia?: boolean
   language?: string
   /** BCP-47 language code → { title, description } 맵. snippet.localizations로 전달. */
   localizations?: Record<string, { title: string; description: string }>
@@ -32,6 +34,12 @@ export async function ytUploadVideo(params: {
   form.append('tags', params.tags.join(','))
   if (params.categoryId) form.append('categoryId', params.categoryId)
   if (params.privacyStatus) form.append('privacyStatus', params.privacyStatus)
+  if (params.selfDeclaredMadeForKids !== undefined) {
+    form.append('selfDeclaredMadeForKids', String(params.selfDeclaredMadeForKids))
+  }
+  if (params.containsSyntheticMedia !== undefined) {
+    form.append('containsSyntheticMedia', String(params.containsSyntheticMedia))
+  }
   if (params.language) form.append('language', params.language)
   if (params.localizations && Object.keys(params.localizations).length > 0) {
     form.append('localizations', JSON.stringify(params.localizations))

--- a/src/lib/db/queries/upload-queue.ts
+++ b/src/lib/db/queries/upload-queue.ts
@@ -16,6 +16,12 @@ export interface UploadQueueItem {
   privacyStatus: string
   language: string
   isShort: boolean
+  uploadCaptions: boolean
+  captionLanguage: string | null
+  captionName: string | null
+  srtContent: string | null
+  selfDeclaredMadeForKids: boolean
+  containsSyntheticMedia: boolean
   status: QueueStatus
   retries: number
   error: string | null
@@ -46,6 +52,12 @@ async function ensureTable() {
       privacy_status TEXT NOT NULL DEFAULT 'private',
       language TEXT NOT NULL DEFAULT '',
       is_short INTEGER NOT NULL DEFAULT 0,
+      upload_captions INTEGER NOT NULL DEFAULT 1,
+      caption_language TEXT,
+      caption_name TEXT,
+      srt_content TEXT,
+      self_declared_made_for_kids INTEGER NOT NULL DEFAULT 0,
+      contains_synthetic_media INTEGER NOT NULL DEFAULT 0,
       status TEXT NOT NULL DEFAULT 'pending',
       retries INTEGER NOT NULL DEFAULT 0,
       error TEXT,
@@ -55,6 +67,24 @@ async function ensureTable() {
     )`,
     args: [],
   })
+  const columns = await db.execute({
+    sql: 'PRAGMA table_info(upload_queue)',
+    args: [],
+  })
+  const existing = new Set(columns.rows.map((row) => String(row.name)))
+  const addColumn = async (name: string, definition: string) => {
+    if (existing.has(name)) return
+    await db.execute({
+      sql: `ALTER TABLE upload_queue ADD COLUMN ${name} ${definition}`,
+      args: [],
+    })
+  }
+  await addColumn('upload_captions', 'INTEGER NOT NULL DEFAULT 1')
+  await addColumn('caption_language', 'TEXT')
+  await addColumn('caption_name', 'TEXT')
+  await addColumn('srt_content', 'TEXT')
+  await addColumn('self_declared_made_for_kids', 'INTEGER NOT NULL DEFAULT 0')
+  await addColumn('contains_synthetic_media', 'INTEGER NOT NULL DEFAULT 0')
   tableEnsured = true
 }
 
@@ -69,12 +99,22 @@ export async function createUploadQueueItem(item: {
   privacyStatus: string
   language: string
   isShort: boolean
+  uploadCaptions?: boolean
+  captionLanguage?: string | null
+  captionName?: string | null
+  srtContent?: string | null
+  selfDeclaredMadeForKids?: boolean
+  containsSyntheticMedia?: boolean
 }): Promise<number> {
   await ensureTable()
   const db = getDb()
   const result = await db.execute({
-    sql: `INSERT INTO upload_queue (user_id, job_id, lang_code, video_url, title, description, tags, privacy_status, language, is_short)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO upload_queue (
+            user_id, job_id, lang_code, video_url, title, description, tags,
+            privacy_status, language, is_short, upload_captions, caption_language,
+            caption_name, srt_content, self_declared_made_for_kids, contains_synthetic_media
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       item.userId,
       item.jobId,
@@ -86,6 +126,12 @@ export async function createUploadQueueItem(item: {
       item.privacyStatus,
       item.language,
       item.isShort ? 1 : 0,
+      (item.uploadCaptions ?? true) ? 1 : 0,
+      item.captionLanguage ?? null,
+      item.captionName ?? null,
+      item.srtContent ?? null,
+      item.selfDeclaredMadeForKids ? 1 : 0,
+      item.containsSyntheticMedia ? 1 : 0,
     ],
   })
   return Number(result.lastInsertRowid)
@@ -219,6 +265,12 @@ function rowToItem(row: Record<string, unknown>): UploadQueueItem {
     privacyStatus: String(row.privacy_status),
     language: String(row.language),
     isShort: Boolean(row.is_short),
+    uploadCaptions: Boolean(row.upload_captions),
+    captionLanguage: row.caption_language ? String(row.caption_language) : null,
+    captionName: row.caption_name ? String(row.caption_name) : null,
+    srtContent: row.srt_content ? String(row.srt_content) : null,
+    selfDeclaredMadeForKids: Boolean(row.self_declared_made_for_kids),
+    containsSyntheticMedia: Boolean(row.contains_synthetic_media),
     status: String(row.status) as QueueStatus,
     retries: Number(row.retries),
     error: row.error ? String(row.error) : null,

--- a/src/lib/upload-queue/process.test.ts
+++ b/src/lib/upload-queue/process.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/db/queries/upload-queue'
 import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
-import { uploadVideoToYouTube } from '@/lib/youtube/upload'
+import { uploadCaptionToYouTube, uploadVideoToYouTube } from '@/lib/youtube/upload'
 
 vi.mock('@/lib/db/queries/upload-queue', () => ({
   claimPendingUploads: vi.fn(),
@@ -26,6 +26,7 @@ vi.mock('@/lib/auth/token-refresh', () => ({
 
 vi.mock('@/lib/youtube/upload', () => ({
   uploadVideoToYouTube: vi.fn(),
+  uploadCaptionToYouTube: vi.fn(),
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -47,6 +48,12 @@ const queueItem = {
   privacyStatus: 'private',
   language: 'en',
   isShort: false,
+  uploadCaptions: true,
+  captionLanguage: 'en',
+  captionName: 'English subtitles',
+  srtContent: '1\n00:00:00,000 --> 00:00:01,000\nHello',
+  selfDeclaredMadeForKids: false,
+  containsSyntheticMedia: true,
   status: 'processing' as const,
   retries: 0,
   error: null,
@@ -96,8 +103,17 @@ describe('processUploadQueue', () => {
         accessToken: 'access-token',
         title: 'Translated title',
         tags: ['dubtube', 'english'],
+        selfDeclaredMadeForKids: false,
+        containsSyntheticMedia: true,
       }),
     )
+    expect(uploadCaptionToYouTube).toHaveBeenCalledWith({
+      accessToken: 'access-token',
+      videoId: 'yt-123',
+      language: 'en',
+      name: 'English subtitles',
+      srtContent: queueItem.srtContent,
+    })
     expect(completeQueueItem).toHaveBeenCalledWith(10, 'yt-123')
     expect(createYouTubeUpload).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'user-1', youtubeVideoId: 'yt-123' }),

--- a/src/lib/upload-queue/process.ts
+++ b/src/lib/upload-queue/process.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/db/queries/upload-queue'
 import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
-import { uploadVideoToYouTube } from '@/lib/youtube/upload'
+import { uploadCaptionToYouTube, uploadVideoToYouTube } from '@/lib/youtube/upload'
 import { logger } from '@/lib/logger'
 
 export interface ProcessUploadQueueOptions {
@@ -58,8 +58,27 @@ export async function processUploadQueue(options: ProcessUploadQueueOptions = {}
         description: item.description,
         tags: item.tags ? item.tags.split(',') : [],
         privacyStatus: item.privacyStatus as 'public' | 'unlisted' | 'private',
+        selfDeclaredMadeForKids: item.selfDeclaredMadeForKids,
+        containsSyntheticMedia: item.containsSyntheticMedia,
         language: item.language || undefined,
       })
+
+      if (item.uploadCaptions && item.srtContent?.trim()) {
+        try {
+          await uploadCaptionToYouTube({
+            accessToken,
+            videoId: result.videoId,
+            language: item.captionLanguage || item.langCode,
+            name: item.captionName || `${item.language || item.langCode} subtitles`,
+            srtContent: item.srtContent,
+          })
+        } catch (err) {
+          logger.warn('queue caption upload failed', {
+            queueId: item.id,
+            error: err instanceof Error ? err.message : 'Unknown error',
+          })
+        }
+      }
 
       await completeQueueItem(item.id, result.videoId)
 

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -161,6 +161,12 @@ const queueYouTubeUploadSchema = z.object({
     privacyStatus: z.string().min(1),
     language: z.string(),
     isShort: z.boolean(),
+    uploadCaptions: z.boolean().optional(),
+    captionLanguage: z.string().nullable().optional(),
+    captionName: z.string().nullable().optional(),
+    srtContent: z.string().nullable().optional(),
+    selfDeclaredMadeForKids: z.boolean().optional(),
+    containsSyntheticMedia: z.boolean().optional(),
   }),
 })
 

--- a/src/lib/validators/youtube.test.ts
+++ b/src/lib/validators/youtube.test.ts
@@ -120,11 +120,15 @@ describe('uploadFormSchema', () => {
       tags: 'a,b,c',
       categoryId: '22',
       privacyStatus: 'unlisted',
+      selfDeclaredMadeForKids: 'false',
+      containsSyntheticMedia: 'true',
       language: 'ko',
     })
     expect(result.title).toBe('My Video')
     expect(result.tags).toEqual(['a', 'b', 'c'])
     expect(result.privacyStatus).toBe('unlisted')
+    expect(result.selfDeclaredMadeForKids).toBe(false)
+    expect(result.containsSyntheticMedia).toBe(true)
   })
 
   it('defaults title and description to empty', () => {

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -48,6 +48,15 @@ const localizationsRecordSchema = z.record(
   }),
 )
 
+const formBooleanSchema = z
+  .union([z.boolean(), z.string()])
+  .optional()
+  .transform((v) => {
+    if (v === undefined) return undefined
+    if (typeof v === 'boolean') return v
+    return v === 'true'
+  })
+
 export const uploadFormSchema = z.object({
   title: z.string().default(''),
   description: z.string().default(''),
@@ -57,6 +66,8 @@ export const uploadFormSchema = z.object({
     .transform((v) => (v ? v.split(',').map((t) => t.trim()).filter(Boolean) : [])),
   categoryId: z.string().optional(),
   privacyStatus: z.enum(['public', 'unlisted', 'private']).optional(),
+  selfDeclaredMadeForKids: formBooleanSchema,
+  containsSyntheticMedia: formBooleanSchema,
   language: z.string().optional(),
   /** form에서는 JSON 문자열로 전달. */
   localizations: z

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -277,8 +277,16 @@ describe('uploadVideoToYouTube', () => {
       title: 'My Vid',
       description: 'Desc',
       tags: ['tag1'],
+      selfDeclaredMadeForKids: true,
+      containsSyntheticMedia: true,
     })
     expect(result).toEqual({ videoId: 'yt-abc', title: 'My Vid', status: 'uploaded' })
+    const initBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string)
+    expect(initBody.status).toMatchObject({
+      privacyStatus: 'private',
+      selfDeclaredMadeForKids: true,
+      containsSyntheticMedia: true,
+    })
   })
 
   it('throws on init failure', async () => {

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -18,6 +18,8 @@ export interface YouTubeUploadInput {
   tags: string[]
   categoryId?: string
   privacyStatus?: 'public' | 'unlisted' | 'private'
+  selfDeclaredMadeForKids?: boolean
+  containsSyntheticMedia?: boolean
   language?: string
   /**
    * BCP-47 언어 코드를 키로 한 추가 번역 맵.
@@ -37,6 +39,8 @@ export async function uploadVideoToYouTube(
     tags,
     categoryId = '22',
     privacyStatus = 'private',
+    selfDeclaredMadeForKids = false,
+    containsSyntheticMedia = false,
     language = 'en',
     localizations,
   } = input
@@ -53,7 +57,8 @@ export async function uploadVideoToYouTube(
     },
     status: {
       privacyStatus,
-      selfDeclaredMadeForKids: false,
+      selfDeclaredMadeForKids,
+      containsSyntheticMedia,
     },
   }
   if (hasLocalizations) {


### PR DESCRIPTION
## Summary
- require explicit review before automatic upload runs after processing
- add YouTube policy controls for captions, made-for-kids, Shorts, and synthetic/AI media disclosure
- propagate policy fields through immediate uploads, completed upload modal, queued uploads, and YouTube metadata

## QA
- npx tsc --noEmit
- npm run lint
- npm test
- npm run build
- (cd extension; npm run lint)
- (cd extension; npm test)

Closes #204