### PR TITLE
fix: 인증 sync 이메일 스푸핑 권한 우회 차단 / feat: 운영 관측 어드민 게이트

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,14 +1,16 @@
 import { Sidebar } from '@/components/layout/Sidebar'
 import { Topbar } from '@/components/layout/Topbar'
+import { isOperationsAdminFromCookies } from '@/lib/ops/admin'
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const isOpsAdmin = await isOperationsAdminFromCookies()
   return (
     <div className="min-h-screen">
-      <Sidebar />
+      <Sidebar isOpsAdmin={isOpsAdmin} />
       <div className="ml-64">
         <Topbar />
         <main className="p-6">{children}</main>

--- a/src/app/(app)/ops/page.tsx
+++ b/src/app/(app)/ops/page.tsx
@@ -1,5 +1,10 @@
+import { notFound } from 'next/navigation'
 import { OpsDashboard } from '@/features/ops/components/OpsDashboard'
+import { isOperationsAdminFromCookies } from '@/lib/ops/admin'
 
-export default function OpsPage() {
+export default async function OpsPage() {
+  if (!(await isOperationsAdminFromCookies())) {
+    notFound()
+  }
   return <OpsDashboard />
 }

--- a/src/app/api/auth/auth-sync.test.ts
+++ b/src/app/api/auth/auth-sync.test.ts
@@ -107,6 +107,15 @@ describe('POST /api/auth/sync', () => {
     expect(setCookie.some((c: string) => c.includes('google_access_token='))).toBe(false)
   })
 
+  it('ignores body email and uses Google-verified email when storing user', async () => {
+    mockGoogleUserinfo('u1', 'real@user.com')
+    const res = await POST(makeReq({ uid: 'u1', email: 'admin@spoofed.com', accessToken: 'tok-valid' }))
+    expect(res.status).toBe(200)
+    expect(upsertUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'u1', email: 'real@user.com' }),
+    )
+  })
+
   it('returns 500 on DB error', async () => {
     mockGoogleUserinfo('u1', 'a@b.com')
     vi.mocked(upsertUser).mockRejectedValueOnce(new Error('DB down'))

--- a/src/app/api/auth/sync/route.ts
+++ b/src/app/api/auth/sync/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
       return apiFail('BAD_REQUEST', 'uid and email required', 400)
     }
 
-    const { uid, email, displayName, photoURL, accessToken: bodyToken } = parsed.data
+    const { uid, displayName, photoURL, accessToken: bodyToken } = parsed.data
 
     // Resolve access token: body → httpOnly cookie → DB (refresh if expired)
     const cookieToken = req.cookies.get('google_access_token')?.value
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest) {
 
     await upsertUser({
       id: uid,
-      email,
+      email: googleUser.email,
       displayName: displayName ?? null,
       photoURL: photoURL ?? null,
       accessToken,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,14 +22,15 @@ const navItems = [
   { to: '/metadata', label: { ko: '메타데이터 번역', en: 'Metadata' }, icon: Globe2 },
   { to: '/batch', label: { ko: '배치 큐', en: 'Batch queue' }, icon: Layers },
   { to: '/uploads', label: { ko: 'YouTube 업로드', en: 'YouTube uploads' }, icon: Upload },
-  { to: '/ops', label: { ko: '운영 관측', en: 'Operations' }, icon: Activity },
+  { to: '/ops', label: { ko: '운영 관측', en: 'Operations' }, icon: Activity, opsAdminOnly: true },
   { to: '/youtube', label: { ko: 'YouTube', en: 'YouTube' }, icon: Video },
   { to: '/billing', label: { ko: '결제', en: 'Billing' }, icon: CreditCard },
 ]
 
-export function Sidebar() {
+export function Sidebar({ isOpsAdmin = false }: { isOpsAdmin?: boolean }) {
   const pathname = usePathname()
   const appLocale = useI18nStore((state) => state.appLocale)
+  const visibleItems = navItems.filter((item) => !item.opsAdminOnly || isOpsAdmin)
 
   return (
     <aside className="fixed left-0 top-0 z-40 flex h-screen w-64 flex-col border-r border-surface-200 bg-white dark:border-surface-800 dark:bg-surface-900">
@@ -43,7 +44,7 @@ export function Sidebar() {
       </div>
 
       <nav className="flex-1 space-y-1 p-3">
-        {navItems.map(({ to, label, icon: Icon }) => {
+        {visibleItems.map(({ to, label, icon: Icon }) => {
           const isActive = pathname === to || pathname?.startsWith(to + '/')
           return (
             <Link

--- a/src/lib/ops/admin.ts
+++ b/src/lib/ops/admin.ts
@@ -1,8 +1,11 @@
 import 'server-only'
 
 import { NextRequest } from 'next/server'
+import { cookies } from 'next/headers'
 import { requireSession, type Session } from '@/lib/auth/session'
 import { apiFail } from '@/lib/api/response'
+import { SESSION_COOKIE, verifySessionCookiePayload } from '@/lib/auth/session-cookie'
+import { getUser, isUserSessionActive } from '@/lib/db/queries'
 
 function getAdminEmails() {
   return (process.env.OPERATIONS_ADMIN_EMAILS || '')
@@ -34,4 +37,24 @@ export async function requireOperationsAdmin(
     }
   }
   return auth
+}
+
+export async function isOperationsAdminFromCookies(): Promise<boolean> {
+  const cookieStore = await cookies()
+  const raw = cookieStore.get(SESSION_COOKIE)?.value
+  if (!raw) return false
+
+  const verified = await verifySessionCookiePayload(raw)
+  if (!verified) return false
+
+  if (!verified.legacy) {
+    const active = await isUserSessionActive(verified.sid, verified.uid)
+    if (!active) return false
+  }
+
+  const user = await getUser(verified.uid)
+  const email = (user?.email as string | undefined) ?? null
+  if (!email) return false
+
+  return isOperationsAdmin({ uid: verified.uid, email })
 }


### PR DESCRIPTION
Closes #221

## 요약
- **fix**: `/api/auth/sync`가 요청 body의 email을 그대로 DB에 저장하던 권한 상승 경로 차단. Google userinfo 검증값만 신뢰하도록 변경.
- **feat**: 운영 관측 영역 어드민 게이트 강화. 비어드민에게 사이드바 메뉴 미노출 + 페이지 진입 시 `notFound()`.

## 보안 패치 상세 (fix)
공격 시나리오:
1. 공격자가 본인 Google 계정으로 정상 로그인
2. `POST /api/auth/sync` body에 `{ uid: <본인>, email: "<admin>" }` 전송
3. `googleUser.sub === uid` 검증은 통과 (본인 uid니까)
4. `upsertUser`가 body의 admin 이메일을 그대로 DB에 저장 → 어드민 권한 상승

패치: body email destructure에서 제외, `googleUser.email` 만 `upsertUser`에 전달.

## 어드민 게이트 (feat)
| 진입점 | 가드 |
|---|---|
| 사이드바 메뉴 | 서버 layout에서 `isOperationsAdminFromCookies()` 해석 후 prop 주입 → 비어드민에게 미노출 |
| `/ops` 페이지 직접 URL | `page.tsx`의 `notFound()` |
| `/api/ops/*` | 기존 `requireOperationsAdmin` (변경 없음) |

신규 헬퍼 `isOperationsAdminFromCookies`는 `next/headers` cookies로 세션 쿠키 검증 → 세션 활성 여부 확인 → DB 이메일 조회 → 환경변수 화이트리스트 매칭.

## 변경 파일
- `src/app/api/auth/sync/route.ts` — 이메일 스푸핑 차단 (security)
- `src/app/api/auth/auth-sync.test.ts` — 회귀 테스트 추가
- `src/lib/ops/admin.ts` — Server Component용 헬퍼 추가
- `src/app/(app)/layout.tsx` — async 전환, prop 주입
- `src/components/layout/Sidebar.tsx` — `opsAdminOnly` 플래그 기반 필터
- `src/app/(app)/ops/page.tsx` — `notFound()` 서버 가드

## Test plan
- [x] auth-sync 테스트 8건 통과 (회귀 테스트 1건 추가 포함)
- [x] `tsc --noEmit` 통과
- [ ] Vercel Preview 환경에서 비어드민 계정으로 로그인 → 사이드바 메뉴 미노출 확인
- [ ] 비어드민이 `/ops` 직접 URL 입력 → 404 확인
- [ ] 어드민 계정 (`OPERATIONS_ADMIN_EMAILS` 등록) → 메뉴 + 대시보드 정상 노출 확인
- [ ] body에 다른 이메일을 실어 `/api/auth/sync` 호출 → DB 이메일이 Google 값으로 유지되는지 직접 검증

## 운영자 액션
1. Vercel 환경변수에 `OPERATIONS_ADMIN_EMAILS=<admin emails (콤마 구분)>` 설정 (production + preview 양쪽)
2. 이번 패치 이전에 admin 이메일로 덮어쓴 row가 있는지 점검:
   ```sql
   SELECT id, email FROM users WHERE email IN ('<admin@example.com>')
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)