### PR TITLE
fix: 자막 트랙 이름 "X subtitles" 하드코딩 제거 — CC 메뉴 시청자 로케일 자동 표시

### DIFF
--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -307,7 +307,9 @@ function UploadRow({ item, userId }: UploadRowProps) {
             await ytUploadCaption({
               videoId: r.videoId,
               language: item.language_code,
-              name: `${langName} subtitles`,
+              // name 비워두면 YouTube가 시청자 로케일에 맞춰 언어 이름 자동 표시.
+              // "X subtitles" 같은 영어 고정 문구를 박으면 일본 시청자에게도 그대로 노출.
+              name: '',
               srtContent: srtText,
             })
           } catch {

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -434,7 +434,8 @@ export function UploadStep() {
           isShort: uploadAsShort,
           uploadCaptions: shouldUploadCaptions,
           captionLanguage: toBcp47(langCode),
-          captionName: `${lang.name} subtitles`,
+          // 빈 문자열로 두면 YouTube가 시청자 로케일에 맞춰 언어 이름 자동 표시.
+          captionName: '',
           srtContent,
           selfDeclaredMadeForKids,
           containsSyntheticMedia,

--- a/src/lib/upload-queue/process.test.ts
+++ b/src/lib/upload-queue/process.test.ts
@@ -50,7 +50,7 @@ const queueItem = {
   isShort: false,
   uploadCaptions: true,
   captionLanguage: 'en',
-  captionName: 'English subtitles',
+  captionName: '',
   srtContent: '1\n00:00:00,000 --> 00:00:01,000\nHello',
   selfDeclaredMadeForKids: false,
   containsSyntheticMedia: true,
@@ -111,7 +111,7 @@ describe('processUploadQueue', () => {
       accessToken: 'access-token',
       videoId: 'yt-123',
       language: 'en',
-      name: 'English subtitles',
+      name: '',
       srtContent: queueItem.srtContent,
     })
     expect(completeQueueItem).toHaveBeenCalledWith(10, 'yt-123')

--- a/src/lib/upload-queue/process.ts
+++ b/src/lib/upload-queue/process.ts
@@ -69,7 +69,9 @@ export async function processUploadQueue(options: ProcessUploadQueueOptions = {}
             accessToken,
             videoId: result.videoId,
             language: item.captionLanguage || item.langCode,
-            name: item.captionName || `${item.language || item.langCode} subtitles`,
+            // captionName이 명시적으로 설정된 경우만 사용하고, 그 외엔 빈 문자열로 두어
+            // YouTube가 시청자 로케일에 맞춰 언어 이름을 자동 표시하도록 함.
+            name: item.captionName ?? '',
             srtContent: item.srtContent,
           })
         } catch (err) {


### PR DESCRIPTION
Closes #231

## 증상
업로드한 영상의 YouTube CC 메뉴에서 자막이 \"English\"가 아니라 \"English subtitles\"로 노출. 일본 시청자도 \"英語\"가 아니라 그대로 \"English subtitles\"를 보게 됨.

## 원인
caption track의 \`snippet.name\` 필드를 \`\${langName} subtitles\` 형태로 하드코딩한 곳이 세 군데:

| 파일 | 라인 | 흐름 |
|---|---|---|
| \`src/app/(app)/uploads/page.tsx\` | 310 | YouTube 업로드 페이지 직접 업로드 |
| \`src/features/dubbing/components/steps/UploadStep.tsx\` | 437 | 더빙 → 큐 적재 시점의 captionName |
| \`src/lib/upload-queue/process.ts\` | 72 | 큐 cron 처리 시 default fallback |

## 패치
세 곳 모두 빈 문자열로 교체. YouTube Data API의 \`captions.snippet.name\`을 비워두면 시청자 로케일에 맞춰 언어 이름이 자동 localize됨.

\`process.ts\`는 \`item.captionName ?? ''\`로 두어 큐 데이터에 명시 지정된 captionName이 있을 때만 사용 — passthrough 유지.

## 효과
- 영문 시청자: \"English\"
- 일본 시청자: \"英語\"
- 한국 시청자: \"한국어\"

\"English subtitles\" 같은 영어 고정 문구가 모든 로케일 시청자에게 노출되던 문제 해소.

## 변경 파일
- \`src/app/(app)/uploads/page.tsx\` — \`name\` 빈 문자열로
- \`src/features/dubbing/components/steps/UploadStep.tsx\` — \`captionName\` 빈 문자열로
- \`src/lib/upload-queue/process.ts\` — fallback 빈 문자열로
- \`src/lib/upload-queue/process.test.ts\` — expectation 갱신

## Test plan
- [x] \`tsc --noEmit\` 통과
- [x] \`upload-queue/process.test.ts\` 4건 통과
- [ ] 새로 영상 업로드 후 다른 로케일(예: youtube.com 일본 IP) 시청자 시점에서 CC 메뉴 확인 — 언어 이름이 자동 localize 되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)