### PR TITLE
fix: 루트 레이아웃 인라인 script 태그 React 19 경고 제거

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { Providers } from "@/components/providers/Providers";
 
@@ -40,10 +41,12 @@ export default function RootLayout({
       className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <head>
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-      </head>
       <body className="min-h-full flex flex-col">
+        <Script
+          id="dubtube-theme-init"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: themeInitScript }}
+        />
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
Closes #223

## 요약
\`src/app/layout.tsx\`의 raw \`<script dangerouslySetInnerHTML />\` 패턴이 React 19의 경고를 발생시켜 \`next/script\`의 \`<Script>\` 컴포넌트로 교체.

## 증상
\`\`\`
Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client. Consider using template tag instead.
  src\app\layout.tsx (44:9) @ RootLayout
\`\`\`

## 변경 내용
- \`next/script\` import
- \`<head>\` 수동 관리 제거 (Next.js가 metadata API + Script를 통해 head를 자동 inject)
- raw \`<script>\` → \`<Script id=\"dubtube-theme-init\" strategy=\"beforeInteractive\" />\`
  - \`id\` 필수 (Next 추적/최적화)
  - \`beforeInteractive\` — 하이드레이션 이전 실행 보장, 다크모드 FOUC 방지

## 기능 회귀 영향
없음. 테마 초기화는 첫 페인트 한 번만 필요하므로 \`beforeInteractive\` 전략에 부합.

## Test plan
- [x] \`tsc --noEmit\` 통과
- [ ] 개발 서버에서 콘솔 경고 사라짐 확인
- [ ] localStorage \`dubtube-theme=dark\` 설정 후 새로고침 → 첫 페인트에 다크모드 즉시 적용 (FOUC 없음)
- [ ] \`prefers-color-scheme: dark\` OS 설정만 있을 때도 동일하게 다크모드 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)