### PR TITLE
[codex] Add i18n base and metadata translation

### DIFF
--- a/src/app/(app)/metadata/layout.tsx
+++ b/src/app/(app)/metadata/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '메타데이터 번역',
+}
+
+export default function MetadataLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/(app)/metadata/page.tsx
+++ b/src/app/(app)/metadata/page.tsx
@@ -1,0 +1,16 @@
+import { MetadataLocalizationTool } from '@/features/metadata/components/MetadataLocalizationTool'
+
+export default function MetadataPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-surface-900 dark:text-white">메타데이터 번역</h1>
+        <p className="text-surface-500 dark:text-surface-400">
+          더빙이나 자막 없이 YouTube 제목·설명 번역만 생성하고 적용합니다.
+        </p>
+      </div>
+
+      <MetadataLocalizationTool />
+    </div>
+  )
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,5 +1,4 @@
-import { Card, CardTitle } from '@/components/ui'
-import { Settings } from 'lucide-react'
+import { SettingsClient } from '@/features/settings/components/SettingsClient'
 
 export default function SettingsPage() {
   return (
@@ -9,12 +8,7 @@ export default function SettingsPage() {
         <p className="text-surface-500 dark:text-surface-400">계정 및 앱 설정을 관리하세요</p>
       </div>
 
-      <Card>
-        <div className="flex items-center gap-3 py-8 text-surface-400">
-          <Settings className="h-5 w-5" />
-          <CardTitle>준비 중</CardTitle>
-        </div>
-      </Card>
+      <SettingsClient />
     </div>
   )
 }

--- a/src/app/api/youtube/metadata/route.ts
+++ b/src/app/api/youtube/metadata/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { fetchVideoMetadata, updateVideoLocalizations } from '@/lib/youtube/server'
+import {
+  parseQuery,
+  parseYtBody,
+  withTokenRetry,
+  ytHandle,
+} from '@/lib/youtube/route-helpers'
+import {
+  metadataQuerySchema,
+  metadataUpdateBodySchema,
+} from '@/lib/validators/youtube'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return ytHandle(async () => {
+    const url = new URL(req.url)
+    const { videoId } = parseQuery(url, metadataQuerySchema)
+    return withTokenRetry(req, (accessToken) => fetchVideoMetadata(accessToken, videoId))
+  })
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return ytHandle(async () => {
+    const body = await parseYtBody(req, metadataUpdateBodySchema)
+    return withTokenRetry(req, (accessToken) =>
+      updateVideoLocalizations({
+        accessToken,
+        videoId: body.videoId,
+        sourceLang: body.sourceLang,
+        title: body.title,
+        description: body.description,
+        localizations: body.localizations,
+      }),
+    )
+  })
+}

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -51,6 +51,24 @@ vi.mock('@/lib/youtube/server', () => ({
     title: 'My Channel',
     thumbnail: '',
   })),
+  fetchVideoMetadata: vi.fn(async () => ({
+    videoId: 'yt-123',
+    title: 'Original title',
+    description: 'Original description',
+    categoryId: '22',
+    tags: ['tag'],
+    defaultLanguage: 'ko',
+    localizations: {},
+  })),
+  updateVideoLocalizations: vi.fn(async () => ({
+    videoId: 'yt-123',
+    title: 'Original title',
+    description: 'Original description',
+    categoryId: '22',
+    tags: ['tag'],
+    defaultLanguage: 'ko',
+    localizations: { en: { title: 'English title', description: 'English description' } },
+  })),
   YouTubeError: class YouTubeError extends Error {
     constructor(
       public status: number,
@@ -224,6 +242,57 @@ describe('GET /api/youtube/stats', () => {
     const body = await res.json()
     expect(body.ok).toBe(true)
     expect(vi.mocked(fetchVideoStatistics)).toHaveBeenCalledWith('mock-token', [])
+  })
+})
+
+describe('/api/youtube/metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches current video metadata', async () => {
+    const { GET } = await import('./metadata/route')
+    const { fetchVideoMetadata } = await import('@/lib/youtube/server')
+    const req = new NextRequest('http://localhost/api/youtube/metadata?videoId=yt-123')
+
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.data.videoId).toBe('yt-123')
+    expect(fetchVideoMetadata).toHaveBeenCalledWith('mock-token', 'yt-123')
+  })
+
+  it('updates localizations without uploading media', async () => {
+    const { POST } = await import('./metadata/route')
+    const { updateVideoLocalizations } = await import('@/lib/youtube/server')
+    const req = new NextRequest('http://localhost/api/youtube/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        videoId: 'yt-123',
+        sourceLang: 'ko',
+        title: 'Original title',
+        description: 'Original description',
+        localizations: {
+          en: { title: 'English title', description: 'English description' },
+        },
+      }),
+    })
+
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(body.ok).toBe(true)
+    expect(updateVideoLocalizations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: 'mock-token',
+        videoId: 'yt-123',
+        localizations: {
+          en: { title: 'English title', description: 'English description' },
+        },
+      }),
+    )
   })
 })
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/utils/cn'
+import { useI18nStore } from '@/stores/i18nStore'
 import {
   LayoutDashboard,
   Languages,
@@ -11,19 +12,22 @@ import {
   Layers,
   Settings,
   Upload,
+  Globe2,
 } from 'lucide-react'
 
 const navItems = [
-  { to: '/dashboard', label: '대시보드', icon: LayoutDashboard },
-  { to: '/dubbing', label: '새 더빙', icon: Languages },
-  { to: '/batch', label: '배치 큐', icon: Layers },
-  { to: '/uploads', label: 'YouTube 업로드', icon: Upload },
-  { to: '/youtube', label: 'YouTube', icon: Video },
-  { to: '/billing', label: '결제', icon: CreditCard },
+  { to: '/dashboard', label: { ko: '대시보드', en: 'Dashboard' }, icon: LayoutDashboard },
+  { to: '/dubbing', label: { ko: '새 더빙', en: 'New dubbing' }, icon: Languages },
+  { to: '/metadata', label: { ko: '메타데이터 번역', en: 'Metadata' }, icon: Globe2 },
+  { to: '/batch', label: { ko: '배치 큐', en: 'Batch queue' }, icon: Layers },
+  { to: '/uploads', label: { ko: 'YouTube 업로드', en: 'YouTube uploads' }, icon: Upload },
+  { to: '/youtube', label: { ko: 'YouTube', en: 'YouTube' }, icon: Video },
+  { to: '/billing', label: { ko: '결제', en: 'Billing' }, icon: CreditCard },
 ]
 
 export function Sidebar() {
   const pathname = usePathname()
+  const appLocale = useI18nStore((state) => state.appLocale)
 
   return (
     <aside className="fixed left-0 top-0 z-40 flex h-screen w-64 flex-col border-r border-surface-200 bg-white dark:border-surface-800 dark:bg-surface-900">
@@ -51,7 +55,7 @@ export function Sidebar() {
               )}
             >
               <Icon className="h-5 w-5" />
-              {label}
+              {label[appLocale]}
             </Link>
           )
         })}
@@ -63,7 +67,7 @@ export function Sidebar() {
           className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-surface-600 hover:bg-surface-100 dark:text-surface-400 dark:hover:bg-surface-800"
         >
           <Settings className="h-5 w-5" />
-          설정
+          {appLocale === 'en' ? 'Settings' : '설정'}
         </Link>
       </div>
     </aside>

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -6,6 +6,7 @@ import { queryClient } from '@/services/queryClient'
 import { ToastContainer } from '@/components/feedback/Toast'
 import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
+import { useI18nStore } from '@/stores/i18nStore'
 import { restoreSession } from '@/lib/google-auth'
 
 function ThemeHydrator() {
@@ -45,11 +46,24 @@ function AuthHydrator() {
   return null
 }
 
+function I18nHydrator() {
+  useEffect(() => {
+    useI18nStore.persist.rehydrate()
+    const unsubscribe = useI18nStore.subscribe((state) => {
+      document.documentElement.lang = state.appLocale
+    })
+    document.documentElement.lang = useI18nStore.getState().appLocale
+    return unsubscribe
+  }, [])
+  return null
+}
+
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => queryClient)
   return (
     <QueryClientProvider client={client}>
       <ThemeHydrator />
+      <I18nHydrator />
       <AuthHydrator />
       {children}
       <ToastContainer />

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -164,7 +164,7 @@ export function UploadStep() {
       const localizations: Record<string, { title: string; description: string }> = {}
       for (const code of selectedLanguages) {
         const t = allTranslations[code]
-        if (t) localizations[code] = { title: t.title, description: t.description }
+        if (t) localizations[toBcp47(code)] = { title: t.title, description: t.description }
       }
 
       const result = await ytUploadVideo({
@@ -175,7 +175,7 @@ export function UploadStep() {
         privacyStatus,
         selfDeclaredMadeForKids,
         containsSyntheticMedia,
-        language: metadataLanguage,
+        language: toBcp47(metadataLanguage),
         localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
       setOriginalUploadState({ status: 'done', videoId: result.videoId })

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -1,0 +1,392 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Check, Languages, Loader2, RefreshCw, Search, Send, Upload } from 'lucide-react'
+import { Badge, Button, Card, CardTitle, Input, Select } from '@/components/ui'
+import { useMyVideos } from '@/hooks/useYouTubeData'
+import { translateMetadata } from '@/lib/api-client/translate'
+import {
+  ytFetchVideoMetadata,
+  ytUpdateVideoLocalizations,
+} from '@/lib/api-client/youtube'
+import type { MetadataTranslation } from '@/lib/api-client/translate'
+import { getMarketLanguagePreset, MARKET_LANGUAGE_PRESETS } from '@/lib/i18n/config'
+import { useI18nStore } from '@/stores/i18nStore'
+import { useNotificationStore } from '@/stores/notificationStore'
+import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import { SUPPORTED_LANGUAGES, fromBcp47, getLanguageByCode, toBcp47 } from '@/utils/languages'
+import { cn } from '@/utils/cn'
+
+const LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((language) => ({
+  value: language.code,
+  label: `${language.flag} ${language.name} (${language.nativeName})`,
+}))
+
+const PRESET_OPTIONS = MARKET_LANGUAGE_PRESETS.map((preset) => ({
+  value: preset.id,
+  label: preset.labelKo,
+}))
+
+function buildInitialTargets(presetId: string, sourceLang: string) {
+  return getMarketLanguagePreset(presetId).languageCodes.filter((code) => code !== sourceLang)
+}
+
+export function MetadataLocalizationTool() {
+  const addToast = useNotificationStore((state) => state.addToast)
+  const { metadataTargetPreset, setMetadataTargetPreset } = useI18nStore()
+  const { defaultLanguage } = useYouTubeSettingsStore()
+  const { data: videos = [], isLoading: loadingVideos } = useMyVideos(50)
+
+  const [videoId, setVideoId] = useState('')
+  const [sourceLang, setSourceLang] = useState(defaultLanguage)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [targetLangs, setTargetLangs] = useState<string[]>(
+    () => buildInitialTargets(metadataTargetPreset, defaultLanguage),
+  )
+  const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
+  const [loadingMetadata, setLoadingMetadata] = useState(false)
+  const [translating, setTranslating] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const filteredVideos = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return videos
+    return videos.filter((video) => video.title.toLowerCase().includes(q))
+  }, [query, videos])
+
+  const selectedPreset = getMarketLanguagePreset(metadataTargetPreset)
+  const targetSet = new Set(targetLangs)
+  const canTranslate = title.trim().length > 0 && targetLangs.length > 0
+  const canApply = videoId && title.trim().length > 0 && Object.keys(translations).length > 0
+
+  const handleLoadMetadata = async () => {
+    if (!videoId) return
+    setLoadingMetadata(true)
+    try {
+      const metadata = await ytFetchVideoMetadata(videoId)
+      setTitle(metadata.title)
+      setDescription(metadata.description)
+      const nextSourceLang = fromBcp47(metadata.defaultLanguage || defaultLanguage)
+      setSourceLang(nextSourceLang)
+      setTargetLangs(buildInitialTargets(metadataTargetPreset, nextSourceLang))
+      setTranslations(metadata.localizations)
+      addToast({ type: 'success', title: 'YouTube 메타데이터를 불러왔습니다' })
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: '메타데이터 불러오기 실패',
+        message: err instanceof Error ? err.message : '알 수 없는 오류',
+      })
+    } finally {
+      setLoadingMetadata(false)
+    }
+  }
+
+  const handleTranslate = async () => {
+    if (!canTranslate) return
+    setTranslating(true)
+    try {
+      const result = await translateMetadata({
+        title: title.trim(),
+        description,
+        sourceLang,
+        targetLangs,
+      })
+      setTranslations((prev) => ({ ...prev, ...result }))
+      addToast({ type: 'success', title: '제목·설명 번역이 생성되었습니다' })
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: '번역 생성 실패',
+        message: err instanceof Error ? err.message : '알 수 없는 오류',
+      })
+    } finally {
+      setTranslating(false)
+    }
+  }
+
+  const handleApply = async () => {
+    if (!canApply) return
+    setSaving(true)
+    try {
+      const localizations = Object.fromEntries(
+        Object.entries(translations).map(([code, value]) => [toBcp47(code), value]),
+      )
+      await ytUpdateVideoLocalizations({
+        videoId,
+        sourceLang: toBcp47(sourceLang),
+        title: title.trim(),
+        description,
+        localizations,
+      })
+      addToast({ type: 'success', title: 'YouTube 제목·설명 번역을 적용했습니다' })
+    } catch (err) {
+      addToast({
+        type: 'error',
+        title: 'YouTube 적용 실패',
+        message: err instanceof Error ? err.message : '알 수 없는 오류',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleTarget = (code: string) => {
+    if (code === sourceLang) return
+    setTargetLangs((current) =>
+      current.includes(code)
+        ? current.filter((item) => item !== code)
+        : [...current, code],
+    )
+  }
+
+  const updateTranslation = (
+    code: string,
+    patch: Partial<MetadataTranslation>,
+  ) => {
+    setTranslations((current) => ({
+      ...current,
+      [code]: {
+        title: current[code]?.title ?? '',
+        description: current[code]?.description ?? '',
+        ...patch,
+      },
+    }))
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <div className="mb-5 flex items-center justify-between gap-3">
+          <div>
+            <CardTitle>YouTube 영상 선택</CardTitle>
+            <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+              내 채널 영상의 현재 제목·설명을 불러와 번역본만 추가합니다.
+            </p>
+          </div>
+          {loadingVideos && <Loader2 className="h-5 w-5 animate-spin text-surface-400" />}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+          <div className="space-y-3">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" />
+              <input
+                type="text"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="영상 제목으로 검색"
+                className="h-10 w-full rounded-lg border border-surface-300 bg-white pl-9 pr-3 text-sm text-surface-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-surface-700 dark:bg-surface-800 dark:text-white"
+              />
+            </div>
+            <Select
+              label="대상 영상"
+              value={videoId}
+              onChange={(event) => {
+                const selected = videos.find((video) => video.videoId === event.target.value)
+                setVideoId(event.target.value)
+                if (selected && !title) setTitle(selected.title)
+              }}
+              options={[
+                { value: '', label: loadingVideos ? '불러오는 중...' : '영상을 선택하세요' },
+                ...filteredVideos.map((video) => ({
+                  value: video.videoId,
+                  label: `${video.title} (${video.privacyStatus})`,
+                })),
+              ]}
+            />
+          </div>
+          <div className="flex items-end">
+            <Button
+              variant="outline"
+              onClick={handleLoadMetadata}
+              loading={loadingMetadata}
+              disabled={!videoId || loadingMetadata}
+              className="w-full md:w-auto"
+            >
+              <RefreshCw className="h-4 w-4" />
+              불러오기
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-50 text-brand-600 dark:bg-brand-900/20 dark:text-brand-300">
+            <Languages className="h-5 w-5" />
+          </div>
+          <div>
+            <CardTitle>제목·설명 번역</CardTitle>
+            <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+              더빙이나 자막 생성 없이 YouTube localizations에 들어갈 번역만 생성합니다.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Select
+            label="원문 언어"
+            value={sourceLang}
+            onChange={(event) => {
+              const nextSourceLang = event.target.value
+              setSourceLang(nextSourceLang)
+              setTargetLangs(buildInitialTargets(metadataTargetPreset, nextSourceLang))
+            }}
+            options={LANGUAGE_OPTIONS}
+          />
+          <Select
+            label="추천 시장"
+            value={metadataTargetPreset}
+            onChange={(event) => {
+              const nextPreset = event.target.value
+              setMetadataTargetPreset(nextPreset)
+              setTargetLangs(buildInitialTargets(nextPreset, sourceLang))
+            }}
+            options={PRESET_OPTIONS}
+          />
+        </div>
+
+        <div className="mt-4 space-y-4">
+          <Input
+            label="원문 제목"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="YouTube 제목"
+          />
+          <div>
+            <label htmlFor="metadata-source-description" className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+              원문 설명
+            </label>
+            <textarea
+              id="metadata-source-description"
+              rows={5}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="YouTube 설명"
+              className="w-full resize-none rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/60">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-surface-800 dark:text-surface-100">
+                {selectedPreset.labelKo}
+              </p>
+              <p className="text-xs text-surface-500 dark:text-surface-400">
+                {selectedPreset.descriptionKo}
+              </p>
+            </div>
+            <Badge variant="brand">{targetLangs.length}개 선택</Badge>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {SUPPORTED_LANGUAGES.map((language) => {
+              const selected = targetSet.has(language.code)
+              const disabled = language.code === sourceLang
+              return (
+                <button
+                  key={language.code}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => toggleTarget(language.code)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition',
+                    selected
+                      ? 'bg-brand-50 text-brand-700 ring-brand-300 dark:bg-brand-900/30 dark:text-brand-200 dark:ring-brand-800'
+                      : 'bg-white text-surface-600 ring-surface-200 hover:bg-surface-50 dark:bg-surface-900 dark:text-surface-300 dark:ring-surface-700 dark:hover:bg-surface-800',
+                    disabled && 'cursor-not-allowed opacity-40',
+                  )}
+                >
+                  {selected && <Check className="h-3 w-3" />}
+                  {language.flag} {language.name}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={handleTranslate}
+            loading={translating}
+            disabled={!canTranslate || translating}
+          >
+            <Languages className="h-4 w-4" />
+            번역 생성
+          </Button>
+          <Button
+            onClick={handleApply}
+            loading={saving}
+            disabled={!canApply || saving}
+          >
+            <Upload className="h-4 w-4" />
+            YouTube에 적용
+          </Button>
+        </div>
+      </Card>
+
+      {Object.keys(translations).length > 0 && (
+        <Card>
+          <div className="mb-5 flex items-center justify-between gap-3">
+            <div>
+              <CardTitle>번역 검토</CardTitle>
+              <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+                적용 전에 언어별 제목과 설명을 직접 수정할 수 있습니다.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleApply}
+              loading={saving}
+              disabled={!canApply || saving}
+            >
+              <Send className="h-4 w-4" />
+              적용
+            </Button>
+          </div>
+
+          <div className="space-y-4">
+            {Object.entries(translations).map(([code, value]) => {
+              const language = getLanguageByCode(code) ?? getLanguageByCode(code.split('-')[0])
+              return (
+                <div key={code} className="rounded-lg border border-surface-200 p-4 dark:border-surface-800">
+                  <div className="mb-3 flex items-center gap-2">
+                    <span className="text-lg">{language?.flag}</span>
+                    <span className="font-medium text-surface-900 dark:text-white">
+                      {language?.name ?? code}
+                    </span>
+                    <span className="text-xs text-surface-400">{toBcp47(code)}</span>
+                  </div>
+                  <div className="space-y-3">
+                    <Input
+                      label="제목"
+                      value={value.title}
+                      onChange={(event) => updateTranslation(code, { title: event.target.value })}
+                    />
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
+                        설명
+                      </label>
+                      <textarea
+                        rows={4}
+                        value={value.description}
+                        onChange={(event) => updateTranslation(code, { description: event.target.value })}
+                        className="w-full resize-none rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { Globe2 } from 'lucide-react'
+import { Card, CardTitle, Select } from '@/components/ui'
+import {
+  APP_LOCALE_LABELS,
+  APP_LOCALES,
+  MARKET_LANGUAGE_PRESETS,
+  type AppLocale,
+} from '@/lib/i18n/config'
+import { useI18nStore } from '@/stores/i18nStore'
+import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
+
+const APP_LOCALE_OPTIONS = APP_LOCALES.map((locale) => ({
+  value: locale,
+  label: `${APP_LOCALE_LABELS[locale].nativeLabel} / ${APP_LOCALE_LABELS[locale].label}`,
+}))
+
+const LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((language) => ({
+  value: language.code,
+  label: `${language.flag} ${language.name} (${language.nativeName})`,
+}))
+
+const PRESET_OPTIONS = MARKET_LANGUAGE_PRESETS.map((preset) => ({
+  value: preset.id,
+  label: `${preset.labelKo} / ${preset.labelEn}`,
+}))
+
+export function SettingsClient() {
+  const { appLocale, metadataTargetPreset, setAppLocale, setMetadataTargetPreset } = useI18nStore()
+  const { defaultLanguage, setDefaultLanguage } = useYouTubeSettingsStore()
+  const isEnglish = appLocale === 'en'
+
+  const selectedPreset = MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === metadataTargetPreset)
+  const presetLanguages = selectedPreset
+    ? selectedPreset.languageCodes.map((code) => getLanguageByCode(code)).filter(Boolean)
+    : []
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-50 text-brand-600 dark:bg-brand-900/20 dark:text-brand-300">
+            <Globe2 className="h-5 w-5" />
+          </div>
+          <div>
+            <CardTitle>{isEnglish ? 'Language and localization' : '언어 및 현지화'}</CardTitle>
+            <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+              {isEnglish
+                ? 'Manage app locale and YouTube title/description translation defaults.'
+                : '앱 언어와 YouTube 제목·설명 번역 기본값을 관리합니다.'}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Select
+            label={isEnglish ? 'App locale' : '앱 언어'}
+            value={appLocale}
+            onChange={(event) => setAppLocale(event.target.value as AppLocale)}
+            options={APP_LOCALE_OPTIONS}
+          />
+          <Select
+            label={isEnglish ? 'Default metadata source language' : '제목·설명 작성 기본 언어'}
+            value={defaultLanguage}
+            onChange={(event) => setDefaultLanguage(event.target.value)}
+            options={LANGUAGE_OPTIONS}
+          />
+          <Select
+            label={isEnglish ? 'Recommended localization market' : '추천 번역 시장'}
+            value={metadataTargetPreset}
+            onChange={(event) => setMetadataTargetPreset(event.target.value)}
+            options={PRESET_OPTIONS}
+            className="md:col-span-2"
+          />
+        </div>
+
+        {selectedPreset && (
+          <div className="mt-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/60">
+            <p className="text-sm font-medium text-surface-800 dark:text-surface-100">
+              {isEnglish ? selectedPreset.labelEn : selectedPreset.labelKo}
+            </p>
+            <p className="mt-1 text-xs text-surface-500 dark:text-surface-400">
+              {isEnglish ? selectedPreset.descriptionEn : selectedPreset.descriptionKo}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {presetLanguages.map((language) => language && (
+                <span
+                  key={language.code}
+                  className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-surface-700 ring-1 ring-surface-200 dark:bg-surface-900 dark:text-surface-200 dark:ring-surface-700"
+                >
+                  {language.flag} {language.name}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -28,6 +28,8 @@ export {
   ytFetchChannelStats,
   ytFetchVideoStats,
   ytFetchMyVideos,
+  ytFetchVideoMetadata,
+  ytUpdateVideoLocalizations,
   ytFetchAnalytics,
 } from './youtube'
 export { translateMetadata, type MetadataTranslation } from './translate'

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -3,7 +3,9 @@ import type {
   MyVideoItem,
   VideoAnalytics,
   VideoStats,
+  YouTubeLocalization,
   YouTubeUploadResult,
+  YouTubeVideoMetadata,
 } from '@/lib/youtube/types'
 import { json } from './shared'
 
@@ -85,6 +87,27 @@ export async function ytFetchMyVideos(
   maxResults = 10,
 ): Promise<MyVideoItem[]> {
   const res = await fetch(`${YT}/videos?maxResults=${maxResults}`, { cache: 'no-store' })
+  return json(res)
+}
+
+export async function ytFetchVideoMetadata(videoId: string): Promise<YouTubeVideoMetadata> {
+  const params = new URLSearchParams({ videoId })
+  const res = await fetch(`${YT}/metadata?${params}`, { cache: 'no-store' })
+  return json(res)
+}
+
+export async function ytUpdateVideoLocalizations(params: {
+  videoId: string
+  sourceLang: string
+  title: string
+  description: string
+  localizations: Record<string, YouTubeLocalization>
+}): Promise<YouTubeVideoMetadata> {
+  const res = await fetch(`${YT}/metadata`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  })
   return json(res)
 }
 

--- a/src/lib/i18n/config.test.ts
+++ b/src/lib/i18n/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APP_LOCALES,
+  DEFAULT_APP_LOCALE,
+  DEFAULT_METADATA_TARGET_PRESET,
+  getMarketLanguagePreset,
+  isAppLocale,
+  MARKET_LANGUAGE_PRESETS,
+  resolveAppLocale,
+} from './config'
+
+describe('i18n config', () => {
+  it('uses Korean and English as base app locales', () => {
+    expect(APP_LOCALES).toEqual(['ko', 'en'])
+    expect(DEFAULT_APP_LOCALE).toBe('ko')
+    expect(isAppLocale('ko')).toBe(true)
+    expect(isAppLocale('en')).toBe(true)
+    expect(isAppLocale('ja')).toBe(false)
+  })
+
+  it('resolves unsupported app locales to the default locale', () => {
+    expect(resolveAppLocale('en')).toBe('en')
+    expect(resolveAppLocale('fr')).toBe('ko')
+    expect(resolveAppLocale(null)).toBe('ko')
+  })
+
+  it('defines metadata target presets for launch and international growth', () => {
+    expect(MARKET_LANGUAGE_PRESETS.map((preset) => preset.id)).toEqual([
+      'core',
+      'creator-growth',
+      'global-broad',
+    ])
+    expect(getMarketLanguagePreset(DEFAULT_METADATA_TARGET_PRESET).languageCodes).toContain('en')
+    expect(getMarketLanguagePreset('missing').id).toBe(DEFAULT_METADATA_TARGET_PRESET)
+  })
+})

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -1,0 +1,64 @@
+export const APP_LOCALES = ['ko', 'en'] as const
+
+export type AppLocale = (typeof APP_LOCALES)[number]
+
+export const DEFAULT_APP_LOCALE: AppLocale = 'ko'
+
+export const APP_LOCALE_LABELS: Record<AppLocale, { label: string; nativeLabel: string }> = {
+  ko: { label: 'Korean', nativeLabel: '한국어' },
+  en: { label: 'English', nativeLabel: 'English' },
+}
+
+export function isAppLocale(value: string | null | undefined): value is AppLocale {
+  return APP_LOCALES.includes(value as AppLocale)
+}
+
+export function resolveAppLocale(value: string | null | undefined): AppLocale {
+  return isAppLocale(value) ? value : DEFAULT_APP_LOCALE
+}
+
+export interface MarketLanguagePreset {
+  id: string
+  labelKo: string
+  labelEn: string
+  descriptionKo: string
+  descriptionEn: string
+  languageCodes: string[]
+}
+
+export const MARKET_LANGUAGE_PRESETS: MarketLanguagePreset[] = [
+  {
+    id: 'core',
+    labelKo: '기본 출시',
+    labelEn: 'Core launch',
+    descriptionKo: '국내 사용자를 우선으로 하되 영어권 시청자까지 바로 대응합니다.',
+    descriptionEn: 'Start with Korea-first operations while covering English-speaking viewers.',
+    languageCodes: ['ko', 'en'],
+  },
+  {
+    id: 'creator-growth',
+    labelKo: '크리에이터 성장 시장',
+    labelEn: 'Creator growth markets',
+    descriptionKo: 'YouTube 소비가 크고 현지화 효율이 좋은 국가권을 우선 공략합니다.',
+    descriptionEn: 'Prioritize regions with large YouTube audiences and efficient localization ROI.',
+    languageCodes: ['en', 'ja', 'es', 'pt', 'id', 'vi', 'th', 'hi'],
+  },
+  {
+    id: 'global-broad',
+    labelKo: '글로벌 확장',
+    labelEn: 'Global expansion',
+    descriptionKo: '초기 성과가 확인된 뒤 유럽과 중동 주요 언어까지 확장합니다.',
+    descriptionEn: 'Expand into major European and Middle Eastern languages after initial traction.',
+    languageCodes: ['en', 'ja', 'es', 'pt', 'fr', 'de', 'id', 'vi', 'th', 'hi', 'ar'],
+  },
+]
+
+export const DEFAULT_METADATA_TARGET_PRESET = 'creator-growth'
+
+export function getMarketLanguagePreset(id: string): MarketLanguagePreset {
+  return (
+    MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === id) ??
+    MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === DEFAULT_METADATA_TARGET_PRESET) ??
+    MARKET_LANGUAGE_PRESETS[0]
+  )
+}

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -40,6 +40,24 @@ export const videosQuerySchema = z.object({
     .pipe(z.number().int().min(1).max(50)),
 })
 
+export const metadataQuerySchema = z.object({
+  videoId: z.string().min(1),
+})
+
+export const metadataUpdateBodySchema = z.object({
+  videoId: z.string().min(1),
+  sourceLang: z.string().min(1),
+  title: z.string().min(1).max(2000),
+  description: z.string().max(20000).default(''),
+  localizations: z.record(
+    z.string().min(1),
+    z.object({
+      title: z.string().min(1).max(2000),
+      description: z.string().max(20000).default(''),
+    }),
+  ),
+})
+
 const localizationsRecordSchema = z.record(
   z.string().min(1),
   z.object({

--- a/src/lib/youtube/metadata.test.ts
+++ b/src/lib/youtube/metadata.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchVideoMetadata, updateVideoLocalizations } from './metadata'
+
+describe('youtube metadata', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches snippet and existing localizations', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        items: [
+          {
+            id: 'v1',
+            snippet: {
+              title: '원문',
+              description: '설명',
+              categoryId: '22',
+              tags: ['a'],
+              defaultLanguage: 'ko',
+            },
+            localizations: {
+              en: { title: 'Title', description: 'Description' },
+            },
+          },
+        ],
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchVideoMetadata('token', 'v1')).resolves.toEqual({
+      videoId: 'v1',
+      title: '원문',
+      description: '설명',
+      categoryId: '22',
+      tags: ['a'],
+      defaultLanguage: 'ko',
+      localizations: {
+        en: { title: 'Title', description: 'Description' },
+      },
+    })
+  })
+
+  it('merges localizations and preserves required snippet fields on update', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          items: [
+            {
+              id: 'v1',
+              snippet: {
+                title: '원문',
+                description: '설명',
+                categoryId: '22',
+                tags: ['keep'],
+                defaultLanguage: 'ko',
+              },
+              localizations: {
+                ja: { title: '既存', description: '既存説明' },
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          id: 'v1',
+          snippet: {
+            title: '원문 수정',
+            description: '설명 수정',
+            categoryId: '22',
+            tags: ['keep'],
+            defaultLanguage: 'ko',
+          },
+          localizations: {
+            ja: { title: '既存', description: '既存説明' },
+            en: { title: 'Updated', description: 'Updated description' },
+          },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await updateVideoLocalizations({
+      accessToken: 'token',
+      videoId: 'v1',
+      sourceLang: 'ko',
+      title: '원문 수정',
+      description: '설명 수정',
+      localizations: {
+        en: { title: 'Updated', description: 'Updated description' },
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body as string)
+    expect(updateBody).toMatchObject({
+      id: 'v1',
+      snippet: {
+        title: '원문 수정',
+        description: '설명 수정',
+        categoryId: '22',
+        tags: ['keep'],
+        defaultLanguage: 'ko',
+      },
+      localizations: {
+        ja: { title: '既存', description: '既存説明' },
+        en: { title: 'Updated', description: 'Updated description' },
+      },
+    })
+    expect(result.localizations.en.title).toBe('Updated')
+  })
+})

--- a/src/lib/youtube/metadata.ts
+++ b/src/lib/youtube/metadata.ts
@@ -1,0 +1,127 @@
+import 'server-only'
+
+import { YouTubeError } from '@/lib/youtube/error'
+import type { YouTubeLocalization, YouTubeVideoMetadata } from '@/lib/youtube/types'
+
+const YOUTUBE_DATA_BASE = 'https://www.googleapis.com/youtube/v3'
+
+interface YouTubeVideoResource {
+  id: string
+  snippet?: {
+    title?: string
+    description?: string
+    categoryId?: string
+    tags?: string[]
+    defaultLanguage?: string
+  }
+  localizations?: Record<string, YouTubeLocalization>
+}
+
+function normalizeLocalizationMap(
+  localizations: Record<string, YouTubeLocalization> | undefined,
+): Record<string, YouTubeLocalization> {
+  if (!localizations) return {}
+  return Object.fromEntries(
+    Object.entries(localizations)
+      .filter(([, value]) => value.title.trim().length > 0)
+      .map(([code, value]) => [
+        code,
+        {
+          title: value.title,
+          description: value.description || '',
+        },
+      ]),
+  )
+}
+
+export async function fetchVideoMetadata(
+  accessToken: string,
+  videoId: string,
+): Promise<YouTubeVideoMetadata> {
+  const res = await fetch(
+    `${YOUTUBE_DATA_BASE}/videos?part=snippet,localizations&id=${encodeURIComponent(videoId)}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new YouTubeError(
+      res.status,
+      `YouTube metadata fetch failed: ${body}`,
+      'METADATA_FETCH_FAILED',
+    )
+  }
+
+  const data = (await res.json()) as { items?: YouTubeVideoResource[] }
+  const item = data.items?.[0]
+  if (!item?.snippet) {
+    throw new YouTubeError(404, 'YouTube video not found', 'VIDEO_NOT_FOUND')
+  }
+
+  return {
+    videoId: item.id,
+    title: item.snippet.title || '',
+    description: item.snippet.description || '',
+    categoryId: item.snippet.categoryId || '22',
+    tags: item.snippet.tags || [],
+    defaultLanguage: item.snippet.defaultLanguage || 'ko',
+    localizations: normalizeLocalizationMap(item.localizations),
+  }
+}
+
+export async function updateVideoLocalizations(input: {
+  accessToken: string
+  videoId: string
+  sourceLang: string
+  title: string
+  description: string
+  localizations: Record<string, YouTubeLocalization>
+}): Promise<YouTubeVideoMetadata> {
+  const current = await fetchVideoMetadata(input.accessToken, input.videoId)
+  const mergedLocalizations = {
+    ...current.localizations,
+    ...normalizeLocalizationMap(input.localizations),
+  }
+
+  const defaultLanguage = input.sourceLang || current.defaultLanguage || 'ko'
+  const body = {
+    id: input.videoId,
+    snippet: {
+      title: input.title || current.title,
+      description: input.description,
+      categoryId: current.categoryId || '22',
+      tags: current.tags,
+      defaultLanguage,
+    },
+    localizations: mergedLocalizations,
+  }
+
+  const res = await fetch(`${YOUTUBE_DATA_BASE}/videos?part=snippet,localizations`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const err = await res.text().catch(() => '')
+    throw new YouTubeError(
+      res.status,
+      `YouTube metadata update failed: ${err}`,
+      'METADATA_UPDATE_FAILED',
+    )
+  }
+
+  const data = (await res.json()) as YouTubeVideoResource
+  const snippet = data.snippet ?? body.snippet
+  return {
+    videoId: data.id || input.videoId,
+    title: snippet.title || body.snippet.title,
+    description: snippet.description || body.snippet.description,
+    categoryId: snippet.categoryId || body.snippet.categoryId,
+    tags: snippet.tags || body.snippet.tags,
+    defaultLanguage: snippet.defaultLanguage || defaultLanguage,
+    localizations: normalizeLocalizationMap(data.localizations ?? mergedLocalizations),
+  }
+}

--- a/src/lib/youtube/server.ts
+++ b/src/lib/youtube/server.ts
@@ -16,3 +16,8 @@ export {
   fetchVideoAnalytics,
   fetchMultiVideoAnalytics,
 } from '@/lib/youtube/analytics'
+export {
+  fetchVideoMetadata,
+  updateVideoLocalizations,
+} from '@/lib/youtube/metadata'
+export type { YouTubeVideoMetadata } from '@/lib/youtube/types'

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -8,6 +8,21 @@ export interface YouTubeUploadResult {
   status: string
 }
 
+export interface YouTubeLocalization {
+  title: string
+  description: string
+}
+
+export interface YouTubeVideoMetadata {
+  videoId: string
+  title: string
+  description: string
+  categoryId: string
+  tags: string[]
+  defaultLanguage: string
+  localizations: Record<string, YouTubeLocalization>
+}
+
 export interface VideoStats {
   videoId: string
   viewCount: number

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -1,14 +1,9 @@
 import 'server-only'
 
-import type { YouTubeUploadResult } from '@/lib/youtube/types'
+import type { YouTubeLocalization, YouTubeUploadResult } from '@/lib/youtube/types'
 import { YouTubeError } from '@/lib/youtube/error'
 
 const YOUTUBE_UPLOAD_BASE = 'https://www.googleapis.com/upload/youtube/v3'
-
-export interface YouTubeLocalization {
-  title: string
-  description: string
-}
 
 export interface YouTubeUploadInput {
   accessToken: string

--- a/src/stores/i18nStore.ts
+++ b/src/stores/i18nStore.ts
@@ -1,0 +1,44 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import {
+  DEFAULT_APP_LOCALE,
+  DEFAULT_METADATA_TARGET_PRESET,
+  resolveAppLocale,
+  type AppLocale,
+} from '@/lib/i18n/config'
+
+interface I18nState {
+  appLocale: AppLocale
+  metadataTargetPreset: string
+  setAppLocale: (locale: AppLocale) => void
+  setMetadataTargetPreset: (presetId: string) => void
+}
+
+export const useI18nStore = create<I18nState>()(
+  persist(
+    (set) => ({
+      appLocale: DEFAULT_APP_LOCALE,
+      metadataTargetPreset: DEFAULT_METADATA_TARGET_PRESET,
+      setAppLocale: (locale) => set({ appLocale: resolveAppLocale(locale) }),
+      setMetadataTargetPreset: (presetId) => set({ metadataTargetPreset: presetId }),
+    }),
+    {
+      name: 'dubtube-i18n',
+      partialize: (state) => ({
+        appLocale: state.appLocale,
+        metadataTargetPreset: state.metadataTargetPreset,
+      }),
+      merge: (persisted, current) => {
+        const state = persisted as Partial<I18nState> | undefined
+        return {
+          ...current,
+          ...state,
+          appLocale: resolveAppLocale(state?.appLocale),
+          metadataTargetPreset: state?.metadataTargetPreset || DEFAULT_METADATA_TARGET_PRESET,
+        }
+      },
+    },
+  ),
+)

--- a/src/utils/languages.test.ts
+++ b/src/utils/languages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { SUPPORTED_LANGUAGES, getLanguageByCode } from './languages'
+import { SUPPORTED_LANGUAGES, fromBcp47, getLanguageByCode, toBcp47 } from './languages'
 
 describe('SUPPORTED_LANGUAGES', () => {
   it('contains expected languages', () => {
@@ -35,5 +35,19 @@ describe('getLanguageByCode', () => {
 
   it('returns undefined for unknown code', () => {
     expect(getLanguageByCode('xx')).toBeUndefined()
+  })
+})
+
+describe('language code mapping', () => {
+  it('maps Perso language codes to YouTube BCP-47 codes', () => {
+    expect(toBcp47('pt')).toBe('pt-BR')
+    expect(toBcp47('zh')).toBe('zh-Hans')
+    expect(toBcp47('ko')).toBe('ko')
+  })
+
+  it('maps YouTube BCP-47 codes back to Perso language codes', () => {
+    expect(fromBcp47('pt-BR')).toBe('pt')
+    expect(fromBcp47('zh-Hans')).toBe('zh')
+    expect(fromBcp47('en-US')).toBe('en')
   })
 })

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -70,3 +70,12 @@ const BCP47_MAP: Record<string, string> = {
 export function toBcp47(persoCode: string): string {
   return BCP47_MAP[persoCode] || persoCode
 }
+
+export function fromBcp47(languageCode: string): string {
+  const lower = languageCode.toLowerCase()
+  const mapped = Object.entries(BCP47_MAP).find(
+    ([, bcp47]) => bcp47.toLowerCase() === lower,
+  )
+  if (mapped) return mapped[0]
+  return lower.split('-')[0]
+}


### PR DESCRIPTION
﻿## Summary
- Add ko/en i18n base config, persisted app locale, and recommended metadata target market presets.
- Add a standalone metadata translation workspace for translating YouTube titles/descriptions without dubbing or captions.
- Add YouTube metadata fetch/update APIs that preserve existing snippet fields and merge localizations before calling videos.update.
- Normalize localization language keys to BCP-47 for YouTube localizations.

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- extension: npm run typecheck
- extension: npm run lint
- extension: npm test
- extension: npm run build
- local dev smoke: GET /metadata returned 200; Playwright rendered /metadata (dev HMR websocket noise only)

Closes #206
