### PR TITLE
feat: "원본 업로드 + 자막 추가" 결과물 모드 활성화 (출시 예정 잠금 해제)

### DIFF
--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -31,18 +31,14 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '기존 영상에 자막 추가',
-      description: '검증이 끝나면 내 YouTube 영상에 번역 자막을 자동 업로드할 수 있습니다.',
-      disabled: true,
-      badge: '출시 예정',
+      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다.',
     })
   } else if (sourceType === 'upload') {
     options.push({
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '원본 업로드 + 자막 추가',
-      description: '검증이 끝나면 원본 업로드 뒤 번역 자막을 자동 추가할 수 있습니다.',
-      disabled: true,
-      badge: '출시 예정',
+      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다.',
     })
   }
 


### PR DESCRIPTION
Closes #233

## 요약
PR #207 (\`bd23491\` \"P0: 출시 안전 기본값과 미검증 업로드 기능 잠금\")에서 잠가뒀던 \`originalWithMultiAudio\` 결과물 모드를 활성화. 사용자 검증 완료.

## 변경
\`src/features/dubbing/components/steps/OutputModeStep.tsx\`에서:
- \`disabled: true\` 제거
- \`badge: '출시 예정'\` 제거  
- description 텍스트 잠금 전 원문 복원 (\"검증이 끝나면\" 어구 제거)

두 모드 모두:
- channel source: \"기존 영상에 자막 추가\"
- upload source: \"원본 업로드 + 자막 추가\"

## 코드 상태 (이미 구현 완료, 잠금만 풀면 됨)

| 단계 | \`originalWithMultiAudio\` 분기 | 상태 |
|---|---|---|
| \`UploadStep.tsx:528-554\` | auto-chain (원본 업로드 → 자막 자동) | ✅ |
| \`UploadSettingsStep.tsx:97-103\` | 다중 오디오 모드 분기 | ✅ |
| \`LanguageSelectStep.tsx:41\` | 립싱크 비적용 | ✅ |
| \`TranslationEditStep.tsx:110-149\` | 결과물 안내 분기 | ✅ |
| \`ProcessingStep.tsx:97\` | 처리 단계 안내 분기 | ✅ |

## 변경하지 않는 것 (PR #207의 다른 안전 잠금)
같은 PR #207에서 같이 들어간 두 가지는 별개 옵트인 가드라 유지:
- \`extension/src/settings.ts\`: \`uploadMode: 'assisted'\` (auto 아님)
- \`src/features/dubbing/store/dubbingStore.ts\`: \`autoUpload: false\`

이 둘은 \`originalWithMultiAudio\` 활성화와 직접 관련 없으므로 별도 판단 필요시 별개 PR로 처리.

## Test plan
- [x] \`tsc --noEmit\` 통과
- [ ] 더빙 위자드 진입 후 \"결과물 선택\" 단계에서 \"원본 업로드 + 자막 추가\" / \"기존 영상에 자막 추가\" 활성 상태 확인
- [ ] 해당 모드 선택 후 끝까지 진행 — 원본 영상 YouTube 업로드 → 자막 자동 업로드 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)