### PR TITLE
fix: 자동 업로드 최종 확인을 "확인" 단계로 이동 + 미리보기 제거 + Shorts tag 라벨 정리

### DIFF
--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -1,12 +1,20 @@
 'use client'
 
 import { ArrowLeft, ArrowRight, Info } from 'lucide-react'
-import { Button, Card, Badge, Toggle } from '@/components/ui'
+import { Button, Card, CardTitle, Badge, Toggle } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { getLanguageByCode } from '@/utils/languages'
+import { useAuthStore } from '@/stores/authStore'
 import { useDubbingStore } from '../../store/dubbingStore'
+import type { PrivacyStatus } from '../../types/dubbing.types'
 
 const MAX_SPEAKERS = 10
+
+const PRIVACY_LABELS: Record<PrivacyStatus, string> = {
+  private: '비공개 (권장)',
+  unlisted: '일부 공개',
+  public: '공개',
+}
 
 export function TranslationEditStep() {
   const {
@@ -17,14 +25,22 @@ export function TranslationEditStep() {
     numberOfSpeakers,
     setNumberOfSpeakers,
     videoMeta,
+    videoSource,
     deliverableMode,
     uploadSettings,
+    setUploadSettings,
     prevStep,
     nextStep,
   } = useDubbingStore()
+  const user = useAuthStore((s) => s.user)
 
   const sourceLang = getLanguageByCode(sourceLanguage)
   const isAutoSource = sourceLanguage === 'auto'
+
+  const needsAutoUploadReview = uploadSettings.autoUpload
+  const canStart = !needsAutoUploadReview || uploadSettings.uploadReviewConfirmed
+  const privacyLabel = PRIVACY_LABELS[uploadSettings.privacyStatus] ?? uploadSettings.privacyStatus
+  const targetChannelLabel = user?.email ?? 'Google 로그인 후 연결된 YouTube 채널'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -153,16 +169,59 @@ export function TranslationEditStep() {
         </div>
       </Card>
 
+      {/* 자동 업로드 최종 확인 — 자동 업로드 ON일 때만 노출. 더빙 시작 전 마지막 사용자 동의 게이트. */}
+      {needsAutoUploadReview && (
+        <Card className="border-amber-200 bg-amber-50/40 dark:border-amber-900 dark:bg-amber-950/10">
+          <CardTitle>자동 업로드 최종 확인</CardTitle>
+          <div className="mt-4 grid gap-2 text-xs text-surface-600 dark:text-surface-300 sm:grid-cols-2">
+            <ReviewItem label="채널" value={targetChannelLabel} />
+            <ReviewItem label="공개 범위" value={privacyLabel} />
+            <ReviewItem label="Shorts tag" value={uploadSettings.uploadAsShort ? 'ON' : 'OFF'} />
+            <ReviewItem label="자막" value={uploadSettings.uploadCaptions ? '업로드' : '업로드 안 함'} />
+            <ReviewItem label="아동용" value={uploadSettings.selfDeclaredMadeForKids ? '예' : '아니오'} />
+            <ReviewItem label="AI 합성 공개" value={uploadSettings.containsSyntheticMedia ? 'ON' : 'OFF'} />
+            <ReviewItem
+              label="제목/설명 번역"
+              value={`${getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage} 기준 → ${selectedLanguages.length}개 언어`}
+            />
+            <ReviewItem
+              label="localizations"
+              value={deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload' ? 'YouTube localizations 포함' : '언어별 제목/설명 적용'}
+            />
+          </div>
+          <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border border-amber-200 bg-white/70 p-3 text-sm text-surface-700 dark:border-amber-900/70 dark:bg-surface-900/50 dark:text-surface-200">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+              checked={uploadSettings.uploadReviewConfirmed}
+              onChange={(e) => setUploadSettings({ uploadReviewConfirmed: e.target.checked })}
+            />
+            <span>
+              위 채널, 공개 범위, 제목/설명 번역, 자막, Shorts tag, 아동용, AI 합성 공개 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.
+            </span>
+          </label>
+        </Card>
+      )}
+
       <div className="flex justify-between">
         <Button variant="secondary" onClick={prevStep}>
           <ArrowLeft className="h-4 w-4" />
           이전
         </Button>
-        <Button onClick={nextStep}>
+        <Button onClick={nextStep} disabled={!canStart}>
           더빙 시작
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
+    </div>
+  )
+}
+
+function ReviewItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-white/70 px-3 py-2 dark:bg-surface-900/50">
+      <p className="text-[11px] font-medium text-surface-400">{label}</p>
+      <p className="mt-0.5 truncate text-surface-700 dark:text-surface-200">{value}</p>
     </div>
   )
 }

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -24,7 +24,6 @@ export function UploadSettingsStep() {
     videoMeta,
     videoSource,
     isShort,
-    selectedLanguages,
     deliverableMode,
     uploadSettings,
     setUploadSettings,

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { ArrowLeft, ArrowRight, Captions, Languages, Link2, ShieldCheck, Sparkles, Upload, Zap } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
 import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
-import { useAuthStore } from '@/stores/authStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
@@ -34,7 +33,6 @@ export function UploadSettingsStep() {
     prevStep,
     nextStep,
   } = useDubbingStore()
-  const user = useAuthStore((s) => s.user)
 
   // YouTube 설정 페이지의 기본값과 동기화 (사용자 override 없을 때만).
   useEffect(() => {
@@ -66,24 +64,6 @@ export function UploadSettingsStep() {
     if (Object.keys(patch).length > 0) setUploadSettings(patch)
   }, [videoMeta?.id, videoMeta?.title, setUploadSettings])
 
-  const firstLangName = useMemo(() => {
-    const first = selectedLanguages[0]
-    if (!first) return null
-    return getLanguageByCode(first)?.name || first
-  }, [selectedLanguages])
-
-  const previewTitle = firstLangName && deliverableMode === 'newDubbedVideos'
-    ? `${uploadSettings.uploadAsShort ? '#Shorts ' : ''}[${firstLangName}] ${uploadSettings.title || '(제목 없음)'}`
-    : uploadSettings.title || '(제목 없음)'
-
-  const previewDescription = (() => {
-    const base = uploadSettings.description || '(설명 없음)'
-    if (uploadSettings.attachOriginalLink && originalYouTubeUrl) {
-      return `${base}\n\n원본 영상: ${originalYouTubeUrl}`
-    }
-    return base
-  })()
-
   const tagsString = uploadSettings.tags.join(', ')
 
   const handleTagsChange = (value: string) => {
@@ -98,14 +78,10 @@ export function UploadSettingsStep() {
   const uploadsVideoToYouTube =
     deliverableMode === 'newDubbedVideos' ||
     (isMultiAudio && videoSource?.type === 'upload')
-  const needsAutoUploadReview = uploadSettings.autoUpload
-  const baseCanContinue =
+  const canContinue =
     deliverableMode === 'originalWithMultiAudio'
       ? true
       : uploadSettings.title.trim().length > 0
-  const canContinue = baseCanContinue && (!needsAutoUploadReview || uploadSettings.uploadReviewConfirmed)
-  const privacyLabel = PRIVACY_OPTIONS.find((o) => o.value === uploadSettings.privacyStatus)?.label ?? uploadSettings.privacyStatus
-  const targetChannelLabel = user?.email ?? 'Google 로그인 후 연결된 YouTube 채널'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -318,56 +294,6 @@ export function UploadSettingsStep() {
         </div>
       </Card>
 
-      {uploadSettings.autoUpload && (
-        <Card className="border-amber-200 bg-amber-50/40 dark:border-amber-900 dark:bg-amber-950/10">
-          <CardTitle>자동 업로드 최종 확인</CardTitle>
-          <div className="mt-4 grid gap-2 text-xs text-surface-600 dark:text-surface-300 sm:grid-cols-2">
-            <ReviewItem label="채널" value={targetChannelLabel} />
-            <ReviewItem label="공개 범위" value={privacyLabel} />
-            <ReviewItem label="Shorts" value={uploadSettings.uploadAsShort ? 'ON' : 'OFF'} />
-            <ReviewItem label="자막" value={uploadSettings.uploadCaptions ? '업로드' : '업로드 안 함'} />
-            <ReviewItem label="아동용" value={uploadSettings.selfDeclaredMadeForKids ? '예' : '아니오'} />
-            <ReviewItem label="AI 합성 공개" value={uploadSettings.containsSyntheticMedia ? 'ON' : 'OFF'} />
-            <ReviewItem
-              label="제목/설명 번역"
-              value={`${getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage} 기준 → ${selectedLanguages.length}개 언어`}
-            />
-            <ReviewItem
-              label="localizations"
-              value={deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload' ? 'YouTube localizations 포함' : '언어별 제목/설명 적용'}
-            />
-          </div>
-          <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border border-amber-200 bg-white/70 p-3 text-sm text-surface-700 dark:border-amber-900/70 dark:bg-surface-900/50 dark:text-surface-200">
-            <input
-              type="checkbox"
-              className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
-              checked={uploadSettings.uploadReviewConfirmed}
-              onChange={(e) => setUploadSettings({ uploadReviewConfirmed: e.target.checked })}
-            />
-            <span>
-              위 채널, 공개 범위, 제목/설명 번역, 자막, Shorts, 아동용, AI 합성 공개 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.
-            </span>
-          </label>
-        </Card>
-      )}
-
-      {/* Preview — only for newDubbedVideos */}
-      {deliverableMode === 'newDubbedVideos' && firstLangName && (
-        <Card className="border-brand-200 bg-brand-50/40 dark:border-brand-800 dark:bg-brand-900/10">
-          <CardTitle>미리보기 ({firstLangName})</CardTitle>
-          <div className="mt-3 space-y-2">
-            <div>
-              <p className="text-xs text-surface-500">제목</p>
-              <p className="mt-0.5 text-sm font-medium text-surface-900 dark:text-white break-all">{previewTitle}</p>
-            </div>
-            <div>
-              <p className="text-xs text-surface-500">설명</p>
-              <p className="mt-0.5 whitespace-pre-line text-sm text-surface-700 dark:text-surface-300">{previewDescription}</p>
-            </div>
-          </div>
-        </Card>
-      )}
-
       <div className="flex justify-between">
         <Button variant="secondary" onClick={prevStep}>
           <ArrowLeft className="h-4 w-4" />
@@ -430,11 +356,3 @@ function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabe
   )
 }
 
-function ReviewItem({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-md bg-white/70 px-3 py-2 dark:bg-surface-900/50">
-      <p className="text-[11px] font-medium text-surface-400">{label}</p>
-      <p className="mt-0.5 truncate text-surface-700 dark:text-surface-200">{value}</p>
-    </div>
-  )
-}


### PR DESCRIPTION
Closes #235

## 요약
더빙 위자드의 4단계(\"업로드 설정\")가 너무 무거워서, 5단계(\"확인\")로 자동 업로드 동의 게이트를 옮기고 가치 낮은 미리보기 카드를 제거. 라벨 모호성도 함께 정리.

## 변경

### 1. \"자동 업로드 최종 확인\" 4단계 → 5단계 이동
4단계 \`UploadSettingsStep\`은 설정 입력 폼이라 카드가 많은데 거기에 동의 게이트까지 있으니 인지 부담이 큼. 어차피 5단계 \`TranslationEditStep\`이 \"설정 확인\" 단계라 더빙 시작 직전 한 번 더 모든 설정을 보는 자리. 자동 업로드 확인도 거기서 같이 처리하는 게 자연스러움.
- 자동 업로드 ON일 때만 5단계에 카드 노출
- 체크 안 하면 \"더빙 시작\" 버튼 비활성 (\`canStart\` 게이트)

### 2. 4단계 \"미리보기\" 카드 제거
첫 번째 대상 언어 기준 제목/설명을 미리 보여주는 카드. 사용자 인지 부담만 늘리고 가치 낮음. 제거.

### 3. \"Shorts\" → \"Shorts tag\" 라벨 정리
최종 확인 카드의 라벨 \"Shorts\"는 영상 자체를 Shorts로 올리는 건지 #Shorts 해시태그/태그를 붙이는 건지 모호. 실제 동작은 후자(태그 부착, 최종 분류는 YouTube가 결정)이라 \"Shorts tag\"로 명확화. 동의 체크박스 문구도 동일하게 정정.

## 변경 파일
- \`src/features/dubbing/components/steps/UploadSettingsStep.tsx\` — 두 카드 제거 + 미사용 변수/import 정리
- \`src/features/dubbing/components/steps/TranslationEditStep.tsx\` — 자동 업로드 확인 카드 이식, ReviewItem helper 이전, 더빙 시작 버튼 게이트 추가

## 게이트 동작 변화

| 시나리오 | 이전 | 이후 |
|---|---|---|
| 자동 업로드 OFF | 4단계 통과 즉시 5단계 → 6단계 | 동일 |
| 자동 업로드 ON, 미체크 | **4단계 \"다음\" 비활성** | 4단계는 통과, **5단계 \"더빙 시작\" 비활성** |
| 자동 업로드 ON, 체크 | 4단계 통과 → 5단계 → 6단계 | 동일 (체크 위치만 5단계로) |

## Test plan
- [x] \`tsc --noEmit\` 통과
- [x] 전체 vitest 495건 통과
- [ ] 4단계: 자동 업로드 ON 토글해도 \"미리보기\"/\"최종 확인\" 카드 노출 안 됨, \"다음\" 활성
- [ ] 5단계: 자동 업로드 ON일 때 \"자동 업로드 최종 확인\" 카드 노출, 체크 전엔 \"더빙 시작\" 비활성
- [ ] 5단계: 자동 업로드 OFF일 때 카드 미노출, \"더빙 시작\" 즉시 활성
- [ ] 최종 확인 카드 안에 \"Shorts tag\" 라벨, 동의 체크박스 문구도 \"Shorts tag\"로 표기

🤖 Generated with [Claude Code](https://claude.com/claude-code)