### PR TITLE
[codex] 더빙 업로드 플로우 및 Perso API 안정화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Perso.ai
 PERSO_API_KEY=
 PERSO_API_BASE_URL=https://api.perso.ai
-NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://perso.ai
+NEXT_PUBLIC_PERSO_FILE_BASE_URL=https://portal-media.perso.ai
 
 # Google OAuth
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     env:
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: test-google-client-id
-      NEXT_PUBLIC_PERSO_FILE_BASE_URL: https://perso.ai
+      NEXT_PUBLIC_PERSO_FILE_BASE_URL: https://portal-media.perso.ai
       PERSO_API_KEY: test-perso-key
       PERSO_API_BASE_URL: https://api.perso.ai
       TURSO_URL: http://localhost

--- a/src/app/(app)/uploads/page.tsx
+++ b/src/app/(app)/uploads/page.tsx
@@ -17,14 +17,12 @@ import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
 
 type UploadState = 'idle' | 'fetching' | 'uploading' | 'done' | 'error'
 type PrivacyStatus = 'public' | 'unlisted' | 'private'
-type ShortsMode = 'regular' | 'shorts' | 'both'
 
 interface UploadSettings {
   title: string
   description: string
   tags: string
   privacyStatus: PrivacyStatus
-  shortsMode: ShortsMode
   uploadCaptions: boolean
   selfDeclaredMadeForKids: boolean
   containsSyntheticMedia: boolean
@@ -34,12 +32,6 @@ const PRIVACY_OPTIONS = [
   { value: 'private', label: '비공개' },
   { value: 'unlisted', label: '일부 공개' },
   { value: 'public', label: '공개' },
-]
-
-const SHORTS_OPTIONS: Array<{ value: ShortsMode; label: string; hint: string }> = [
-  { value: 'regular', label: '일반 영상', hint: '일반 YouTube 영상으로 업로드' },
-  { value: 'shorts', label: 'Shorts', hint: '제목/태그에 #Shorts 추가' },
-  { value: 'both', label: '일반 + Shorts 양쪽', hint: '두 개의 영상으로 각각 업로드' },
 ]
 
 async function fetchCompletedLanguages(uid: string): Promise<CompletedJobLanguage[]> {
@@ -55,7 +47,6 @@ function buildDefaultSettings(item: CompletedJobLanguage, langName: string): Upl
     description: `${item.video_title} - ${langName} dubbed by Dubtube AI`,
     tags: `Dubtube, AI dubbing, ${langName}, dubbed`,
     privacyStatus: 'private',
-    shortsMode: 'regular',
     uploadCaptions: true,
     selfDeclaredMadeForKids: false,
     containsSyntheticMedia: true,
@@ -140,33 +131,6 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
           />
           <span>Disclose AI-generated or synthetic media</span>
         </label>
-
-        <div>
-          <label className="mb-1.5 block text-sm font-medium text-surface-700 dark:text-surface-300">
-            업로드 형식
-          </label>
-          <div className="grid grid-cols-3 gap-2">
-            {SHORTS_OPTIONS.map((opt) => {
-              const active = settings.shortsMode === opt.value
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => onChange({ ...settings, shortsMode: opt.value })}
-                  className={
-                    'rounded-lg border px-3 py-2 text-left transition-colors cursor-pointer ' +
-                    (active
-                      ? 'border-brand-500 bg-brand-50 dark:bg-brand-900/20'
-                      : 'border-surface-200 hover:border-surface-300 dark:border-surface-700 dark:hover:border-surface-600')
-                  }
-                >
-                  <div className="text-sm font-medium text-surface-900 dark:text-white">{opt.label}</div>
-                  <div className="mt-0.5 text-[11px] text-surface-500">{opt.hint}</div>
-                </button>
-              )
-            })}
-          </div>
-        </div>
 
         <div className="flex items-center gap-2 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50">
           <span className="text-xs text-surface-500">Language: {langName}</span>
@@ -253,34 +217,21 @@ function UploadRow({ item, userId }: UploadRowProps) {
       setState('uploading')
       const baseTags = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
 
-      // Build the list of variants to upload (1 for regular/shorts, 2 for both).
-      const variants: Array<{ isShort: boolean; title: string; tags: string[] }> = []
-      if (settings.shortsMode === 'regular' || settings.shortsMode === 'both') {
-        variants.push({ isShort: false, title: settings.title, tags: baseTags })
-      }
-      if (settings.shortsMode === 'shorts' || settings.shortsMode === 'both') {
-        variants.push({
-          isShort: true,
-          title: settings.title.startsWith('#Shorts ') ? settings.title : `#Shorts ${settings.title}`,
-          tags: Array.from(new Set([...baseTags, 'Shorts'])),
-        })
-      }
-
-      const doUpload = (url: string, v: (typeof variants)[number]) =>
+      const doUpload = (url: string) =>
         ytUploadVideo({
           videoUrl: url,
-          title: v.title,
+          title: settings.title,
           description: settings.description,
-          tags: v.tags,
+          tags: baseTags,
           privacyStatus: settings.privacyStatus,
           selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
           containsSyntheticMedia: settings.containsSyntheticMedia,
           language: item.language_code,
         })
 
-      const uploadOnce = async (v: (typeof variants)[number]) => {
+      const uploadOnce = async () => {
         try {
-          return await doUpload(videoUrl!, v)
+          return await doUpload(videoUrl!)
         } catch (err) {
           const msg = err instanceof Error ? err.message : ''
           const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
@@ -291,66 +242,57 @@ function UploadRow({ item, userId }: UploadRowProps) {
           videoUrl = fresh.video
           srtUrl = srtUrl ?? fresh.srt
           setState('uploading')
-          return await doUpload(videoUrl, v)
+          return await doUpload(videoUrl)
         }
       }
 
-      const results: Array<{ variant: (typeof variants)[number]; videoId: string }> = []
-      for (const v of variants) {
-        const r = await uploadOnce(v)
-        results.push({ variant: v, videoId: r.videoId })
+      const result = await uploadOnce()
 
-        if (settings.uploadCaptions && srtUrl) {
-          try {
-            const srtRes = await fetch(srtUrl)
-            const srtText = await srtRes.text()
-            await ytUploadCaption({
-              videoId: r.videoId,
-              language: item.language_code,
-              // name 비워두면 YouTube가 시청자 로케일에 맞춰 언어 이름 자동 표시.
-              // "X subtitles" 같은 영어 고정 문구를 박으면 일본 시청자에게도 그대로 노출.
-              name: '',
-              srtContent: srtText,
-            })
-          } catch {
-            // SRT optional
-          }
+      if (settings.uploadCaptions && srtUrl) {
+        try {
+          const srtRes = await fetch(srtUrl)
+          const srtText = await srtRes.text()
+          await ytUploadCaption({
+            videoId: result.videoId,
+            language: item.language_code,
+            // name 비워두면 YouTube가 시청자 로케일에 맞춰 언어 이름 자동 표시.
+            // "X subtitles" 같은 영어 고정 문구를 박으면 일본 시청자에게도 그대로 노출.
+            name: '',
+            srtContent: srtText,
+          })
+        } catch {
+          // SRT optional
         }
       }
 
-      // Surface the regular (non-short) upload on the row if present, else the first one.
-      const displayed = results.find((r) => !r.variant.isShort) ?? results[0]
-      setVideoId(displayed.videoId)
+      setVideoId(result.videoId)
       setState('done')
 
       const privacyLabel = PRIVACY_OPTIONS.find((o) => o.value === settings.privacyStatus)?.label || settings.privacyStatus
-      const modeLabel = settings.shortsMode === 'both' ? '일반 + Shorts' : settings.shortsMode === 'shorts' ? 'Shorts' : '일반'
       addToast({
         type: 'success',
         title: `${langName} upload complete`,
-        message: `${modeLabel} · ${privacyLabel} (${results.length}개 업로드)`,
+        message: privacyLabel,
       })
 
       await Promise.all([
-        ...results.map((r) =>
-          dbMutation({
-            type: 'createYouTubeUpload',
-            payload: {
-              userId,
-              youtubeVideoId: r.videoId,
-              title: r.variant.title,
-              languageCode: item.language_code,
-              privacyStatus: settings.privacyStatus,
-              isShort: r.variant.isShort,
-            },
-          }),
-        ),
+        dbMutation({
+          type: 'createYouTubeUpload',
+          payload: {
+            userId,
+            youtubeVideoId: result.videoId,
+            title: settings.title,
+            languageCode: item.language_code,
+            privacyStatus: settings.privacyStatus,
+            isShort: false,
+          },
+        }),
         dbMutation({
           type: 'updateJobLanguageYouTube',
           payload: {
             jobId: item.job_id,
             langCode: item.language_code,
-            youtubeVideoId: displayed.videoId,
+            youtubeVideoId: result.videoId,
           },
         }),
       ])

--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -19,9 +19,9 @@ export default function YouTubeSettingsPage() {
   const defaultLanguage = useYouTubeSettingsStore((s) => s.defaultLanguage)
   const setDefaultLanguage = useYouTubeSettingsStore((s) => s.setDefaultLanguage)
 
-  const { data: channel, isLoading: channelLoading } = useChannelStats()
+  const { data: channel, isLoading: channelLoading, error: channelError } = useChannelStats()
   const isConnected = !!channel
-  const { data: videos = [], isLoading: videosLoading } = useMyVideos(10)
+  const { data: videos = [], isLoading: videosLoading, error: videosError } = useMyVideos(10, isConnected)
 
   return (
     <div className="space-y-6">
@@ -37,6 +37,13 @@ export default function YouTubeSettingsPage() {
           <div className="mt-4 flex items-center gap-2 text-surface-400">
             <Loader2 className="h-4 w-4 animate-spin" />
             <span className="text-sm">채널 정보 불러오는 중...</span>
+          </div>
+        ) : channelError ? (
+          <div className="mt-4 flex flex-col items-center gap-3 py-8">
+            <Video className="h-12 w-12 text-surface-300" />
+            <p className="text-sm text-red-500">
+              {channelError instanceof Error ? channelError.message : 'YouTube 채널 정보를 불러오지 못했습니다.'}
+            </p>
           </div>
         ) : isConnected ? (
           <div className="mt-4 flex items-center justify-between">
@@ -168,6 +175,10 @@ export default function YouTubeSettingsPage() {
               <Loader2 className="h-4 w-4 animate-spin" />
               <span className="text-sm">영상 목록 불러오는 중...</span>
             </div>
+          ) : videosError ? (
+            <p className="py-4 text-center text-sm text-red-500">
+              {videosError instanceof Error ? videosError.message : 'YouTube 영상 목록을 불러오지 못했습니다.'}
+            </p>
           ) : videos.length === 0 ? (
             <p className="py-4 text-center text-sm text-surface-400">영상이 없습니다</p>
           ) : (

--- a/src/app/api/auth/auth-callback.test.ts
+++ b/src/app/api/auth/auth-callback.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/lib/env', () => ({
   })),
   getClientEnv: vi.fn(() => ({
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: 'test-client-id',
-    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://perso.ai',
+    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://portal-media.perso.ai',
   })),
 }))
 

--- a/src/app/api/dashboard/dashboard-routes.test.ts
+++ b/src/app/api/dashboard/dashboard-routes.test.ts
@@ -26,6 +26,8 @@ vi.mock('@/lib/db/queries', () => ({
   updateJobStatus: vi.fn(),
   createYouTubeUpload: vi.fn(async () => 10),
   updateJobLanguageYouTube: vi.fn(),
+  startJobLanguageYouTubeUpload: vi.fn(async () => ({ status: 'reserved' })),
+  failJobLanguageYouTubeUpload: vi.fn(),
 }))
 
 vi.mock('@/lib/db/client', () => ({
@@ -626,6 +628,36 @@ describe('/api/dashboard/mutations', () => {
     const res = await POST(req)
     expect(res.status).toBe(200)
     const body = await res.json()
+    expect(body.data).toEqual({ jobId: 1, langCode: 'ko' })
+  })
+
+  it('returns upload reservation status for startJobLanguageYouTubeUpload', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'startJobLanguageYouTubeUpload',
+        payload: { jobId: 1, langCode: 'ko' },
+      }),
+    })
+    const res = await POST(req)
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.data).toEqual({ status: 'reserved' })
+  })
+
+  it('returns 200 for failJobLanguageYouTubeUpload', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'failJobLanguageYouTubeUpload',
+        payload: { jobId: 1, langCode: 'ko' },
+      }),
+    })
+    const res = await POST(req)
+    const body = await res.json()
+    expect(res.status).toBe(200)
     expect(body.data).toEqual({ jobId: 1, langCode: 'ko' })
   })
 

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -9,6 +9,8 @@ import {
   updateJobLanguageProjects,
   createYouTubeUpload,
   updateJobLanguageYouTube,
+  startJobLanguageYouTubeUpload,
+  failJobLanguageYouTubeUpload,
   deductUserMinutes,
   reserveJobCredits,
   releaseJobCredits,
@@ -132,6 +134,16 @@ export async function POST(req: NextRequest) {
       case 'updateJobLanguageYouTube': {
         const { jobId, langCode, youtubeVideoId } = action.payload
         await updateJobLanguageYouTube(jobId, langCode, youtubeVideoId)
+        return apiOk({ jobId, langCode })
+      }
+      case 'startJobLanguageYouTubeUpload': {
+        const { jobId, langCode } = action.payload
+        const reservation = await startJobLanguageYouTubeUpload(jobId, langCode)
+        return apiOk(reservation)
+      }
+      case 'failJobLanguageYouTubeUpload': {
+        const { jobId, langCode } = action.payload
+        await failJobLanguageYouTubeUpload(jobId, langCode)
         return apiOk({ jobId, langCode })
       }
       case 'updateJobLanguageProjects': {

--- a/src/app/api/perso/external/metadata/route.ts
+++ b/src/app/api/perso/external/metadata/route.ts
@@ -8,18 +8,27 @@ import type { ExternalMetadataResponse } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+function externalRequestBody(spaceSeq: number, url: string, lang?: string) {
+  const normalizedLang = lang?.trim()
+  return {
+    space_seq: spaceSeq,
+    url,
+    ...(normalizedLang && normalizedLang !== 'auto' ? { lang: normalizedLang } : {}),
+  }
+}
+
 export async function POST(req: NextRequest) {
   const auth = await requireSession(req)
   if (!auth.ok) return auth.response
 
   return handle(async () => {
-    const { spaceSeq, url, lang = 'ko' } = await parseBody(req, externalMetadataBodySchema)
+    const { spaceSeq, url, lang } = await parseBody(req, externalMetadataBodySchema)
     return persoFetch<ExternalMetadataResponse>(
       '/file/api/v1/video-translator/external/metadata',
       {
         method: 'POST',
         baseURL: 'file',
-        body: { space_seq: spaceSeq, url, lang },
+        body: externalRequestBody(spaceSeq, url, lang),
       },
     )
   })

--- a/src/app/api/perso/external/upload/route.ts
+++ b/src/app/api/perso/external/upload/route.ts
@@ -10,18 +10,27 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
 
+function externalRequestBody(spaceSeq: number, url: string, lang?: string) {
+  const normalizedLang = lang?.trim()
+  return {
+    space_seq: spaceSeq,
+    url,
+    ...(normalizedLang && normalizedLang !== 'auto' ? { lang: normalizedLang } : {}),
+  }
+}
+
 export async function PUT(req: NextRequest) {
   const auth = await requireSession(req)
   if (!auth.ok) return auth.response
 
   return handle(async () => {
-    const { spaceSeq, url, lang = 'ko' } = await parseBody(req, externalUploadBodySchema)
+    const { spaceSeq, url, lang } = await parseBody(req, externalUploadBodySchema)
     const media = await persoFetch<UploadVideoResponse>(
       '/file/api/upload/video/external',
       {
         method: 'PUT',
         baseURL: 'file',
-        body: { space_seq: spaceSeq, url, lang },
+        body: externalRequestBody(spaceSeq, url, lang),
         timeoutMs: 300_000,
       },
     )

--- a/src/app/api/perso/lipsync/route.ts
+++ b/src/app/api/perso/lipsync/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
     await assertPersoProjectOwner(auth.session.uid, projectSeq)
     return persoFetch<unknown>(
       `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/lip-sync`,
-      { method: 'POST', baseURL: 'api' },
+      { method: 'POST', baseURL: 'api', body: { preferredSpeedType: 'GREEN' } },
     )
   })
 }

--- a/src/app/api/perso/perso-ownership-routes.test.ts
+++ b/src/app/api/perso/perso-ownership-routes.test.ts
@@ -87,6 +87,34 @@ describe('Perso routes — resource ownership', () => {
 
     expect(res.status).toBe(200)
     expect(mockAssertMediaOwner).toHaveBeenCalledWith('user1', 10)
+    expect(mockPersoFetch).toHaveBeenLastCalledWith(
+      '/video-translator/api/v1/projects/spaces/3/translate',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          title: 'Dubtube project 10',
+          ttsModel: 'ELEVEN_V2',
+          withLipSync: false,
+        }),
+      }),
+    )
+  })
+
+  it('does not forward auto as external upload lang', async () => {
+    const { PUT } = await import('./external/upload/route')
+    const req = new NextRequest('http://localhost/api/perso/external/upload', {
+      method: 'PUT',
+      body: JSON.stringify({ spaceSeq: 3, url: 'https://youtube.com/watch?v=abc', lang: 'auto' }),
+    })
+
+    const res = await PUT(req)
+
+    expect(res.status).toBe(200)
+    expect(mockPersoFetch).toHaveBeenCalledWith(
+      '/file/api/upload/video/external',
+      expect.objectContaining({
+        body: { space_seq: 3, url: 'https://youtube.com/watch?v=abc' },
+      }),
+    )
   })
 
   it('records media ownership after external upload', async () => {
@@ -105,5 +133,40 @@ describe('Perso routes — resource ownership', () => {
       sourceType: 'external',
       fileUrl: 'https://youtube.com/watch?v=abc',
     }))
+  })
+
+  it('maps script text edits to Perso targetText', async () => {
+    const { PATCH } = await import('./script/route')
+    const req = new NextRequest('http://localhost/api/perso/script?projectSeq=7&sentenceSeq=9', {
+      method: 'PATCH',
+      body: JSON.stringify({ translatedText: 'updated text' }),
+    })
+
+    const res = await PATCH(req)
+
+    expect(res.status).toBe(200)
+    expect(mockPersoFetch).toHaveBeenCalledWith(
+      '/video-translator/api/v1/project/7/audio-sentence/9',
+      expect.objectContaining({
+        body: { targetText: 'updated text' },
+      }),
+    )
+  })
+
+  it('requests lip sync with the required speed body', async () => {
+    const { POST } = await import('./lipsync/route')
+    const req = new NextRequest('http://localhost/api/perso/lipsync?projectSeq=7&spaceSeq=3', {
+      method: 'POST',
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    expect(mockPersoFetch).toHaveBeenCalledWith(
+      '/video-translator/api/v1/projects/7/spaces/3/lip-sync',
+      expect.objectContaining({
+        body: { preferredSpeedType: 'GREEN' },
+      }),
+    )
   })
 })

--- a/src/app/api/perso/projects/route.ts
+++ b/src/app/api/perso/projects/route.ts
@@ -7,6 +7,10 @@ import type { ProjectDetail } from '@/lib/perso/types'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+interface ProjectListResponse {
+  content?: ProjectDetail[]
+}
+
 export async function GET(req: NextRequest) {
   const auth = await requireSession(req)
   if (!auth.ok) return auth.response
@@ -14,9 +18,18 @@ export async function GET(req: NextRequest) {
   return handle(async () => {
     const url = new URL(req.url)
     const spaceSeq = requireIntParam(url, 'spaceSeq')
-    return persoFetch<ProjectDetail[]>(
+    const data = await persoFetch<ProjectDetail[] | ProjectListResponse>(
       `/video-translator/api/v1/projects/spaces/${spaceSeq}`,
-      { baseURL: 'api' },
+      {
+        baseURL: 'api',
+        query: {
+          memberRole: 'developer',
+          size: 50,
+          offset: 0,
+          sortDirection: 'desc',
+        },
+      },
     )
+    return Array.isArray(data) ? data : data.content ?? []
   })
 }

--- a/src/app/api/perso/script/regenerate/route.ts
+++ b/src/app/api/perso/script/regenerate/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from 'next/server'
 import { requireSession } from '@/lib/auth/session'
 import { persoFetch } from '@/lib/perso/client'
-import { handle, requireIntParam } from '@/lib/perso/route-helpers'
+import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
 import { assertPersoProjectOwner } from '@/lib/perso/ownership'
+import { generateAudioBodySchema } from '@/lib/validators/perso'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -16,9 +17,10 @@ export async function PATCH(req: NextRequest) {
     const projectSeq = requireIntParam(url, 'projectSeq')
     const audioSentenceSeq = requireIntParam(url, 'audioSentenceSeq')
     await assertPersoProjectOwner(auth.session.uid, projectSeq)
+    const body = await parseBody(req, generateAudioBodySchema)
     return persoFetch<unknown>(
       `/video-translator/api/v1/project/${projectSeq}/audio-sentence/${audioSentenceSeq}/generate-audio`,
-      { method: 'PATCH', baseURL: 'api' },
+      { method: 'PATCH', baseURL: 'api', body },
     )
   })
 }

--- a/src/app/api/perso/script/route.ts
+++ b/src/app/api/perso/script/route.ts
@@ -64,7 +64,7 @@ export async function PATCH(req: NextRequest) {
     const body = await parseBody(req, scriptPatchBodySchema)
     return persoFetch<unknown>(
       `/video-translator/api/v1/project/${projectSeq}/audio-sentence/${sentenceSeq}`,
-      { method: 'PATCH', baseURL: 'api', body },
+      { method: 'PATCH', baseURL: 'api', body: { targetText: body.translatedText } },
     )
   })
 }

--- a/src/app/api/perso/srt/route.ts
+++ b/src/app/api/perso/srt/route.ts
@@ -37,15 +37,28 @@ export async function GET(req: NextRequest) {
     const kind = url.searchParams.get('kind') === 'original' ? 'original' : 'translated'
     await assertPersoProjectOwner(auth.session.uid, projectSeq)
 
-    const data = await persoFetch<DownloadResponse>(
-      `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`,
-      { baseURL: 'api', query: { target: 'audioScript' } },
-    )
+    const downloadPath = `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/download`
+    const preferredTarget = kind === 'translated' ? 'translatedSubtitle' : 'originalSubtitle'
+    let data = await persoFetch<DownloadResponse>(downloadPath, {
+      baseURL: 'api',
+      query: { target: preferredTarget },
+    }).catch(() => null)
 
-    const path =
+    let path =
       kind === 'translated'
-        ? data.srtFile?.translatedSubtitleDownloadLink
-        : data.srtFile?.originalSubtitleDownloadLink
+        ? data?.srtFile?.translatedSubtitleDownloadLink
+        : data?.srtFile?.originalSubtitleDownloadLink
+
+    if (!path) {
+      data = await persoFetch<DownloadResponse>(downloadPath, {
+        baseURL: 'api',
+        query: { target: 'audioScript' },
+      })
+      path =
+        kind === 'translated'
+          ? data.srtFile?.translatedSubtitleDownloadLink
+          : data.srtFile?.originalSubtitleDownloadLink
+    }
 
     if (!path) {
       throw Object.assign(new Error(`No ${kind} subtitle link in audioScript response`), {

--- a/src/app/api/perso/translate/route.ts
+++ b/src/app/api/perso/translate/route.ts
@@ -6,6 +6,7 @@ import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
 import { translateBodySchema } from '@/lib/validators/perso'
 import type { TranslateResponse } from '@/lib/perso/types'
 import { assertPersoMediaOwner } from '@/lib/perso/ownership'
+import { logger } from '@/lib/logger'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -31,13 +32,41 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    return persoFetch<TranslateResponse>(
-      `/video-translator/api/v1/projects/spaces/${spaceSeq}/translate`,
-      {
-        method: 'POST',
-        baseURL: 'api',
-        body,
-      },
-    )
+    const title = body.title?.trim() || `Dubtube project ${body.mediaSeq}`
+    const customDictionaryBlobPath = body.customDictionaryBlobPath?.trim()
+    const srtBlobPath = body.srtBlobPath?.trim()
+    const persoBody = {
+      mediaSeq: body.mediaSeq,
+      isVideoProject: body.isVideoProject,
+      sourceLanguageCode: body.sourceLanguageCode.trim() || 'auto',
+      targetLanguageCodes: body.targetLanguageCodes.map((code) => code.trim()),
+      numberOfSpeakers: body.numberOfSpeakers,
+      withLipSync: body.withLipSync ?? false,
+      preferredSpeedType: body.preferredSpeedType,
+      ttsModel: body.ttsModel ?? 'ELEVEN_V2',
+      title,
+      ...(customDictionaryBlobPath ? { customDictionaryBlobPath } : {}),
+      ...(srtBlobPath ? { srtBlobPath } : {}),
+    }
+
+    try {
+      return await persoFetch<TranslateResponse>(
+        `/video-translator/api/v1/projects/spaces/${spaceSeq}/translate`,
+        {
+          method: 'POST',
+          baseURL: 'api',
+          body: persoBody,
+        },
+      )
+    } catch (err) {
+      if (err instanceof PersoError && err.status === 400) {
+        logger.warn('perso translate rejected', {
+          code: err.code,
+          message: err.message,
+          body: persoBody,
+        })
+      }
+      throw err
+    }
   })
 }

--- a/src/app/api/perso/validate/route.ts
+++ b/src/app/api/perso/validate/route.ts
@@ -13,12 +13,13 @@ export async function POST(req: NextRequest) {
 
   return handle(async () => {
     const body = await parseBody(req, mediaValidateBodySchema)
+    const extension = body.extension.startsWith('.') ? body.extension : `.${body.extension}`
     return persoFetch<{ valid?: boolean } | null>(
       '/file/api/v1/media/validate',
       {
         method: 'POST',
         baseURL: 'file',
-        body,
+        body: { ...body, extension },
       },
     )
   })

--- a/src/app/api/youtube/metadata/route.ts
+++ b/src/app/api/youtube/metadata/route.ts
@@ -39,6 +39,7 @@ export async function POST(req: NextRequest) {
         sourceLang: body.sourceLang,
         title: body.title,
         description: body.description,
+        tags: body.tags,
         localizations: body.localizations,
       }),
     )

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -274,6 +274,7 @@ describe('/api/youtube/metadata', () => {
         sourceLang: 'ko',
         title: 'Original title',
         description: 'Original description',
+        tags: ['Dubtube', 'AI더빙'],
         localizations: {
           en: { title: 'English title', description: 'English description' },
         },
@@ -288,6 +289,7 @@ describe('/api/youtube/metadata', () => {
       expect.objectContaining({
         accessToken: 'mock-token',
         videoId: 'yt-123',
+        tags: ['Dubtube', 'AI더빙'],
         localizations: {
           en: { title: 'English title', description: 'English description' },
         },

--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -90,7 +90,7 @@ function ScriptRow({
     if (dirty) await handleSave()
     setRegenerating(true)
     try {
-      await regenerateSentenceAudio(projectSeq, sentence.audioSentenceSeq)
+      await regenerateSentenceAudio(projectSeq, sentence.audioSentenceSeq, sentence.editedTranslatedText)
       addToast({
         type: 'success',
         title: '재생성 요청됨',
@@ -101,7 +101,7 @@ function ScriptRow({
     } finally {
       setRegenerating(false)
     }
-  }, [dirty, handleSave, projectSeq, sentence.audioSentenceSeq, addToast])
+  }, [dirty, handleSave, projectSeq, sentence.audioSentenceSeq, sentence.editedTranslatedText, addToast])
 
   return (
     <div className="space-y-2 rounded-lg border border-surface-200 p-3 dark:border-surface-800">

--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { ArrowLeft, ArrowRight, Check, Search, X } from 'lucide-react'
-import { Button, Card, Toggle, Tooltip } from '@/components/ui'
+import { Button, Card } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import {
   REGION_LABELS,
@@ -26,8 +26,6 @@ export function LanguageSelectStep() {
   const {
     selectedLanguages,
     toggleLanguage,
-    lipSyncEnabled,
-    setLipSync,
     deliverableMode,
     prevStep,
     nextStep,
@@ -36,12 +34,13 @@ export function LanguageSelectStep() {
   const [region, setRegion] = useState<RegionFilter>('popular')
   const [query, setQuery] = useState('')
 
-  // 원본 영상에 자막/오디오 트랙만 추가하는 모드는 비디오 픽셀을 건드리지 않으므로
-  // 립싱크가 적용될 곳이 없다. 스텝을 오가며 stale 상태가 남는 것을 막기 위해 강제 reset.
-  const lipSyncApplicable = deliverableMode !== 'originalWithMultiAudio'
-  useEffect(() => {
-    if (!lipSyncApplicable && lipSyncEnabled) setLipSync(false)
-  }, [lipSyncApplicable, lipSyncEnabled, setLipSync])
+  // Lip sync UI is temporarily hidden. Keep the state/reset logic here for easy restore.
+  // const lipSyncEnabled = useDubbingStore((s) => s.lipSyncEnabled)
+  // const setLipSync = useDubbingStore((s) => s.setLipSync)
+  // const lipSyncApplicable = deliverableMode !== 'originalWithMultiAudio'
+  // useEffect(() => {
+  //   if (!lipSyncApplicable && lipSyncEnabled) setLipSync(false)
+  // }, [lipSyncApplicable, lipSyncEnabled, setLipSync])
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -57,14 +56,18 @@ export function LanguageSelectStep() {
     })
   }, [region, query])
 
-  const estimatedCredits = selectedLanguages.length * 15 + (lipSyncEnabled ? selectedLanguages.length * 8 : 0)
+  const estimatedCredits = selectedLanguages.length * 15
+  // const estimatedCredits = selectedLanguages.length * 15 + (lipSyncEnabled ? selectedLanguages.length * 8 : 0)
+  const selectionDescription = deliverableMode === 'originalWithMultiAudio'
+    ? '자막을 생성할 언어를 선택하세요'
+    : '더빙할 언어를 선택하세요'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="text-center">
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">대상 언어 선택</h2>
         <p className="mt-1 text-surface-500">
-          더빙할 언어를 선택하세요 ({selectedLanguages.length}개 선택됨)
+          {selectionDescription} ({selectedLanguages.length}개 선택됨)
         </p>
       </div>
 
@@ -166,6 +169,7 @@ export function LanguageSelectStep() {
 
       {/* Dub options */}
       <Card>
+        {/*
         <p className="mb-3 text-sm font-semibold text-surface-900 dark:text-white">더빙 옵션</p>
         {lipSyncApplicable && (
           <div className="flex items-center justify-between">
@@ -181,8 +185,9 @@ export function LanguageSelectStep() {
             <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
           </div>
         )}
+        */}
 
-        <div className={cn('rounded-lg bg-surface-50 p-3 dark:bg-surface-800', lipSyncApplicable && 'mt-4')}>
+        <div className="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
           <div className="flex items-center justify-between text-sm">
             <span className="text-surface-600 dark:text-surface-400">예상 크레딧</span>
             <span className="font-bold text-surface-900 dark:text-white">{estimatedCredits} 크레딧</span>

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -22,7 +22,7 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
       value: 'newDubbedVideos',
       icon: Film,
       title: '새 더빙 영상 업로드',
-      description: '더빙된 영상을 언어별 새 YouTube 영상으로 업로드합니다.',
+      description: '더빙된 영상을 YouTube에 업로드합니다.',
     },
   ]
 
@@ -31,14 +31,14 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '기존 영상에 자막 추가',
-      description: '내 YouTube 영상에 번역 자막을 자동 업로드합니다.',
+      description: '번역된 자막을 기존 YouTube 영상에 업로드합니다.',
     })
   } else if (sourceType === 'upload') {
     options.push({
       value: 'originalWithMultiAudio',
       icon: Subtitles,
       title: '원본 업로드 + 자막 추가',
-      description: '원본 영상을 YouTube에 업로드한 뒤, 번역 자막을 자동 추가합니다.',
+      description: '원본 영상과 번역된 자막을 YouTube에 업로드합니다.',
     })
   }
 
@@ -46,7 +46,7 @@ function getAvailableOptions(sourceType: VideoSourceType): DeliverableOption[] {
     value: 'downloadOnly',
     icon: Download,
     title: '다운로드만',
-    description: '더빙 파일을 다운로드만 합니다. YouTube에 업로드하지 않습니다.',
+    description: 'YouTube에 업로드하지 않고 관련 파일을 다운로드합니다.',
   })
 
   return options

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -1,14 +1,13 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import { ArrowLeft, ArrowRight, Info } from 'lucide-react'
-import { Button, Card, CardTitle, Badge, Toggle } from '@/components/ui'
+import { Button, Card, Badge } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { getLanguageByCode } from '@/utils/languages'
 import { useAuthStore } from '@/stores/authStore'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
-
-const MAX_SPEAKERS = 10
 
 const PRIVACY_LABELS: Record<PrivacyStatus, string> = {
   private: '비공개 (권장)',
@@ -18,13 +17,7 @@ const PRIVACY_LABELS: Record<PrivacyStatus, string> = {
 
 export function TranslationEditStep() {
   const {
-    sourceLanguage,
     selectedLanguages,
-    lipSyncEnabled,
-    setLipSync,
-    numberOfSpeakers,
-    setNumberOfSpeakers,
-    videoMeta,
     videoSource,
     deliverableMode,
     uploadSettings,
@@ -34,95 +27,66 @@ export function TranslationEditStep() {
   } = useDubbingStore()
   const user = useAuthStore((s) => s.user)
 
-  const sourceLang = getLanguageByCode(sourceLanguage)
-  const isAutoSource = sourceLanguage === 'auto'
-
   const needsAutoUploadReview = uploadSettings.autoUpload
   const canStart = !needsAutoUploadReview || uploadSettings.uploadReviewConfirmed
   const privacyLabel = PRIVACY_LABELS[uploadSettings.privacyStatus] ?? uploadSettings.privacyStatus
   const targetChannelLabel = user?.email ?? 'Google 로그인 후 연결된 YouTube 채널'
+  const uploadsVideoToYouTube =
+    deliverableMode === 'newDubbedVideos' ||
+    (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')
+  const showsAiDisclosureSetting = deliverableMode === 'newDubbedVideos'
+  const showsCaptionSetting = deliverableMode === 'newDubbedVideos' || deliverableMode === 'originalWithMultiAudio'
+  const deliverableModeLabel = deliverableMode === 'newDubbedVideos'
+    ? '새 더빙 영상 업로드'
+    : deliverableMode === 'originalWithMultiAudio'
+      ? '원본 영상에 자막 추가'
+      : '다운로드만'
+  const metadataLanguageLabel =
+    getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage
+  const tagsLabel = uploadSettings.tags.length > 0 ? uploadSettings.tags.join(', ') : '없음'
+  const autoUploadConfirmationText = uploadsVideoToYouTube
+    ? showsAiDisclosureSetting
+      ? '위 채널, 공개 범위, 작성 언어, 태그, 자막, 아동용, AI 합성 고지 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.'
+      : '위 채널, 공개 범위, 작성 언어, 태그, 자막, 아동용 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.'
+    : '위 대상 언어, 결과물 모드, 자동 업로드, 자막 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="text-center">
         <h2 className="text-2xl font-bold text-surface-900 dark:text-white">설정 확인</h2>
         <p className="mt-1 text-surface-500">
-          처리 전 더빙 설정을 확인하세요.
+          진행 전 설정을 확인하세요.
         </p>
       </div>
 
       {/* Summary card */}
       <Card>
-        <h3 className="font-semibold text-surface-900 dark:text-white mb-4">더빙 설정</h3>
+        <div className="space-y-3">
+          {uploadsVideoToYouTube && (
+            <SummaryRow label="채널" value={targetChannelLabel} />
+          )}
 
-        <div className="space-y-4">
-          {/* Source video */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400">원본 영상</span>
-            <span className="text-sm font-medium text-surface-900 dark:text-white truncate ml-4 max-w-[300px]">
-              {videoMeta?.title || '알 수 없음'}
-            </span>
-          </div>
+          <SummaryRow
+            label={`대상 언어 (${selectedLanguages.length})`}
+            value={(
+              <div className="flex flex-wrap justify-end gap-2">
+                {selectedLanguages.map((code) => {
+                  const lang = getLanguageByCode(code)
+                  if (!lang) return null
+                  return (
+                    <Badge key={code} variant="brand">
+                      {lang.flag} {lang.name}
+                    </Badge>
+                  )
+                })}
+              </div>
+            )}
+          />
 
-          {/* Source language */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400">원본 언어</span>
-            <span className="text-sm font-medium text-surface-900 dark:text-white">
-              {isAutoSource
-                ? '🌐 자동 감지'
-                : `${sourceLang?.flag ?? ''} ${sourceLang?.name ?? '알 수 없음'}`}
-            </span>
-          </div>
-
-          {/* Target languages */}
-          <div className="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400 mb-2 block">
-              대상 언어 ({selectedLanguages.length})
-            </span>
-            <div className="flex flex-wrap gap-2">
-              {selectedLanguages.map((code) => {
-                const lang = getLanguageByCode(code)
-                if (!lang) return null
-                return (
-                  <Badge key={code} variant="brand">
-                    {lang.flag} {lang.name}
-                  </Badge>
-                )
-              })}
-            </div>
-          </div>
-
-          {/* Number of speakers */}
-          <div className="rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-surface-600 dark:text-surface-400">화자 수</span>
-              <span className="text-sm font-semibold text-surface-900 dark:text-white">
-                {numberOfSpeakers}명
-              </span>
-            </div>
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {Array.from({ length: MAX_SPEAKERS }, (_, i) => i + 1).map((n) => (
-                <button
-                  key={n}
-                  type="button"
-                  onClick={() => setNumberOfSpeakers(n)}
-                  className={cn(
-                    'h-8 w-8 rounded-lg text-sm font-medium transition-all cursor-pointer',
-                    numberOfSpeakers === n
-                      ? 'bg-brand-500 text-white'
-                      : 'bg-white text-surface-600 border border-surface-300 hover:border-brand-300 dark:bg-surface-700 dark:text-surface-300 dark:border-surface-600',
-                  )}
-                >
-                  {n}
-                </button>
-              ))}
-            </div>
-            <p className="mt-2 text-xs text-surface-400">
-              영상에 등장하는 화자 수를 선택하세요.
-            </p>
-          </div>
-
-          {/* Lip sync — 원본+자막 모드는 비디오 픽셀을 건드리지 않으므로 미노출 */}
+          {/*
+          Lip sync — 원본+자막 모드는 비디오 픽셀을 건드리지 않으므로 미노출.
+          립싱크 UI는 임시 숨김 상태이며, 기능 복구 시 아래 블록과 Toggle import,
+          lipSyncEnabled/setLipSync store 값을 함께 되살리면 된다.
           {deliverableMode !== 'originalWithMultiAudio' && (
             <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
               <div>
@@ -132,28 +96,63 @@ export function TranslationEditStep() {
               <Toggle checked={lipSyncEnabled} onChange={setLipSync} />
             </div>
           )}
+          */}
 
-          {/* Deliverable mode */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400">결과물 모드</span>
-            <span className="text-sm font-medium text-surface-900 dark:text-white">
-              {deliverableMode === 'newDubbedVideos' ? '새 더빙 영상 업로드'
-                : deliverableMode === 'originalWithMultiAudio' ? '원본 영상에 자막 추가'
-                : '다운로드만'}
-            </span>
-          </div>
+          {uploadsVideoToYouTube && (
+            <SummaryRow label="공개 범위" value={privacyLabel} />
+          )}
 
-          {/* Auto upload */}
-          <div className="flex items-center justify-between rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
-            <span className="text-sm text-surface-600 dark:text-surface-400">자동 업로드</span>
-            <span className={cn(
-              'text-sm font-medium',
-              uploadSettings.autoUpload ? 'text-emerald-600 dark:text-emerald-400' : 'text-surface-500',
-            )}>
-              {uploadSettings.autoUpload ? 'ON' : 'OFF'}
-            </span>
-          </div>
+          <SummaryRow label="결과물 모드" value={deliverableModeLabel} />
+
+          <SummaryRow
+            label="자동 업로드"
+            value={<StatusValue active={uploadSettings.autoUpload} />}
+          />
+
+          {showsCaptionSetting && (
+            <SummaryRow
+              label="자막"
+              value={<StatusValue active={uploadSettings.autoUpload && uploadSettings.uploadCaptions} />}
+            />
+          )}
+
+          {uploadsVideoToYouTube && (
+            <>
+              <SummaryRow
+                label="작성 언어"
+                value={`${metadataLanguageLabel} 기준`}
+              />
+              <SummaryRow
+                label="태그"
+                value={tagsLabel}
+              />
+              <SummaryRow
+                label="아동용"
+                value={uploadSettings.selfDeclaredMadeForKids ? '예' : '아니오'}
+              />
+              {showsAiDisclosureSetting && (
+                <SummaryRow
+                  label="AI 합성 고지"
+                  value={<StatusValue active={uploadSettings.containsSyntheticMedia} />}
+                />
+              )}
+            </>
+          )}
         </div>
+
+        {needsAutoUploadReview && (
+          <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-sm text-surface-700 dark:border-amber-900/70 dark:bg-amber-950/20 dark:text-surface-200">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+              checked={uploadSettings.uploadReviewConfirmed}
+              onChange={(e) => setUploadSettings({ uploadReviewConfirmed: e.target.checked })}
+            />
+            <span>
+              {autoUploadConfirmationText}
+            </span>
+          </label>
+        )}
       </Card>
 
       {/* Info note */}
@@ -169,40 +168,6 @@ export function TranslationEditStep() {
         </div>
       </Card>
 
-      {/* 자동 업로드 최종 확인 — 자동 업로드 ON일 때만 노출. 더빙 시작 전 마지막 사용자 동의 게이트. */}
-      {needsAutoUploadReview && (
-        <Card className="border-amber-200 bg-amber-50/40 dark:border-amber-900 dark:bg-amber-950/10">
-          <CardTitle>자동 업로드 최종 확인</CardTitle>
-          <div className="mt-4 grid gap-2 text-xs text-surface-600 dark:text-surface-300 sm:grid-cols-2">
-            <ReviewItem label="채널" value={targetChannelLabel} />
-            <ReviewItem label="공개 범위" value={privacyLabel} />
-            <ReviewItem label="Shorts tag" value={uploadSettings.uploadAsShort ? 'ON' : 'OFF'} />
-            <ReviewItem label="자막" value={uploadSettings.uploadCaptions ? '업로드' : '업로드 안 함'} />
-            <ReviewItem label="아동용" value={uploadSettings.selfDeclaredMadeForKids ? '예' : '아니오'} />
-            <ReviewItem label="AI 합성 공개" value={uploadSettings.containsSyntheticMedia ? 'ON' : 'OFF'} />
-            <ReviewItem
-              label="제목/설명 번역"
-              value={`${getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage} 기준 → ${selectedLanguages.length}개 언어`}
-            />
-            <ReviewItem
-              label="localizations"
-              value={deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload' ? 'YouTube localizations 포함' : '언어별 제목/설명 적용'}
-            />
-          </div>
-          <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-lg border border-amber-200 bg-white/70 p-3 text-sm text-surface-700 dark:border-amber-900/70 dark:bg-surface-900/50 dark:text-surface-200">
-            <input
-              type="checkbox"
-              className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
-              checked={uploadSettings.uploadReviewConfirmed}
-              onChange={(e) => setUploadSettings({ uploadReviewConfirmed: e.target.checked })}
-            />
-            <span>
-              위 채널, 공개 범위, 제목/설명 번역, 자막, Shorts tag, 아동용, AI 합성 공개 설정을 확인했으며 처리 완료 후 자동 업로드를 실행합니다.
-            </span>
-          </label>
-        </Card>
-      )}
-
       <div className="flex justify-between">
         <Button variant="secondary" onClick={prevStep}>
           <ArrowLeft className="h-4 w-4" />
@@ -217,11 +182,36 @@ export function TranslationEditStep() {
   )
 }
 
-function ReviewItem({ label, value }: { label: string; value: string }) {
+function SummaryRow({
+  label,
+  value,
+  description,
+}: {
+  label: string
+  value: ReactNode
+  description?: string
+}) {
   return (
-    <div className="rounded-md bg-white/70 px-3 py-2 dark:bg-surface-900/50">
-      <p className="text-[11px] font-medium text-surface-400">{label}</p>
-      <p className="mt-0.5 truncate text-surface-700 dark:text-surface-200">{value}</p>
+    <div className="flex items-start justify-between gap-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800">
+      <div className="min-w-0">
+        <span className="text-sm text-surface-600 dark:text-surface-400">{label}</span>
+        {description && (
+          <p className="mt-0.5 text-xs text-surface-400">{description}</p>
+        )}
+      </div>
+      <div className="max-w-[60%] break-words text-right text-sm font-medium text-surface-900 dark:text-white">
+        {value}
+      </div>
     </div>
+  )
+}
+
+function StatusValue({ active }: { active: boolean }) {
+  return (
+    <span className={cn(
+      active ? 'text-emerald-600 dark:text-emerald-400' : 'text-surface-500',
+    )}>
+      {active ? 'ON' : 'OFF'}
+    </span>
   )
 }

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { ArrowLeft, ArrowRight, Captions, Languages, Link2, ShieldCheck, Sparkles, Upload, Zap } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Captions, Languages, Link2, ShieldCheck, Sparkles, Upload } from 'lucide-react'
 import { Button, Card, CardTitle, Input, Select } from '@/components/ui'
 import { extractVideoId } from '@/utils/validators'
-import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
+import { SUPPORTED_LANGUAGES } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
+import { getAiDisclosureText, stripAiDisclosureFooter } from '../../utils/aiDisclosure'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
 const PRIVACY_OPTIONS: { value: PrivacyStatus; label: string }[] = [
@@ -23,7 +24,6 @@ export function UploadSettingsStep() {
   const {
     videoMeta,
     videoSource,
-    isShort,
     deliverableMode,
     uploadSettings,
     setUploadSettings,
@@ -44,6 +44,20 @@ export function UploadSettingsStep() {
   const originalYouTubeUrl = originalYouTubeId
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
+  const aiDisclosureText = getAiDisclosureText(uploadSettings.metadataLanguage)
+
+  useEffect(() => {
+    const strippedDescription = stripAiDisclosureFooter(uploadSettings.description)
+    if (strippedDescription !== uploadSettings.description) {
+      setUploadSettings({ description: strippedDescription })
+    }
+  }, [uploadSettings.description, setUploadSettings])
+
+  useEffect(() => {
+    if (deliverableMode === 'newDubbedVideos' && !uploadSettings.autoUpload && uploadSettings.uploadCaptions) {
+      setUploadSettings({ uploadCaptions: false })
+    }
+  }, [deliverableMode, uploadSettings.autoUpload, uploadSettings.uploadCaptions, setUploadSettings])
 
   // 영상 정보로 제목/설명을 초기 1회 채워준다. 사용자가 빈 값으로 지웠을 때
   // 다시 채워 넣지 않도록 videoMeta.id 단위로 한 번만 실행. (deps에 입력값을
@@ -58,7 +72,7 @@ export function UploadSettingsStep() {
     const patch: Partial<typeof uploadSettings> = {}
     if (!title) patch.title = videoMeta.title
     if (!description) {
-      patch.description = `${videoMeta.title} - Dubtube AI 더빙\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.`
+      patch.description = `${videoMeta.title} - Dubtube AI 더빙`
     }
     if (Object.keys(patch).length > 0) setUploadSettings(patch)
   }, [videoMeta?.id, videoMeta?.title, setUploadSettings])
@@ -77,10 +91,25 @@ export function UploadSettingsStep() {
   const uploadsVideoToYouTube =
     deliverableMode === 'newDubbedVideos' ||
     (isMultiAudio && videoSource?.type === 'upload')
+  const shouldShowAiDisclosure = deliverableMode === 'newDubbedVideos'
   const canContinue =
     deliverableMode === 'originalWithMultiAudio'
       ? true
       : uploadSettings.title.trim().length > 0
+  const handleSyntheticMediaToggle = () => {
+    setUploadSettings({
+      containsSyntheticMedia: !uploadSettings.containsSyntheticMedia,
+      description: stripAiDisclosureFooter(uploadSettings.description),
+    })
+  }
+  const handleAutoUploadToggle = () => {
+    const nextAutoUpload = !uploadSettings.autoUpload
+    setUploadSettings(nextAutoUpload
+      ? { autoUpload: true, uploadCaptions: true }
+      : { autoUpload: false, uploadCaptions: false })
+  }
+  const captionUploadDisabled =
+    deliverableMode === 'newDubbedVideos' && !uploadSettings.autoUpload
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -93,26 +122,23 @@ export function UploadSettingsStep() {
         </p>
       </div>
 
-      {/* Title/Desc/Tags — only for newDubbedVideos or originalWithMultiAudio(upload) */}
+      {/* Title/Desc/Tags — for new dubbed video uploads */}
       {deliverableMode === 'newDubbedVideos' && (
         <Card>
           <CardTitle>제목 · 설명 · 태그</CardTitle>
-          <p className="mt-1 mb-4 text-xs text-surface-500">
-            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 각 대상 언어로 자동 번역되어 업로드됩니다.
-          </p>
           <div className="space-y-4">
             <Select
-              label="제목·설명 작성 언어"
+              label="작성 언어"
               value={uploadSettings.metadataLanguage}
               onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
               options={LANGUAGE_OPTIONS}
             />
             <p className="-mt-2 text-xs text-surface-400">
-              마이페이지의 기본 작성 언어를 따르며, 여기에서 더빙별로 변경할 수 있습니다.
+              작성하기 편한 언어를 선택하세요. 제목과 설명은 더빙 대상 언어 기준으로 자동 번역되어 업로드됩니다.
             </p>
 
             <Input
-              label="제목 (공통)"
+              label="제목"
               value={uploadSettings.title}
               onChange={(e) => setUploadSettings({ title: e.target.value })}
               placeholder="영상 제목"
@@ -130,6 +156,9 @@ export function UploadSettingsStep() {
                 placeholder="영상 설명"
                 className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
               />
+              {uploadSettings.containsSyntheticMedia && shouldShowAiDisclosure && (
+                <AiDisclosurePreview text={aiDisclosureText} />
+              )}
             </div>
 
             <Input
@@ -138,6 +167,9 @@ export function UploadSettingsStep() {
               onChange={(e) => handleTagsChange(e.target.value)}
               placeholder="Dubtube, AI더빙, dubbed"
             />
+            <p className="-mt-2 text-xs text-surface-400">
+              태그는 번역하지 않고 그대로 사용합니다.
+            </p>
 
             <Select
               label="공개 설정"
@@ -145,9 +177,6 @@ export function UploadSettingsStep() {
               onChange={(e) => setUploadSettings({ privacyStatus: e.target.value as PrivacyStatus })}
               options={PRIVACY_OPTIONS}
             />
-            <p className="-mt-2 text-xs text-surface-400">
-              안전을 위해 비공개를 권장합니다. 업로드 후 YouTube Studio에서 변경할 수 있습니다.
-            </p>
           </div>
         </Card>
       )}
@@ -156,16 +185,16 @@ export function UploadSettingsStep() {
       {isMultiAudio && videoSource?.type === 'upload' && (
         <Card>
           <CardTitle>원본 영상 업로드 설정</CardTitle>
-          <p className="mt-1 mb-4 text-xs text-surface-500">
-            아래 텍스트는 <strong>{getLanguageByCode(uploadSettings.metadataLanguage)?.name ?? uploadSettings.metadataLanguage}</strong> 기준으로 작성한 것으로 간주하고, 선택한 대상 언어로 자동 번역되어 YouTube `localizations`에 함께 등록됩니다.
-          </p>
           <div className="space-y-4">
             <Select
-              label="제목·설명 작성 언어"
+              label="작성 언어"
               value={uploadSettings.metadataLanguage}
               onChange={(e) => setUploadSettings({ metadataLanguage: e.target.value })}
               options={LANGUAGE_OPTIONS}
             />
+            <p className="-mt-2 text-xs text-surface-400">
+              작성하기 편한 언어를 선택하세요. 제목과 설명은 더빙 대상 언어 기준으로 자동 번역되어 업로드됩니다.
+            </p>
 
             <Input
               label="제목"
@@ -186,7 +215,20 @@ export function UploadSettingsStep() {
                 placeholder="영상 설명"
                 className="w-full rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 resize-none"
               />
+              {uploadSettings.containsSyntheticMedia && shouldShowAiDisclosure && (
+                <AiDisclosurePreview text={aiDisclosureText} />
+              )}
             </div>
+
+            <Input
+              label="태그 (쉼표 구분)"
+              value={tagsString}
+              onChange={(e) => handleTagsChange(e.target.value)}
+              placeholder="Dubtube, AI더빙, subtitles"
+            />
+            <p className="-mt-2 text-xs text-surface-400">
+              태그는 번역하지 않고 그대로 사용합니다.
+            </p>
 
             <Select
               label="공개 설정"
@@ -207,25 +249,24 @@ export function UploadSettingsStep() {
             label="완료 즉시 자동 업로드"
             description={isMultiAudio
               ? '더빙 완료 시 자동으로 오디오 트랙을 추가합니다.'
-              : '더빙이 완료되면 개입 없이 모든 언어를 자동으로 업로드합니다.'}
+              : '더빙이 완료되면 더빙된 영상을 자동으로 업로드합니다.'}
             active={uploadSettings.autoUpload}
             activeLabel="ON"
             inactiveLabel="OFF"
-            onToggle={() => setUploadSettings({ autoUpload: !uploadSettings.autoUpload })}
+            onToggle={handleAutoUploadToggle}
           />
 
-          {/* Shorts 토글: 새로 영상을 YouTube에 올리는 케이스에만 노출.
-              channel 모드는 이미 업로드된 영상이라 Shorts 분류가 고정됨. */}
-          {(deliverableMode === 'newDubbedVideos' ||
-            (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')) && (
+          {(deliverableMode === 'newDubbedVideos' || isMultiAudio) && (
             <ToggleRow
-              icon={<Zap className="h-4 w-4 text-brand-500" />}
-              label={isShort ? 'Shorts 해시태그 붙이기 (자동 감지됨)' : 'Shorts 해시태그 붙이기'}
-              description="제목 앞에 #Shorts가 추가되고 Shorts 태그가 붙습니다. 최종 Shorts 분류는 영상 비율·길이에 따라 YouTube가 결정합니다."
-              active={uploadSettings.uploadAsShort}
+              icon={<Captions className="h-4 w-4 text-surface-400" />}
+              label={isMultiAudio ? '자막(SRT) 업로드' : '더빙 영상에 자막(SRT) 자동 업로드'}
+              description={isMultiAudio ? '완료된 언어의 번역 자막을 대상 영상에 업로드합니다.' : '선택한 언어에 맞는 자막을 함께 업로드합니다.'}
+              active={captionUploadDisabled ? false : uploadSettings.uploadCaptions}
               activeLabel="ON"
               inactiveLabel="OFF"
-              onToggle={() => setUploadSettings({ uploadAsShort: !uploadSettings.uploadAsShort })}
+              onToggle={() => setUploadSettings({ uploadCaptions: !uploadSettings.uploadCaptions })}
+              disabled={captionUploadDisabled}
+              disabledBadgeLabel="자동 업로드 OFF"
             />
           )}
 
@@ -241,39 +282,29 @@ export function UploadSettingsStep() {
             />
           )}
 
-          {(deliverableMode === 'newDubbedVideos' || isMultiAudio) && (
-            <ToggleRow
-              icon={<Captions className="h-4 w-4 text-surface-400" />}
-              label={isMultiAudio ? '자막(SRT) 업로드' : '더빙 영상에 자막(SRT) 첨부'}
-              description={isMultiAudio ? '완료된 언어의 번역 자막을 대상 영상에 업로드합니다.' : '즉시 업로드와 예약 업로드 모두 번역 자막을 함께 처리합니다.'}
-              active={uploadSettings.uploadCaptions}
-              activeLabel="ON"
-              inactiveLabel="OFF"
-              onToggle={() => setUploadSettings({ uploadCaptions: !uploadSettings.uploadCaptions })}
-            />
-          )}
-
           {uploadsVideoToYouTube && (
             <>
               <ToggleRow
                 icon={<ShieldCheck className="h-4 w-4 text-surface-400" />}
                 label="아동용으로 제작됨"
-                description="YouTube의 아동용 콘텐츠 신고값입니다. 기본값은 아니오입니다."
+                description="YouTube의 아동용 콘텐츠 신고값입니다."
                 active={uploadSettings.selfDeclaredMadeForKids}
                 activeLabel="예"
                 inactiveLabel="아니오"
                 onToggle={() => setUploadSettings({ selfDeclaredMadeForKids: !uploadSettings.selfDeclaredMadeForKids })}
               />
 
-              <ToggleRow
-                icon={<Sparkles className="h-4 w-4 text-amber-500" />}
-                label="AI 합성/변형 콘텐츠 공개"
-                description="AI 더빙 음성이 포함되므로 기본값은 공개 ON입니다."
-                active={uploadSettings.containsSyntheticMedia}
-                activeLabel="ON"
-                inactiveLabel="OFF"
-                onToggle={() => setUploadSettings({ containsSyntheticMedia: !uploadSettings.containsSyntheticMedia })}
-              />
+              {shouldShowAiDisclosure && (
+                <ToggleRow
+                  icon={<Sparkles className="h-4 w-4 text-amber-500" />}
+                  label="AI 합성/변형 콘텐츠 공개"
+                  description="설명 맨 아래에 AI 보이스 클론 더빙 고지 문구를 자동으로 붙입니다."
+                  active={uploadSettings.containsSyntheticMedia}
+                  activeLabel="ON"
+                  inactiveLabel="OFF"
+                  onToggle={handleSyntheticMediaToggle}
+                />
+              )}
             </>
           )}
 
@@ -307,6 +338,19 @@ export function UploadSettingsStep() {
   )
 }
 
+function AiDisclosurePreview({ text }: { text: string }) {
+  return (
+    <div className="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-900/70 dark:bg-amber-950/20">
+      <p className="text-[11px] font-medium text-amber-700 dark:text-amber-300">
+        설명 맨 아래에 자동 추가
+      </p>
+      <p className="mt-1 text-xs leading-5 text-surface-700 dark:text-surface-200">
+        {text}
+      </p>
+    </div>
+  )
+}
+
 interface ToggleRowProps {
   icon: React.ReactNode
   label: string
@@ -316,11 +360,12 @@ interface ToggleRowProps {
   inactiveLabel: string
   onToggle: () => void
   disabled?: boolean
+  disabledBadgeLabel?: string
 }
 
-function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle, disabled }: ToggleRowProps) {
+function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabel, onToggle, disabled, disabledBadgeLabel = '준비 중' }: ToggleRowProps) {
   return (
-    <div className={`flex items-center justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 ${disabled ? 'opacity-60' : ''}`}>
+    <div className={`flex items-start justify-between gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 ${disabled ? 'opacity-60' : ''}`}>
       <div className="flex min-w-0 items-start gap-2">
         <div className="mt-0.5 flex-shrink-0">{icon}</div>
         <div className="min-w-0">
@@ -328,12 +373,12 @@ function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabe
             <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>
             {disabled && (
               <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
-                준비 중
+                {disabledBadgeLabel}
               </span>
             )}
           </div>
           {description && (
-            <p className={`mt-0.5 text-xs text-surface-400 ${disabled ? '' : 'truncate'}`}>{description}</p>
+            <p className="mt-1 text-xs leading-5 text-surface-500 dark:text-surface-400">{description}</p>
           )}
         </div>
       </div>
@@ -354,4 +399,3 @@ function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabe
     </div>
   )
 }
-

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Download, Check, RotateCcw, Upload, Loader2, Volume2 } from 'lucide-react'
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button, Card, CardTitle, Badge, Progress } from '@/components/ui'
 import { getLanguageByCode } from '@/utils/languages'
@@ -13,29 +13,36 @@ import { useAuthStore } from '@/stores/authStore'
 import {
   ytUploadVideo,
   ytUploadCaption,
+  ytFetchVideoMetadata,
+  ytUpdateVideoLocalizations,
   getPersoFileUrl,
   getTranslatedSrt,
   translateMetadata,
   type MetadataTranslation,
 } from '@/lib/api-client'
 import { toBcp47 } from '@/utils/languages'
-import { dbMutation } from '@/lib/api/dbMutation'
+import { dbMutation, dbMutationStrict } from '@/lib/api/dbMutation'
 import { SubtitleScriptEditor } from '../SubtitleScriptEditor'
 import { YouTubeExtensionUpload } from '../YouTubeExtensionUpload'
+import { appendAiDisclosureFooter, appendTextFooter, stripAiDisclosureFooter } from '../../utils/aiDisclosure'
+import type { YouTubeUploadState } from '../../types/dubbing.types'
 
 type UploadStatus = 'idle' | 'uploading' | 'done' | 'error'
 
-interface LangUploadState {
-  status: UploadStatus
-  progress: number
-  videoId?: string
-  error?: string
+function isYouTubeUploadLocked(state: YouTubeUploadState | undefined) {
+  return state?.status === 'uploading' || state?.status === 'done'
+}
+
+interface YouTubeUploadReservation {
+  status: 'reserved' | 'already_uploaded' | 'already_uploading' | 'not_found'
+  youtubeVideoId?: string | null
 }
 
 export function UploadStep() {
   const {
     selectedLanguages, videoMeta, videoSource, languageProgress, dbJobId,
-    spaceSeq, projectMap, uploadSettings, deliverableMode, originalVideoUrl, reset,
+    spaceSeq, projectMap, youtubeUploads: ytUploads, setYouTubeUploadState,
+    uploadSettings, deliverableMode, originalVideoUrl, isShort, reset,
   } = useDubbingStore()
   const { fetchDownloads } = usePersoFlow()
   const addToast = useNotificationStore((s) => s.addToast)
@@ -51,31 +58,34 @@ export function UploadStep() {
 
   const {
     autoUpload,
-    uploadAsShort,
     attachOriginalLink,
     title: settingsTitle,
     description: settingsDescription,
     tags: settingsTags,
     privacyStatus,
     metadataLanguage,
-    uploadCaptions: shouldUploadCaptions,
+    uploadCaptions: uploadCaptionsEnabled,
     selfDeclaredMadeForKids,
     containsSyntheticMedia,
     uploadReviewConfirmed,
   } = uploadSettings
+  const editableDescription = stripAiDisclosureFooter(settingsDescription || '')
+  const shouldUploadCaptions = autoUpload && uploadCaptionsEnabled
+  const shouldApplyAiDisclosure = deliverableMode === 'newDubbedVideos' && containsSyntheticMedia
+  const videoMetaTitle = videoMeta?.title
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
-  const [ytUploads, setYtUploads] = useState<Record<string, LangUploadState>>({})
   const [captionUploads, setCaptionUploads] = useState<Record<string, UploadStatus>>({})
   const [audioTrackEnabled, setAudioTrackEnabled] = useState(false)
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
-  const autoUploadTriggered = useRef(false)
   const autoChainTriggered = useRef(false)
+  const existingVideoTagSyncRef = useRef<Set<string>>(new Set())
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
   // ─── Metadata translations (Gemini) ─────────────────────────────────
   // Upload Step에 진입한 시점의 (title, description, metadataLanguage, selectedLanguages) 조합으로
   // 한 번 번역해두고 캐시. 모든 언어별 업로드와 localizations에서 공용으로 쓴다.
+  // AI 고지 문구는 Gemini에 보내지 않고, 번역 후 로컬 문구 목록에서 언어별로 붙인다.
   // 실패해도 fallback으로 원문이 들어가도록 처리되어 업로드를 막지 않는다.
   const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
   const translatePromiseRef = useRef<Promise<Record<string, MetadataTranslation>> | null>(null)
@@ -83,7 +93,7 @@ export function UploadStep() {
   const ensureTranslations = useCallback(async (): Promise<Record<string, MetadataTranslation>> => {
     const cacheKey = JSON.stringify({
       title: settingsTitle?.trim() || videoMeta?.title || '',
-      description: settingsDescription || '',
+      description: editableDescription,
       metadataLanguage,
       selectedLanguages,
     })
@@ -100,7 +110,7 @@ export function UploadStep() {
       try {
         const result = await translateMetadata({
           title: baseTitle,
-          description: settingsDescription || '',
+          description: editableDescription,
           sourceLang: metadataLanguage || 'ko',
           targetLangs: selectedLanguages,
         })
@@ -110,7 +120,7 @@ export function UploadStep() {
         // 실패 시 모든 언어를 원문으로 fallback. 사용자에게는 toast로 1회 안내.
         const fallback: Record<string, MetadataTranslation> = {}
         for (const code of selectedLanguages) {
-          fallback[code] = { title: baseTitle, description: settingsDescription || '' }
+          fallback[code] = { title: baseTitle, description: editableDescription }
         }
         setTranslations(fallback)
         addToast({
@@ -125,7 +135,7 @@ export function UploadStep() {
     })()
     translatePromiseRef.current = p
     return p
-  }, [translations, settingsTitle, videoMeta?.title, settingsDescription, metadataLanguage, selectedLanguages, addToast])
+  }, [translations, settingsTitle, videoMeta?.title, editableDescription, metadataLanguage, selectedLanguages, addToast])
 
   // Original video upload state (for upload + originalWithMultiAudio)
   const [originalUploadState, setOriginalUploadState] = useState<{
@@ -138,16 +148,52 @@ export function UploadStep() {
   const multiAudioVideoId =
     originalUploadState.videoId || channelVideoId || null
 
-  /** 번역되었거나 원문인 description에 공통 footer(원본 링크)를 붙여 준다. */
+  /** 번역되었거나 원문인 description에 공통 footer를 붙여 준다. AI 고지는 더빙 영상 업로드에만 붙인다. */
   const applyDescriptionFooter = useCallback(
-    (desc: string) => {
+    (desc: string, languageCode: string) => {
+      let next = stripAiDisclosureFooter(desc)
       if (attachOriginalLink && originalYouTubeUrl) {
-        return `${desc}\n\n원본 영상: ${originalYouTubeUrl}`
+        next = appendTextFooter(next, `원본 영상: ${originalYouTubeUrl}`)
       }
-      return desc
+      return appendAiDisclosureFooter(next, languageCode, shouldApplyAiDisclosure)
     },
-    [attachOriginalLink, originalYouTubeUrl],
+    [attachOriginalLink, originalYouTubeUrl, shouldApplyAiDisclosure],
   )
+
+  const applyTagsToExistingVideo = useCallback(async (targetVideoId: string) => {
+    const requestedTags = Array.from(new Set(settingsTags.map((tag) => tag.trim()).filter(Boolean)))
+    if (!isAuthenticated || requestedTags.length === 0) return
+
+    const syncKey = `${targetVideoId}:${requestedTags.join('\n')}`
+    if (existingVideoTagSyncRef.current.has(syncKey)) return
+    existingVideoTagSyncRef.current.add(syncKey)
+
+    try {
+      const metadata = await ytFetchVideoMetadata(targetVideoId)
+      const mergedTags = Array.from(new Set([...metadata.tags, ...requestedTags]))
+      if (
+        mergedTags.length === metadata.tags.length &&
+        mergedTags.every((tag, index) => tag === metadata.tags[index])
+      ) {
+        return
+      }
+
+      await ytUpdateVideoLocalizations({
+        videoId: targetVideoId,
+        sourceLang: metadata.defaultLanguage || toBcp47(metadataLanguage),
+        title: metadata.title || settingsTitle?.trim() || videoMetaTitle || 'Untitled',
+        description: metadata.description,
+        tags: mergedTags,
+        localizations: metadata.localizations,
+      })
+    } catch (err) {
+      addToast({
+        type: 'warning',
+        title: 'YouTube 태그 적용 실패',
+        message: err instanceof Error ? err.message : '자막 업로드는 계속 진행합니다.',
+      })
+    }
+  }, [addToast, isAuthenticated, metadataLanguage, settingsTags, settingsTitle, videoMetaTitle])
 
   const handleNewDubbing = () => reset()
   const handleGoToDashboard = () => { reset(); router.push('/dashboard') }
@@ -164,17 +210,22 @@ export function UploadStep() {
       const localizations: Record<string, { title: string; description: string }> = {}
       for (const code of selectedLanguages) {
         const t = allTranslations[code]
-        if (t) localizations[toBcp47(code)] = { title: t.title, description: t.description }
+        if (t) {
+          localizations[toBcp47(code)] = {
+            title: t.title,
+            description: applyDescriptionFooter(t.description, code),
+          }
+        }
       }
 
       const result = await ytUploadVideo({
         videoUrl: originalVideoUrl,
         title: settingsTitle?.trim() || videoMeta?.title || 'Original Video',
-        description: settingsDescription || '',
+        description: applyDescriptionFooter(editableDescription, metadataLanguage),
         tags: settingsTags,
         privacyStatus,
         selfDeclaredMadeForKids,
-        containsSyntheticMedia,
+        containsSyntheticMedia: shouldApplyAiDisclosure,
         language: toBcp47(metadataLanguage),
         localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
@@ -191,7 +242,7 @@ export function UploadStep() {
       addToast({ type: 'error', title: '원본 영상 업로드 실패', message: msg })
       return null
     }
-  }, [isAuthenticated, originalVideoUrl, settingsTitle, settingsDescription, settingsTags, privacyStatus, selfDeclaredMadeForKids, containsSyntheticMedia, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage])
+  }, [isAuthenticated, originalVideoUrl, settingsTitle, editableDescription, settingsTags, privacyStatus, selfDeclaredMadeForKids, shouldApplyAiDisclosure, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage, applyDescriptionFooter])
 
   // ─── Audio → Studio helper ──────────────────────────────────────────
   const handleAudioToStudio = useCallback(async (langCode: string, targetVideoId?: string) => {
@@ -279,6 +330,9 @@ export function UploadStep() {
 
   // ─── Upload dubbed video to YouTube (newDubbedVideos mode) ──────────
   const handleYouTubeUpload = useCallback(async (langCode: string) => {
+    const existingUpload = useDubbingStore.getState().youtubeUploads[langCode]
+    if (isYouTubeUploadLocked(existingUpload)) return
+
     if (!isAuthenticated) {
       addToast({ type: 'error', title: 'YouTube에 먼저 로그인해주세요' })
       return
@@ -287,27 +341,48 @@ export function UploadStep() {
     const lang = getLanguageByCode(langCode)
     if (!lang) return
 
-    setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 0 } }))
+    setYouTubeUploadState(langCode, { status: 'uploading', progress: 0 })
+    let uploadReserved = false
 
     try {
+      if (dbJobId) {
+        const reservation = await dbMutationStrict<YouTubeUploadReservation>({
+          type: 'startJobLanguageYouTubeUpload',
+          payload: { jobId: dbJobId, langCode },
+        })
+        if (reservation.status === 'already_uploaded') {
+          setYouTubeUploadState(langCode, {
+            status: 'done',
+            progress: 100,
+            videoId: reservation.youtubeVideoId || undefined,
+          })
+          return
+        }
+        if (reservation.status === 'already_uploading') {
+          setYouTubeUploadState(langCode, { status: 'uploading', progress: 10 })
+          return
+        }
+        if (reservation.status !== 'reserved') {
+          throw new Error('YouTube 업로드 상태를 확인할 수 없습니다.')
+        }
+        uploadReserved = true
+      }
+
       const downloads = await fetchDownloads(langCode, 'dubbingVideo')
       const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
       if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
       const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
-      setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 20 } }))
-      const titlePrefix = uploadAsShort ? '#Shorts ' : ''
-
+      setYouTubeUploadState(langCode, { status: 'uploading', progress: 20 })
       // 번역된 제목·설명을 가져와 그 언어 영상의 메타로 사용한다.
       const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
-      const ytTitle = `${titlePrefix}${translated.title}`
-      const ytDescription = applyDescriptionFooter(translated.description)
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: editableDescription }
+      const ytTitle = translated.title
+      const ytDescription = applyDescriptionFooter(translated.description, langCode)
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
-        ...(uploadAsShort ? ['Shorts'] : []),
       ]))
       const result = await ytUploadVideo({
         videoUrl,
@@ -316,13 +391,13 @@ export function UploadStep() {
         tags: langTags,
         privacyStatus,
         selfDeclaredMadeForKids,
-        containsSyntheticMedia,
+        containsSyntheticMedia: shouldApplyAiDisclosure,
         language: langCode,
       })
-      setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 90 } }))
+      setYouTubeUploadState(langCode, { status: 'uploading', progress: 90 })
 
       // Upload SRT caption — use Perso's official translated SRT (audioScript target)
-      setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 92 } }))
+      setYouTubeUploadState(langCode, { status: 'uploading', progress: 92 })
       if (shouldUploadCaptions) {
         try {
           const pSeq = projectMap[langCode]
@@ -340,12 +415,15 @@ export function UploadStep() {
         } catch { /* caption upload is optional */ }
       }
 
-      setYtUploads((prev) => ({
-        ...prev,
-        [langCode]: { status: 'done', progress: 100, videoId: result.videoId },
-      }))
+      setYouTubeUploadState(langCode, { status: 'done', progress: 100, videoId: result.videoId })
 
       try {
+        if (dbJobId) {
+          await dbMutationStrict({
+            type: 'updateJobLanguageYouTube',
+            payload: { jobId: dbJobId, langCode, youtubeVideoId: result.videoId },
+          })
+        }
         if (userId) {
           await dbMutation({
             type: 'createYouTubeUpload',
@@ -355,15 +433,9 @@ export function UploadStep() {
               title: ytTitle,
               languageCode: langCode,
               privacyStatus,
-              isShort: uploadAsShort,
+              isShort,
             },
           })
-          if (dbJobId) {
-            await dbMutation({
-              type: 'updateJobLanguageYouTube',
-              payload: { jobId: dbJobId, langCode, youtubeVideoId: result.videoId },
-            })
-          }
         }
       } catch { /* DB save best-effort */ }
 
@@ -375,38 +447,64 @@ export function UploadStep() {
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : '업로드 실패'
-      setYtUploads((prev) => ({
-        ...prev,
-        [langCode]: { status: 'error', progress: 0, error: msg },
-      }))
+      if (uploadReserved && dbJobId) {
+        await dbMutation({
+          type: 'failJobLanguageYouTubeUpload',
+          payload: { jobId: dbJobId, langCode },
+        })
+      }
+      setYouTubeUploadState(langCode, { status: 'error', progress: 0, error: msg })
       addToast({ type: 'error', title: `${lang?.name} 업로드 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, isAuthenticated, settingsTitle, settingsDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, containsSyntheticMedia, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, isShort, isAuthenticated, settingsTitle, editableDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, shouldApplyAiDisclosure, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter, setYouTubeUploadState])
 
   // ─── Queue upload (background — survives tab close) ─────────────────
   const queueYouTubeUpload = useCallback(async (langCode: string) => {
+    const existingUpload = useDubbingStore.getState().youtubeUploads[langCode]
+    if (isYouTubeUploadLocked(existingUpload)) return
+
     if (!userId || !dbJobId) return
 
     const lang = getLanguageByCode(langCode)
     if (!lang) return
 
-    setYtUploads((prev) => ({ ...prev, [langCode]: { status: 'uploading', progress: 10 } }))
+    setYouTubeUploadState(langCode, { status: 'uploading', progress: 10 })
+    let uploadReserved = false
 
     try {
+      const reservation = await dbMutationStrict<YouTubeUploadReservation>({
+        type: 'startJobLanguageYouTubeUpload',
+        payload: { jobId: dbJobId, langCode },
+      })
+      if (reservation.status === 'already_uploaded') {
+        setYouTubeUploadState(langCode, {
+          status: 'done',
+          progress: 100,
+          videoId: reservation.youtubeVideoId || undefined,
+        })
+        return
+      }
+      if (reservation.status === 'already_uploading') {
+        setYouTubeUploadState(langCode, { status: 'uploading', progress: 10 })
+        return
+      }
+      if (reservation.status !== 'reserved') {
+        throw new Error('YouTube 업로드 상태를 확인할 수 없습니다.')
+      }
+      uploadReserved = true
+
       const downloads = await fetchDownloads(langCode, 'dubbingVideo')
       const rawVideoUrl = downloads?.videoFile?.videoDownloadLink
       if (!rawVideoUrl) throw new Error('더빙 영상 다운로드 링크를 찾을 수 없습니다')
       const videoUrl = rawVideoUrl.startsWith('http') ? rawVideoUrl : getPersoFileUrl(rawVideoUrl)
 
-      const titlePrefix = uploadAsShort ? '#Shorts ' : ''
       const allTranslations = await ensureTranslations()
       const baseTitle = settingsTitle?.trim() || videoMeta?.title || 'Dubbed Video'
-      const translated = allTranslations[langCode] ?? { title: baseTitle, description: settingsDescription || '' }
-      const ytTitle = `${titlePrefix}${translated.title}`
+      const translated = allTranslations[langCode] ?? { title: baseTitle, description: editableDescription }
+      const ytTitle = translated.title
       const langTags = Array.from(new Set([
         ...settingsTags,
         lang.name,
-        ...(uploadAsShort ? ['Shorts'] : []),
       ]))
       let srtContent: string | null = null
       if (shouldUploadCaptions) {
@@ -427,25 +525,22 @@ export function UploadStep() {
           langCode,
           videoUrl,
           title: ytTitle,
-          description: applyDescriptionFooter(translated.description),
+          description: applyDescriptionFooter(translated.description, langCode),
           tags: langTags,
           privacyStatus,
           language: langCode,
-          isShort: uploadAsShort,
+          isShort,
           uploadCaptions: shouldUploadCaptions,
           captionLanguage: toBcp47(langCode),
           // 빈 문자열로 두면 YouTube가 시청자 로케일에 맞춰 언어 이름 자동 표시.
           captionName: '',
           srtContent,
           selfDeclaredMadeForKids,
-          containsSyntheticMedia,
+          containsSyntheticMedia: shouldApplyAiDisclosure,
         },
       })
 
-      setYtUploads((prev) => ({
-        ...prev,
-        [langCode]: { status: 'done', progress: 100 },
-      }))
+      setYouTubeUploadState(langCode, { status: 'done', progress: 100 })
       addToast({
         type: 'success',
         title: `${lang.name} 업로드 예약됨`,
@@ -453,28 +548,33 @@ export function UploadStep() {
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : '큐 등록 실패'
-      setYtUploads((prev) => ({
-        ...prev,
-        [langCode]: { status: 'error', progress: 0, error: msg },
-      }))
+      if (uploadReserved) {
+        await dbMutation({
+          type: 'failJobLanguageYouTubeUpload',
+          payload: { jobId: dbJobId, langCode },
+        })
+      }
+      setYouTubeUploadState(langCode, { status: 'error', progress: 0, error: msg })
       addToast({ type: 'error', title: `${lang?.name} 큐 등록 실패`, message: msg })
     }
-  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, uploadAsShort, settingsTitle, settingsDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, containsSyntheticMedia, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter])
+  }, [fetchDownloads, videoMeta, addToast, userId, dbJobId, isShort, settingsTitle, editableDescription, settingsTags, privacyStatus, shouldUploadCaptions, selfDeclaredMadeForKids, shouldApplyAiDisclosure, projectMap, spaceSeq, ensureTranslations, applyDescriptionFooter, setYouTubeUploadState])
 
-  const completedLangs = selectedLanguages.filter((code) => {
+  const completedLangs = useMemo(() => selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
     return lp?.progressReason === 'COMPLETED' || lp?.progressReason === 'Completed'
-  })
+  }), [languageProgress, selectedLanguages])
 
-  const failedLangs = selectedLanguages.filter((code) => {
+  const failedLangs = useMemo(() => selectedLanguages.filter((code) => {
     const lp = languageProgress.find((p) => p.langCode === code)
     return lp?.progressReason === 'FAILED' || lp?.progressReason === 'Failed' || lp?.progressReason === 'CANCELED'
-  })
+  }), [languageProgress, selectedLanguages])
 
   const anyUploading = Object.values(ytUploads).some((s) => s.status === 'uploading')
+  const hasPendingYouTubeUploads = completedLangs.some((code) => !isYouTubeUploadLocked(ytUploads[code]))
+  const hasAutoUploadCandidates = completedLangs.some((code) => !ytUploads[code])
 
   const handleUploadAll = useCallback(async () => {
-    const pending = completedLangs.filter((code) => ytUploads[code]?.status !== 'done')
+    const pending = completedLangs.filter((code) => !isYouTubeUploadLocked(ytUploads[code]))
     const CONCURRENCY = 2
     for (let i = 0; i < pending.length; i += CONCURRENCY) {
       const batch = pending.slice(i, i + CONCURRENCY)
@@ -483,7 +583,7 @@ export function UploadStep() {
   }, [completedLangs, ytUploads, handleYouTubeUpload])
 
   const handleQueueAll = useCallback(async () => {
-    const pending = completedLangs.filter((code) => ytUploads[code]?.status !== 'done')
+    const pending = completedLangs.filter((code) => !isYouTubeUploadLocked(ytUploads[code]))
     for (const code of pending) {
       await queueYouTubeUpload(code)
     }
@@ -520,10 +620,17 @@ export function UploadStep() {
     }
   }, [projectMap, spaceSeq, addToast])
 
+  const uploadCaptionsWithMetadata = useCallback(async (targetVideoId: string, langs: string[]) => {
+    if (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'channel') {
+      await applyTagsToExistingVideo(targetVideoId)
+    }
+    await uploadCaptions(targetVideoId, langs)
+  }, [applyTagsToExistingVideo, deliverableMode, uploadCaptions, videoSource?.type])
+
   const handleUploadCaptionsToVideo = useCallback(async (targetVideoId: string) => {
     const pending = completedLangs.filter((code) => captionUploads[code] !== 'done')
-    await uploadCaptions(targetVideoId, pending)
-  }, [completedLangs, captionUploads, uploadCaptions])
+    await uploadCaptionsWithMetadata(targetVideoId, pending)
+  }, [completedLangs, captionUploads, uploadCaptionsWithMetadata])
 
   // ─── Auto-chain: originalWithMultiAudio ──────────────────────────────
   // 1. Upload original (if file upload) → 2. Auto-upload captions → 3. Extension for audio tracks
@@ -544,8 +651,12 @@ export function UploadStep() {
         targetVideoId = await uploadOriginalToYouTube()
       }
 
+      if (targetVideoId && videoSource?.type === 'channel') {
+        await applyTagsToExistingVideo(targetVideoId)
+      }
+
       if (targetVideoId && shouldUploadCaptions) {
-        await uploadCaptions(targetVideoId, completedLangs)
+        await uploadCaptionsWithMetadata(targetVideoId, completedLangs)
       }
     }
 
@@ -557,11 +668,10 @@ export function UploadStep() {
   useEffect(() => {
     if (deliverableMode !== 'newDubbedVideos') return
     if (!uploadReviewConfirmed) return
-    if (autoUpload && isAuthenticated && completedLangs.length > 0 && !autoUploadTriggered.current && !anyUploading) {
-      autoUploadTriggered.current = true
+    if (autoUpload && isAuthenticated && hasAutoUploadCandidates && !anyUploading) {
       handleUploadAll()
     }
-  }, [deliverableMode, autoUpload, isAuthenticated, uploadReviewConfirmed, completedLangs.length, anyUploading, handleUploadAll])
+  }, [deliverableMode, autoUpload, isAuthenticated, uploadReviewConfirmed, hasAutoUploadCandidates, anyUploading, handleUploadAll])
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -692,7 +802,7 @@ export function UploadStep() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => uploadCaptions(multiAudioVideoId, [code])}
+                          onClick={() => uploadCaptionsWithMetadata(multiAudioVideoId, [code])}
                           disabled={!isAuthenticated}
                         >
                           <Upload className="h-3.5 w-3.5" />
@@ -840,8 +950,6 @@ export function UploadStep() {
                 <p>
                   자동 업로드: <span className="font-medium text-surface-700 dark:text-surface-300">{autoUpload ? 'ON' : 'OFF'}</span>
                   {' · '}
-                  Shorts: <span className="font-medium text-surface-700 dark:text-surface-300">{uploadAsShort ? 'ON' : 'OFF'}</span>
-                  {' · '}
                   공개: <span className="font-medium text-surface-700 dark:text-surface-300">{privacyStatus === 'public' ? '공개' : privacyStatus === 'unlisted' ? '일부 공개' : '비공개'}</span>
                 </p>
                 <p>
@@ -849,10 +957,10 @@ export function UploadStep() {
                   {' · '}
                   아동용: <span className="font-medium text-surface-700 dark:text-surface-300">{selfDeclaredMadeForKids ? '예' : '아니오'}</span>
                   {' · '}
-                  AI 합성 공개: <span className="font-medium text-surface-700 dark:text-surface-300">{containsSyntheticMedia ? 'ON' : 'OFF'}</span>
+                  AI 합성 고지: <span className="font-medium text-surface-700 dark:text-surface-300">{shouldApplyAiDisclosure ? '설명에 추가' : '추가 안 함'}</span>
                 </p>
                 {attachOriginalLink && originalYouTubeUrl && (
-                  <p className="truncate">원본 링크 첨부: {originalYouTubeUrl}</p>
+                  <p className="break-words">원본 링크 첨부: {originalYouTubeUrl}</p>
                 )}
               </div>
 
@@ -900,7 +1008,7 @@ export function UploadStep() {
                             variant="outline"
                             size="sm"
                             onClick={() => handleYouTubeUpload(code)}
-                            disabled={anyUploading}
+                            disabled={anyUploading || isYouTubeUploadLocked(state)}
                           >
                             <Upload className="h-3.5 w-3.5" />
                             즉시
@@ -909,7 +1017,7 @@ export function UploadStep() {
                             variant="ghost"
                             size="sm"
                             onClick={() => queueYouTubeUpload(code)}
-                            disabled={anyUploading}
+                            disabled={anyUploading || isYouTubeUploadLocked(state)}
                           >
                             예약
                           </Button>
@@ -925,7 +1033,7 @@ export function UploadStep() {
                   <Button
                     className="flex-1"
                     onClick={handleUploadAll}
-                    disabled={anyUploading}
+                    disabled={anyUploading || !hasPendingYouTubeUploads}
                     loading={anyUploading}
                   >
                     <Upload className="h-4 w-4" />
@@ -935,7 +1043,7 @@ export function UploadStep() {
                     variant="secondary"
                     className="flex-1"
                     onClick={handleQueueAll}
-                    disabled={anyUploading}
+                    disabled={anyUploading || !hasPendingYouTubeUploads}
                   >
                     <Upload className="h-4 w-4" />
                     예약 (탭 닫아도 OK)

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -31,10 +31,13 @@ export function VideoInputStep() {
   const [uploadProgress, setUploadProgress] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const initialTab = searchParams.get('url') ? 'url' : 'upload'
+  const [activeTab, setActiveTab] = useState(initialTab)
 
-  const { data: channel, isLoading: channelLoading } = useChannelStats()
+  const channelTabActive = activeTab === 'channel'
+  const { data: channel, isLoading: channelLoading, error: channelError } = useChannelStats(channelTabActive)
   const isConnected = !!channel
-  const { data: myVideos = [], isLoading: myVideosLoading } = useMyVideos(50)
+  const { data: myVideos = [], isLoading: myVideosLoading, error: myVideosError } = useMyVideos(50, channelTabActive && isConnected)
   const [videoSearch, setVideoSearch] = useState('')
 
   const publicVideos = useMemo(
@@ -123,8 +126,11 @@ export function VideoInputStep() {
       </div>
 
       <Tabs
-        defaultValue={searchParams.get('url') ? 'url' : 'upload'}
-        onChange={() => setError(null)}
+        defaultValue={initialTab}
+        onChange={(value) => {
+          setError(null)
+          setActiveTab(value)
+        }}
       >
         <TabsList className="mx-auto w-fit">
           <TabsTrigger value="upload">
@@ -214,6 +220,13 @@ export function VideoInputStep() {
               <Loader2 className="mx-auto h-6 w-6 animate-spin text-surface-400" />
               <p className="mt-3 text-sm text-surface-500">채널 정보 불러오는 중...</p>
             </Card>
+          ) : channelError ? (
+            <Card className="py-12 text-center">
+              <Film className="mx-auto h-10 w-10 text-surface-400" />
+              <p className="mt-3 text-sm text-red-500">
+                {channelError instanceof Error ? channelError.message : 'YouTube 채널 정보를 불러오지 못했습니다.'}
+              </p>
+            </Card>
           ) : !isConnected ? (
             <Card className="py-12 text-center">
               <Film className="mx-auto h-10 w-10 text-surface-400" />
@@ -224,6 +237,13 @@ export function VideoInputStep() {
             <Card className="py-12 text-center">
               <Loader2 className="mx-auto h-6 w-6 animate-spin text-surface-400" />
               <p className="mt-3 text-sm text-surface-500">영상 목록 불러오는 중...</p>
+            </Card>
+          ) : myVideosError ? (
+            <Card className="py-12 text-center">
+              <Film className="mx-auto h-10 w-10 text-surface-400" />
+              <p className="mt-3 text-sm text-red-500">
+                {myVideosError instanceof Error ? myVideosError.message : 'YouTube 영상 목록을 불러오지 못했습니다.'}
+              </p>
             </Card>
           ) : myVideos.length === 0 ? (
             <Card className="py-12 text-center">

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -24,6 +24,8 @@ const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
 const POLL_BACKOFF = 1.5          // 매 폴링마다 1.5배씩 증가
 const POLL_FINALIZING = 2_000     // 100%인데 COMPLETED 아직 안 온 경우 빠르게 재확인
+const DEFAULT_SOURCE_LANGUAGE = 'auto'
+const DEFAULT_SPEAKER_COUNT = 1
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -289,9 +291,8 @@ export function usePersoFlow() {
       duration: 8000,
     })
 
-    const sourceLanguage = store.getState().sourceLanguage
     try {
-      const meta = await getExternalMetadata(spaceSeq!, url, sourceLanguage)
+      const meta = await getExternalMetadata(spaceSeq!, url, DEFAULT_SOURCE_LANGUAGE)
       store.getState().setVideoMeta({
         id: url,
         title: meta.originalName || (isYouTube ? 'YouTube Video' : 'External Video'),
@@ -303,7 +304,7 @@ export function usePersoFlow() {
         height: meta.height,
       })
 
-      const result = await uploadExternalVideo(spaceSeq!, url, sourceLanguage)
+      const result = await uploadExternalVideo(spaceSeq!, url, DEFAULT_SOURCE_LANGUAGE)
       store.getState().setMediaSeq(result.seq)
 
       addToast({ type: 'success', title: '영상 가져오기 완료' })
@@ -316,10 +317,11 @@ export function usePersoFlow() {
   }, [initSpace, addToast])
 
   const submitDubbing = useCallback(async () => {
-    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, sourceLanguage, numberOfSpeakers } = store.getState()
+    const { spaceSeq, mediaSeq, selectedLanguages, lipSyncEnabled, videoMeta } = store.getState()
     if (!spaceSeq || !mediaSeq) throw new Error('Missing space or media')
+    const targetLanguages = Array.from(new Set(selectedLanguages))
 
-    addToast({ type: 'info', title: 'Submitting dubbing job...', message: `${selectedLanguages.length} languages` })
+    addToast({ type: 'info', title: 'Submitting dubbing job...', message: `${targetLanguages.length} languages` })
 
     try {
       try {
@@ -328,37 +330,39 @@ export function usePersoFlow() {
         // Already initialized
       }
 
-      const pendingProjectMap = Object.fromEntries(selectedLanguages.map((lang) => [lang, 0]))
+      const pendingProjectMap = Object.fromEntries(targetLanguages.map((lang) => [lang, 0]))
       const dbJobId = await saveJobToDb(
         mediaSeq,
         spaceSeq,
-        selectedLanguages,
+        targetLanguages,
         pendingProjectMap,
         lipSyncEnabled,
-        sourceLanguage,
+        DEFAULT_SOURCE_LANGUAGE,
       )
       await dbMutationStrict({ type: 'reserveJobCredits', payload: { jobId: dbJobId } })
 
       const result = await submitTranslation(spaceSeq, {
         mediaSeq,
         isVideoProject: true,
-        sourceLanguageCode: sourceLanguage,
-        targetLanguageCodes: selectedLanguages,
-        numberOfSpeakers: Math.max(1, Math.min(10, numberOfSpeakers || 1)),
+        sourceLanguageCode: DEFAULT_SOURCE_LANGUAGE,
+        targetLanguageCodes: targetLanguages,
+        numberOfSpeakers: DEFAULT_SPEAKER_COUNT,
         withLipSync: lipSyncEnabled,
         preferredSpeedType: 'GREEN',
+        ttsModel: 'ELEVEN_V2',
+        title: videoMeta?.title?.trim() || `Dubtube project ${mediaSeq}`,
       })
 
       const projectIds = result.startGenerateProjectIdList || []
       const projectMap: Record<string, number> = {}
-      selectedLanguages.forEach((lang, i) => {
+      targetLanguages.forEach((lang, i) => {
         if (projectIds[i]) {
           projectMap[lang] = projectIds[i]
         }
       })
       store.getState().setProjectMap(projectMap)
 
-      const initialProgress: LanguageProgress[] = selectedLanguages.map((code) => ({
+      const initialProgress: LanguageProgress[] = targetLanguages.map((code) => ({
         langCode: code,
         projectSeq: projectMap[code] || 0,
         status: 'transcribing',
@@ -372,7 +376,7 @@ export function usePersoFlow() {
         type: 'updateJobLanguageProjects',
         payload: {
           jobId: dbJobId,
-          languages: selectedLanguages.map((code) => ({ code, projectSeq: projectMap[code] || 0 })),
+          languages: targetLanguages.map((code) => ({ code, projectSeq: projectMap[code] || 0 })),
         },
       })
 

--- a/src/features/dubbing/store/dubbingStore.test.ts
+++ b/src/features/dubbing/store/dubbingStore.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useDubbingStore } from './dubbingStore'
+
+describe('dubbingStore YouTube uploads', () => {
+  beforeEach(() => {
+    useDubbingStore.getState().reset()
+  })
+
+  it('keeps uploaded video ids until a new dubbing reset', () => {
+    useDubbingStore.getState().setYouTubeUploadState('en', {
+      status: 'done',
+      progress: 100,
+      videoId: 'yt-123',
+    })
+
+    expect(useDubbingStore.getState().youtubeUploads.en).toEqual({
+      status: 'done',
+      progress: 100,
+      videoId: 'yt-123',
+    })
+
+    useDubbingStore.getState().reset()
+
+    expect(useDubbingStore.getState().youtubeUploads).toEqual({})
+  })
+})

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -13,6 +13,7 @@ import type {
   UploadSettings,
   DeliverableMode,
   PrivacyStatus,
+  YouTubeUploadState,
 } from '../types/dubbing.types'
 
 // YouTube 설정 페이지의 기본값을 그때그때 가져온다.
@@ -36,8 +37,7 @@ const readDefaultLanguage = (): string => {
 }
 
 const buildDefaultUploadSettings = (): UploadSettings => ({
-  autoUpload: false,
-  uploadAsShort: false,
+  autoUpload: true,
   attachOriginalLink: true,
   title: '',
   description: '',
@@ -52,7 +52,6 @@ const buildDefaultUploadSettings = (): UploadSettings => ({
 
 const REVIEW_RESET_FIELDS: Array<keyof UploadSettings> = [
   'autoUpload',
-  'uploadAsShort',
   'attachOriginalLink',
   'title',
   'description',
@@ -114,6 +113,10 @@ interface DubbingState {
   setLanguageProgress: (progress: LanguageProgress[]) => void
   updateLanguageProgress: (langCode: string, update: Partial<LanguageProgress>) => void
 
+  // Step 7: YouTube upload state — persists across route navigation until reset.
+  youtubeUploads: Record<string, YouTubeUploadState>
+  setYouTubeUploadState: (langCode: string, state: YouTubeUploadState) => void
+
   // DB
   dbJobId: number | null
   setDbJobId: (id: number) => void
@@ -135,9 +138,6 @@ interface DubbingState {
   privacyOverridden: boolean
   /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
   metadataLanguageOverridden: boolean
-  /** Wizard 세션 내에서 사용자가 Shorts 토글을 직접 변경했는지 여부.
-   * true이면 videoMeta 갱신 시 자동 감지가 uploadAsShort를 덮어쓰지 않는다. */
-  uploadAsShortOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
@@ -167,6 +167,7 @@ const initialState = {
   isShort: false,
   segments: {} as Record<string, TranslationSegment[]>,
   projectMap: {} as Record<string, number>,
+  youtubeUploads: {} as Record<string, YouTubeUploadState>,
   dbJobId: null as number | null,
   jobStatus: 'idle' as JobStatus,
   languageProgress: [] as LanguageProgress[],
@@ -176,7 +177,6 @@ const initialState = {
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
   metadataLanguageOverridden: false,
-  uploadAsShortOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -248,15 +248,13 @@ export const useDubbingStore = create<DubbingState>((set) => ({
         lp.langCode === langCode ? { ...lp, ...update } : lp,
       ),
     })),
+  setYouTubeUploadState: (langCode, state) =>
+    set((s) => ({
+      youtubeUploads: { ...s.youtubeUploads, [langCode]: state },
+    })),
 
   setDbJobId: (id) => set({ dbJobId: id }),
-  setIsShort: (v) => set((s) => ({
-    isShort: v,
-    // 사용자가 토글을 직접 만진 적이 있으면 그 선택을 보존한다.
-    uploadSettings: s.uploadAsShortOverridden
-      ? s.uploadSettings
-      : { ...s.uploadSettings, uploadAsShort: v, uploadReviewConfirmed: false },
-  })),
+  setIsShort: (v) => set({ isShort: v }),
 
   setDeliverableMode: (mode) => set({ deliverableMode: mode }),
   setCopyrightAcknowledged: (v) => set({ copyrightAcknowledged: v }),
@@ -274,8 +272,6 @@ export const useDubbingStore = create<DubbingState>((set) => ({
         patch.privacyStatus !== undefined ? true : s.privacyOverridden,
       metadataLanguageOverridden:
         patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
-      uploadAsShortOverridden:
-        patch.uploadAsShort !== undefined ? true : s.uploadAsShortOverridden,
     }
   }),
 

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -6,7 +6,6 @@ export type PrivacyStatus = 'public' | 'unlisted' | 'private'
 
 export interface UploadSettings {
   autoUpload: boolean
-  uploadAsShort: boolean
   attachOriginalLink: boolean
   title: string
   description: string
@@ -67,6 +66,15 @@ export interface LanguageProgress {
   audioUrl?: string
   srtUrl?: string
   dubbingVideoUrl?: string
+}
+
+export type YouTubeUploadStatus = 'uploading' | 'done' | 'error'
+
+export interface YouTubeUploadState {
+  status: YouTubeUploadStatus
+  progress: number
+  videoId?: string
+  error?: string
 }
 
 export interface DubbingJob {

--- a/src/features/dubbing/utils/aiDisclosure.test.ts
+++ b/src/features/dubbing/utils/aiDisclosure.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendAiDisclosureFooter,
+  appendTextFooter,
+  getAiDisclosureText,
+  stripAiDisclosureFooter,
+} from './aiDisclosure'
+
+describe('aiDisclosure', () => {
+  it('returns localized disclosure text', () => {
+    expect(getAiDisclosureText('ko')).toBe('Dubtube에서 AI 보이스 클론으로 더빙되었습니다.')
+    expect(getAiDisclosureText('ja')).toBe('DubtubeでAI音声クローンにより吹き替えられました。')
+    expect(getAiDisclosureText('pt-BR')).toBe('Este video foi dublado pela Dubtube com um clone de voz de IA.')
+  })
+
+  it('falls back to English for unknown language codes', () => {
+    expect(getAiDisclosureText('unknown')).toBe('This video was dubbed by Dubtube using an AI voice clone.')
+  })
+
+  it('appends footers without changing the main description', () => {
+    expect(appendTextFooter('사용자 설명', '원본 영상: https://youtube.com/watch?v=abc')).toBe(
+      '사용자 설명\n\n원본 영상: https://youtube.com/watch?v=abc',
+    )
+  })
+
+  it('strips only known disclosure footer text', () => {
+    expect(stripAiDisclosureFooter('사용자 설명\n\nDubtube에서 AI 보이스 클론으로 더빙되었습니다.')).toBe('사용자 설명')
+    expect(stripAiDisclosureFooter('사용자 설명\n\n원본 영상에서 AI 보이스 클론으로 더빙되었습니다.')).toBe('사용자 설명')
+    expect(stripAiDisclosureFooter('사용자가 직접 작성한 설명')).toBe('사용자가 직접 작성한 설명')
+  })
+
+  it('preserves trailing spaces when no disclosure footer exists', () => {
+    expect(stripAiDisclosureFooter('사용자 설명 ')).toBe('사용자 설명 ')
+  })
+
+  it('does not append disclosure when disabled', () => {
+    expect(appendAiDisclosureFooter('사용자 설명', 'ko', false)).toBe('사용자 설명')
+  })
+
+  it('appends disclosure as a non-editable footer when enabled', () => {
+    expect(appendAiDisclosureFooter('사용자 설명', 'ko', true)).toBe(
+      '사용자 설명\n\nDubtube에서 AI 보이스 클론으로 더빙되었습니다.',
+    )
+  })
+})

--- a/src/features/dubbing/utils/aiDisclosure.ts
+++ b/src/features/dubbing/utils/aiDisclosure.ts
@@ -1,0 +1,87 @@
+const AI_DISCLOSURE_TEXT: Record<string, string> = {
+  en: 'This video was dubbed by Dubtube using an AI voice clone.',
+  ko: 'Dubtube에서 AI 보이스 클론으로 더빙되었습니다.',
+  ja: 'DubtubeでAI音声クローンにより吹き替えられました。',
+  zh: '本视频由 Dubtube 使用 AI 语音克隆配音。',
+  es: 'Este video fue doblado por Dubtube con un clon de voz de IA.',
+  pt: 'Este video foi dublado pela Dubtube com um clone de voz de IA.',
+  fr: 'Cette vidéo a été doublée par Dubtube avec un clone vocal IA.',
+  de: 'Dieses Video wurde von Dubtube mit einem KI-Stimmklon synchronisiert.',
+  hi: 'इस वीडियो को Dubtube ने एआई वॉइस क्लोन से डब किया है।',
+  id: 'Video ini didubbing oleh Dubtube dengan klon suara AI.',
+  vi: 'Video này được Dubtube lồng tiếng bằng bản sao giọng nói AI.',
+  th: 'วิดีโอนี้ได้รับการพากย์โดย Dubtube ด้วยเสียงโคลน AI',
+  ms: 'Video ini dialih suara oleh Dubtube menggunakan klon suara AI.',
+  fil: 'Ang video na ito ay dinub ng Dubtube gamit ang AI voice clone.',
+  ta: 'இந்த வீடியோ Dubtube மூலம் AI குரல் குளோனைக் கொண்டு டப் செய்யப்பட்டது.',
+  kk: 'Бұл видео Dubtube арқылы AI дауыс клонымен дубляждалды.',
+  it: 'Questo video è stato doppiato da Dubtube con un clone vocale IA.',
+  nl: 'Deze video is door Dubtube nagesynchroniseerd met een AI-stemkloon.',
+  ru: 'Это видео дублировано в Dubtube с помощью ИИ-клона голоса.',
+  uk: 'Це відео дубльовано в Dubtube за допомогою AI-клону голосу.',
+  pl: 'Ten film został zdubbingowany przez Dubtube z użyciem klonu głosu AI.',
+  cs: 'Toto video bylo nadabováno v Dubtube pomocí klonu hlasu AI.',
+  sk: 'Toto video bolo nadabované v Dubtube pomocou klonu hlasu AI.',
+  hu: 'Ezt a videót a Dubtube AI-hangklónnal szinkronizálta.',
+  ro: 'Acest videoclip a fost dublat de Dubtube cu o clonă vocală AI.',
+  bg: 'Този видеоклип е дублиран от Dubtube с AI клонинг на глас.',
+  hr: 'Ovaj je video Dubtube sinkronizirao pomoću AI klona glasa.',
+  el: 'Αυτό το βίντεο μεταγλωττίστηκε από το Dubtube με κλώνο φωνής AI.',
+  sv: 'Den här videon dubbades av Dubtube med en AI-röstklon.',
+  no: 'Denne videoen ble dubbet av Dubtube med en AI-stemmeklon.',
+  da: 'Denne video er dubbet af Dubtube med en AI-stemmeklon.',
+  fi: 'Tämä video on dubattu Dubtubella AI-äänikloonilla.',
+  tr: 'Bu video Dubtube tarafından bir yapay zeka ses klonuyla dublajlandı.',
+  ar: 'تمت دبلجة هذا الفيديو بواسطة Dubtube باستخدام نسخة صوتية بالذكاء الاصطناعي.',
+}
+
+const LEGACY_DISCLOSURE_TEXT = [
+  '원본 영상에서 AI 보이스 클론으로 더빙되었습니다.',
+]
+
+function normalizeLanguageCode(languageCode: string): string {
+  return languageCode.toLowerCase().split('-')[0]
+}
+
+export function getAiDisclosureText(languageCode: string): string {
+  const code = normalizeLanguageCode(languageCode)
+  return AI_DISCLOSURE_TEXT[code] ?? AI_DISCLOSURE_TEXT.en
+}
+
+export function appendTextFooter(description: string, footer: string): string {
+  const cleanDescription = description.trimEnd()
+  const cleanFooter = footer.trim()
+  if (!cleanFooter) return cleanDescription
+  return cleanDescription ? `${cleanDescription}\n\n${cleanFooter}` : cleanFooter
+}
+
+export function stripAiDisclosureFooter(description: string): string {
+  const knownFooters = [
+    ...Object.values(AI_DISCLOSURE_TEXT),
+    ...LEGACY_DISCLOSURE_TEXT,
+  ]
+  let next = description
+
+  for (const footer of knownFooters) {
+    const cleanFooter = footer.trim()
+    const trimmedEnd = next.trimEnd()
+    if (trimmedEnd === cleanFooter) return ''
+
+    const suffix = `\n\n${cleanFooter}`
+    if (trimmedEnd.endsWith(suffix)) {
+      next = trimmedEnd.slice(0, -suffix.length)
+    }
+  }
+
+  return next
+}
+
+export function appendAiDisclosureFooter(
+  description: string,
+  languageCode: string,
+  enabled: boolean,
+): string {
+  const baseDescription = stripAiDisclosureFooter(description)
+  if (!enabled) return baseDescription
+  return appendTextFooter(baseDescription, getAiDisclosureText(languageCode))
+}

--- a/src/features/landing/FeatureShowcase.tsx
+++ b/src/features/landing/FeatureShowcase.tsx
@@ -1,4 +1,4 @@
-import { Mic, Subtitles, Clock, BarChart3, Wand2 } from 'lucide-react'
+import { Mic, Subtitles, Clock, BarChart3 } from 'lucide-react'
 
 const features = [
   {
@@ -11,11 +11,12 @@ const features = [
     title: '번역 에디터',
     description: '문장 단위로 번역을 검토하고 수정할 수 있습니다. 브랜드명, 고유명사 보호 기능.',
   },
-  {
-    icon: Wand2,
-    title: '립싱크',
-    description: '선택적 AI 립싱크로 실사 영상에 최적화. 입 모양이 더빙 오디오와 완벽하게 맞습니다.',
-  },
+  // Lip sync feature is temporarily hidden from the landing page.
+  // {
+  //   icon: Wand2,
+  //   title: '립싱크',
+  //   description: '선택적 AI 립싱크로 실사 영상에 최적화. 입 모양이 더빙 오디오와 완벽하게 맞습니다.',
+  // },
   {
     icon: Clock,
     title: '롱폼 지원',

--- a/src/features/landing/PricingSection.tsx
+++ b/src/features/landing/PricingSection.tsx
@@ -9,7 +9,7 @@ const INCLUDED_FEATURES = [
   `${SUPPORTED_LANGUAGE_COUNT}개 언어 지원`,
   '1080p 출력',
   '워터마크 없음',
-  '립싱크',
+  // '립싱크',
   'YouTube 자동 업로드',
   '크레딧 만료 없음',
 ]

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -40,9 +40,9 @@ export function MetadataLocalizationTool() {
   const addToast = useNotificationStore((state) => state.addToast)
   const { metadataTargetPreset, setMetadataTargetPreset } = useI18nStore()
   const { defaultLanguage } = useYouTubeSettingsStore()
-  const { data: videos = [], isLoading: loadingVideos } = useMyVideos(50)
 
   const [mode, setMode] = useState<Mode>('existing')
+  const { data: videos = [], isLoading: loadingVideos, error: videosError } = useMyVideos(50, mode === 'existing')
   const [videoId, setVideoId] = useState('')
   const [videoFile, setVideoFile] = useState<File | null>(null)
   /** 내 영상 모드에서 "불러오기"가 한 번이라도 성공했는지 — 하단 번역 카드 노출 게이트. */
@@ -328,6 +328,11 @@ export function MetadataLocalizationTool() {
                   })),
                 ]}
               />
+              {videosError && (
+                <p className="text-sm text-red-500">
+                  {videosError instanceof Error ? videosError.message : 'YouTube 영상 목록을 불러오지 못했습니다.'}
+                </p>
+              )}
             </div>
             <div className="flex items-end">
               <Button

--- a/src/hooks/useYouTubeData.ts
+++ b/src/hooks/useYouTubeData.ts
@@ -11,23 +11,23 @@ async function fetchJson<T>(url: string): Promise<T> {
   return json.data as T
 }
 
-export function useChannelStats() {
+export function useChannelStats(enabled = true) {
   const user = useAuthStore((s) => s.user)
   return useQuery<ChannelStats | null>({
     queryKey: ['channel-stats', user?.uid],
     queryFn: () => fetchJson<ChannelStats | null>('/api/youtube/stats?channel=true'),
-    enabled: !!user,
+    enabled: !!user && enabled,
     staleTime: 5 * 60_000,
     retry: false,
   })
 }
 
-export function useMyVideos(maxResults = 10) {
+export function useMyVideos(maxResults = 10, enabled = true) {
   const user = useAuthStore((s) => s.user)
   return useQuery<MyVideoItem[]>({
     queryKey: ['my-videos', user?.uid, maxResults],
     queryFn: () => fetchJson<MyVideoItem[]>(`/api/youtube/videos?maxResults=${maxResults}`),
-    enabled: !!user,
+    enabled: !!user && enabled,
     staleTime: 2 * 60_000,
     retry: false,
   })

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -30,6 +30,7 @@ import {
   ytFetchVideoStats,
   ytFetchChannelStats,
   ytFetchMyVideos,
+  ytUpdateVideoLocalizations,
 } from './api-client'
 
 function okResponse<T>(data: T) {
@@ -63,6 +64,7 @@ describe('getPersoFileUrl', () => {
 
   it('prepends base URL for relative path with leading slash', () => {
     const result = getPersoFileUrl('/files/video.mp4')
+    expect(result).toContain('https://portal-media.perso.ai')
     expect(result).toContain('/files/video.mp4')
   })
 
@@ -220,11 +222,18 @@ describe('Perso mutation endpoints', () => {
     expect(mockFetch.mock.calls[0][1].method).toBe('POST')
   })
 
-  it('getExternalMetadata uses default lang ko', async () => {
+  it('getExternalMetadata omits lang by default', async () => {
     mockFetch.mockResolvedValueOnce(okResponse({ title: 'T' }))
     await getExternalMetadata(1, 'https://youtube.com/watch?v=abc')
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-    expect(body.lang).toBe('ko')
+    expect(body.lang).toBeUndefined()
+  })
+
+  it('getExternalMetadata omits lang when source is auto', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ title: 'T' }))
+    await getExternalMetadata(1, 'https://youtube.com/watch?v=abc', 'auto')
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.lang).toBeUndefined()
   })
 
   it('uploadExternalVideo puts to external/upload', async () => {
@@ -268,11 +277,12 @@ describe('Perso mutation endpoints', () => {
     expect(mockFetch.mock.calls[0][0]).toContain('sentenceSeq=20')
   })
 
-  it('regenerateSentenceAudio patches with params', async () => {
+  it('regenerateSentenceAudio patches with params and targetText', async () => {
     mockFetch.mockResolvedValueOnce(okResponse(null))
-    await regenerateSentenceAudio(10, 30)
+    await regenerateSentenceAudio(10, 30, 'translated')
     expect(mockFetch.mock.calls[0][1].method).toBe('PATCH')
     expect(mockFetch.mock.calls[0][0]).toContain('audioSentenceSeq=30')
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({ targetText: 'translated' })
   })
 
   it('requestLipSync posts with params', async () => {
@@ -345,6 +355,26 @@ describe('ytUploadCaption', () => {
   })
 })
 
+describe('ytUpdateVideoLocalizations', () => {
+  it('sends tags to metadata update API', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'v1', tags: ['a'] }))
+    await ytUpdateVideoLocalizations({
+      videoId: 'v1',
+      sourceLang: 'ko',
+      title: 'Title',
+      description: 'Description',
+      tags: ['a'],
+      localizations: {},
+    })
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/metadata')
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body as string)).toMatchObject({
+      videoId: 'v1',
+      tags: ['a'],
+    })
+  })
+})
+
 // ── uploadFileToBlob (XHR) ─────────────────────────────────
 
 describe('uploadFileToBlob', () => {
@@ -372,7 +402,7 @@ describe('uploadFileToBlob', () => {
     const xhr = xhrInstances[0]
     expect(xhr.open).toHaveBeenCalledWith('PUT', 'https://blob.example/sas')
     expect(xhr.setRequestHeader).toHaveBeenCalledWith('x-ms-blob-type', 'BlockBlob')
-    expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'video/mp4')
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream')
 
     xhr.status = 200
     ;(xhr.onload as () => void)()

--- a/src/lib/api-client/perso.ts
+++ b/src/lib/api-client/perso.ts
@@ -17,6 +17,15 @@ import { getJson, sendJson } from './shared'
 
 const PERSO = '/api/perso'
 
+function withExternalLang(
+  body: { spaceSeq: number; url: string },
+  lang?: string,
+) {
+  const normalizedLang = lang?.trim()
+  if (!normalizedLang || normalizedLang === 'auto') return body
+  return { ...body, lang: normalizedLang }
+}
+
 // ─── Spaces & Languages ───────────────────────────────────────
 
 export function getSpaces() {
@@ -32,21 +41,17 @@ export function getLanguages() {
 export function getExternalMetadata(
   spaceSeq: number,
   url: string,
-  lang = 'ko',
+  lang?: string,
 ): Promise<ExternalMetadataResponse> {
-  return sendJson(`${PERSO}/external/metadata`, 'POST', {
-    spaceSeq,
-    url,
-    lang,
-  })
+  return sendJson(`${PERSO}/external/metadata`, 'POST', withExternalLang({ spaceSeq, url }, lang))
 }
 
 export function uploadExternalVideo(
   spaceSeq: number,
   url: string,
-  lang = 'ko',
+  lang?: string,
 ): Promise<UploadVideoResponse> {
-  return sendJson(`${PERSO}/external/upload`, 'PUT', { spaceSeq, url, lang })
+  return sendJson(`${PERSO}/external/upload`, 'PUT', withExternalLang({ spaceSeq, url }, lang))
 }
 
 // ─── Direct file upload (SAS → Blob → register) ──────────────
@@ -65,10 +70,7 @@ export async function uploadFileToBlob(
     const xhr = new XMLHttpRequest()
     xhr.open('PUT', sasUrl)
     xhr.setRequestHeader('x-ms-blob-type', 'BlockBlob')
-    xhr.setRequestHeader(
-      'Content-Type',
-      file.type || 'application/octet-stream',
-    )
+    xhr.setRequestHeader('Content-Type', 'application/octet-stream')
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable && onProgress) {
         onProgress(Math.round((e.loaded / e.total) * 100))
@@ -185,10 +187,12 @@ export function updateSentenceTranslation(
 export function regenerateSentenceAudio(
   projectSeq: number,
   audioSentenceSeq: number,
+  targetText: string,
 ) {
   return sendJson<unknown>(
     `${PERSO}/script/regenerate?projectSeq=${projectSeq}&audioSentenceSeq=${audioSentenceSeq}`,
     'PATCH',
+    { targetText },
   )
 }
 
@@ -241,7 +245,7 @@ export async function getTranslatedSrt(
 // ─── Helper: resolve Perso file path to full URL ──────────────
 
 const PERSO_FILE_BASE =
-  process.env.NEXT_PUBLIC_PERSO_FILE_BASE_URL || 'https://perso.ai'
+  process.env.NEXT_PUBLIC_PERSO_FILE_BASE_URL || 'https://portal-media.perso.ai'
 
 export function getPersoFileUrl(path: string): string {
   if (!path) return ''

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -101,6 +101,7 @@ export async function ytUpdateVideoLocalizations(params: {
   sourceLang: string
   title: string
   description: string
+  tags?: string[]
   localizations: Record<string, YouTubeLocalization>
 }): Promise<YouTubeVideoMetadata> {
   const res = await fetch(`${YT}/metadata`, {

--- a/src/lib/auth/token-refresh.test.ts
+++ b/src/lib/auth/token-refresh.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/env', () => ({
   })),
   getClientEnv: vi.fn(() => ({
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: 'client-id',
-    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://perso.ai',
+    NEXT_PUBLIC_PERSO_FILE_BASE_URL: 'https://portal-media.perso.ai',
   })),
 }))
 

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -40,6 +40,8 @@ export {
 
 export {
   createYouTubeUpload,
+  startJobLanguageYouTubeUpload,
+  failJobLanguageYouTubeUpload,
   updateYouTubeStats,
   updateJobLanguageYouTube,
 } from './youtube'

--- a/src/lib/db/queries/jobs.test.ts
+++ b/src/lib/db/queries/jobs.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExecute = vi.fn()
+const mockBatch = vi.fn()
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({
+    execute: mockExecute,
+    batch: mockBatch,
+  })),
+}))
+
+import {
+  createDubbingJobWithLanguages,
+  updateJobLanguageProjects,
+} from './jobs'
+
+const job = {
+  userId: 'user1',
+  videoTitle: 'video',
+  videoDurationMs: 1000,
+  videoThumbnail: '',
+  sourceLanguage: 'auto',
+  mediaSeq: 1,
+  spaceSeq: 2,
+  lipSyncEnabled: false,
+  isShort: false,
+}
+
+describe('job queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates all language rows with the explicit dubbing job id', async () => {
+    mockExecute.mockResolvedValueOnce({ lastInsertRowid: 35 })
+    mockBatch.mockResolvedValueOnce([])
+
+    const jobId = await createDubbingJobWithLanguages(job, [
+      { code: 'en', projectSeq: 0 },
+      { code: 'ja', projectSeq: 0 },
+    ])
+
+    expect(jobId).toBe(35)
+    expect(mockBatch).toHaveBeenCalledWith([
+      expect.objectContaining({ args: [35, 'en', 0] }),
+      expect.objectContaining({ args: [35, 'ja', 0] }),
+    ])
+    const languageSql = mockBatch.mock.calls[0][0].map((q: { sql: string }) => q.sql).join('\n')
+    expect(languageSql).not.toContain('last_insert_rowid')
+  })
+
+  it('updates existing project rows and inserts missing language rows', async () => {
+    mockExecute
+      .mockResolvedValueOnce({ rows: [{ id: 10 }] })
+      .mockResolvedValueOnce({ rowsAffected: 1 })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ lastInsertRowid: 11 })
+
+    await updateJobLanguageProjects(35, [
+      { code: 'en', projectSeq: 347162 },
+      { code: 'ja', projectSeq: 347163 },
+    ])
+
+    expect(mockExecute).toHaveBeenNthCalledWith(2, {
+      sql: 'UPDATE job_languages SET project_seq = ? WHERE id = ?',
+      args: [347162, 10],
+    })
+    expect(mockExecute).toHaveBeenNthCalledWith(4, {
+      sql: expect.stringContaining('INSERT INTO job_languages'),
+      args: [35, 'ja', 347163],
+    })
+  })
+})

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -50,23 +50,24 @@ export async function createDubbingJobWithLanguages(
   languages: { code: string; projectSeq: number }[],
 ): Promise<number> {
   const db = getDb()
-  const jobArgs = [
-    job.userId, job.videoTitle, job.videoDurationMs, job.videoThumbnail,
-    job.sourceLanguage, job.mediaSeq, job.spaceSeq,
-    job.lipSyncEnabled ? 1 : 0, job.isShort ? 1 : 0,
-  ]
-  const results = await db.batch([
-    {
-      sql: `INSERT INTO dubbing_jobs (user_id, video_title, video_duration_ms, video_thumbnail, source_language, media_seq, space_seq, lip_sync_enabled, is_short, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'processing')`,
-      args: jobArgs,
-    },
-    ...languages.map((lang) => ({
-      sql: 'INSERT INTO job_languages (job_id, language_code, project_seq) VALUES (last_insert_rowid(), ?, ?)',
-      args: [lang.code, lang.projectSeq],
-    })),
-  ])
-  return Number(results[0].lastInsertRowid)
+  const result = await db.execute({
+    sql: `INSERT INTO dubbing_jobs (user_id, video_title, video_duration_ms, video_thumbnail, source_language, media_seq, space_seq, lip_sync_enabled, is_short, status)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'processing')`,
+    args: [
+      job.userId,
+      job.videoTitle,
+      job.videoDurationMs,
+      job.videoThumbnail,
+      job.sourceLanguage,
+      job.mediaSeq,
+      job.spaceSeq,
+      job.lipSyncEnabled ? 1 : 0,
+      job.isShort ? 1 : 0,
+    ],
+  })
+  const jobId = Number(result.lastInsertRowid)
+  await createJobLanguages(jobId, languages)
+  return jobId
 }
 
 export async function updateJobLanguageProjects(
@@ -75,12 +76,25 @@ export async function updateJobLanguageProjects(
 ) {
   if (languages.length === 0) return
   const db = getDb()
-  await db.batch(
-    languages.map((lang) => ({
-      sql: 'UPDATE job_languages SET project_seq = ? WHERE job_id = ? AND language_code = ?',
-      args: [lang.projectSeq, jobId, lang.code],
-    })),
-  )
+  for (const lang of languages) {
+    const existing = await db.execute({
+      sql: 'SELECT id FROM job_languages WHERE job_id = ? AND language_code = ? ORDER BY id LIMIT 1',
+      args: [jobId, lang.code],
+    })
+    const id = existing.rows[0]?.id
+    if (id !== undefined && id !== null) {
+      await db.execute({
+        sql: 'UPDATE job_languages SET project_seq = ? WHERE id = ?',
+        args: [lang.projectSeq, id],
+      })
+    } else {
+      await db.execute({
+        sql: `INSERT INTO job_languages (job_id, language_code, project_seq, status, progress_reason)
+              VALUES (?, ?, ?, 'pending', 'PENDING')`,
+        args: [jobId, lang.code, lang.projectSeq],
+      })
+    }
+  }
 }
 
 export async function updateJobLanguageProgress(

--- a/src/lib/db/queries/youtube.test.ts
+++ b/src/lib/db/queries/youtube.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExecute = vi.fn()
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({
+    execute: mockExecute,
+  })),
+}))
+
+import {
+  failJobLanguageYouTubeUpload,
+  startJobLanguageYouTubeUpload,
+} from './youtube'
+
+describe('youtube db queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reserves a language upload before the YouTube request starts', async () => {
+    mockExecute
+      .mockResolvedValueOnce({ rows: [{ youtube_video_id: null, youtube_upload_status: null }] })
+      .mockResolvedValueOnce({ rowsAffected: 1 })
+
+    await expect(startJobLanguageYouTubeUpload(35, 'en')).resolves.toEqual({
+      status: 'reserved',
+    })
+    expect(mockExecute).toHaveBeenNthCalledWith(2, {
+      sql: expect.stringContaining("youtube_upload_status = 'uploading'"),
+      args: [35, 'en'],
+    })
+  })
+
+  it('returns existing video id instead of reserving again', async () => {
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ youtube_video_id: 'yt-123', youtube_upload_status: 'uploaded' }],
+    })
+
+    await expect(startJobLanguageYouTubeUpload(35, 'en')).resolves.toEqual({
+      status: 'already_uploaded',
+      youtubeVideoId: 'yt-123',
+    })
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks when another upload is already in progress', async () => {
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ youtube_video_id: null, youtube_upload_status: 'uploading' }],
+    })
+
+    await expect(startJobLanguageYouTubeUpload(35, 'en')).resolves.toEqual({
+      status: 'already_uploading',
+    })
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks a reserved upload as failed so the user can retry', async () => {
+    mockExecute.mockResolvedValueOnce({ rowsAffected: 1 })
+
+    await failJobLanguageYouTubeUpload(35, 'en')
+
+    expect(mockExecute).toHaveBeenCalledWith({
+      sql: expect.stringContaining("youtube_upload_status = 'failed'"),
+      args: [35, 'en'],
+    })
+  })
+})

--- a/src/lib/db/queries/youtube.ts
+++ b/src/lib/db/queries/youtube.ts
@@ -2,6 +2,11 @@ import 'server-only'
 
 import { getDb } from '@/lib/db/client'
 
+export interface JobLanguageYouTubeUploadReservation {
+  status: 'reserved' | 'already_uploaded' | 'already_uploading' | 'not_found'
+  youtubeVideoId?: string | null
+}
+
 export async function createYouTubeUpload(upload: {
   userId: string
   jobLanguageId?: number
@@ -26,6 +31,66 @@ export async function createYouTubeUpload(upload: {
     ],
   })
   return Number(result.lastInsertRowid)
+}
+
+export async function startJobLanguageYouTubeUpload(
+  jobId: number,
+  langCode: string,
+): Promise<JobLanguageYouTubeUploadReservation> {
+  const db = getDb()
+  const current = await db.execute({
+    sql: `SELECT youtube_video_id, youtube_upload_status
+          FROM job_languages
+          WHERE job_id = ? AND language_code = ?
+          LIMIT 1`,
+    args: [jobId, langCode],
+  })
+  const row = current.rows[0]
+  if (!row) return { status: 'not_found' }
+
+  const youtubeVideoId = row.youtube_video_id ? String(row.youtube_video_id) : null
+  if (youtubeVideoId) return { status: 'already_uploaded', youtubeVideoId }
+  if (row.youtube_upload_status === 'uploading') {
+    return { status: 'already_uploading' }
+  }
+
+  const reserved = await db.execute({
+    sql: `UPDATE job_languages
+          SET youtube_upload_status = 'uploading', updated_at = datetime('now')
+          WHERE job_id = ? AND language_code = ?
+            AND youtube_video_id IS NULL
+            AND COALESCE(youtube_upload_status, '') != 'uploading'`,
+    args: [jobId, langCode],
+  })
+  if (Number(reserved.rowsAffected ?? 0) > 0) {
+    return { status: 'reserved' }
+  }
+
+  const latest = await db.execute({
+    sql: `SELECT youtube_video_id, youtube_upload_status
+          FROM job_languages
+          WHERE job_id = ? AND language_code = ?
+          LIMIT 1`,
+    args: [jobId, langCode],
+  })
+  const latestRow = latest.rows[0]
+  const latestVideoId = latestRow?.youtube_video_id ? String(latestRow.youtube_video_id) : null
+  if (latestVideoId) return { status: 'already_uploaded', youtubeVideoId: latestVideoId }
+  if (latestRow?.youtube_upload_status === 'uploading') return { status: 'already_uploading' }
+  return { status: 'not_found' }
+}
+
+export async function failJobLanguageYouTubeUpload(
+  jobId: number,
+  langCode: string,
+) {
+  const db = getDb()
+  await db.execute({
+    sql: `UPDATE job_languages
+          SET youtube_upload_status = 'failed', updated_at = datetime('now')
+          WHERE job_id = ? AND language_code = ? AND youtube_video_id IS NULL`,
+    args: [jobId, langCode],
+  })
 }
 
 export async function updateYouTubeStats(

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -37,7 +37,7 @@ const clientSchema = z.object({
   NEXT_PUBLIC_PERSO_FILE_BASE_URL: z
     .string()
     .url()
-    .default("https://perso.ai"),
+    .default("https://portal-media.perso.ai"),
   NEXT_PUBLIC_GOOGLE_CLIENT_ID: z
     .string()
     .min(1, "NEXT_PUBLIC_GOOGLE_CLIENT_ID is required"),

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -46,11 +46,12 @@ export interface MediaValidateRequest {
   spaceSeq: number
   durationMs: number
   originalName: string
-  mediaType: string
+  mediaType: 'video' | 'audio'
   extension: string
-  size: number
-  width: number
-  height: number
+  size?: number
+  width?: number
+  height?: number
+  thumbnailFilePath?: string | null
 }
 
 export interface TranslateRequest {
@@ -63,6 +64,8 @@ export interface TranslateRequest {
   preferredSpeedType: 'GREEN' | 'RED'
   customDictionaryBlobPath?: string
   srtBlobPath?: string
+  ttsModel?: 'ELEVEN_V2' | 'ELEVEN_V3'
+  title?: string
 }
 
 export interface TranslateResponse {
@@ -144,11 +147,17 @@ export type DownloadTarget =
   | 'lipSyncVideo'
   | 'originalSubtitle'
   | 'translatedSubtitle'
+  | 'originalVoiceAudio'
   /** Perso가 생성한 SRT(원본/번역)와 부가 산출물 링크를 묶어 반환한다. */
   | 'audioScript'
   | 'voiceAudio'
   | 'backgroundAudio'
+  | 'voicewithBackgroundAudio'
+  | 'translatedAudio'
   | 'all'
+  | 'originalVoiceSpeakers'
+  | 'speakerSegmentExcel'
+  | 'speakerSegmentWithTranslationExcel'
 
 export interface ScriptSentence {
   sentenceSeq: number

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -94,6 +94,22 @@ const updateJobLanguageYouTubeSchema = z.object({
   }),
 })
 
+const startJobLanguageYouTubeUploadSchema = z.object({
+  type: z.literal('startJobLanguageYouTubeUpload'),
+  payload: z.object({
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+  }),
+})
+
+const failJobLanguageYouTubeUploadSchema = z.object({
+  type: z.literal('failJobLanguageYouTubeUpload'),
+  payload: z.object({
+    jobId: z.number().int(),
+    langCode: z.string().min(1),
+  }),
+})
+
 const deductUserMinutesSchema = z.object({
   type: z.literal('deductUserMinutes'),
   payload: z.object({
@@ -179,6 +195,8 @@ export const mutationActionSchema = z.discriminatedUnion('type', [
   updateJobStatusSchema,
   createYouTubeUploadSchema,
   updateJobLanguageYouTubeSchema,
+  startJobLanguageYouTubeUploadSchema,
+  failJobLanguageYouTubeUploadSchema,
   deductUserMinutesSchema,
   reserveJobCreditsSchema,
   releaseJobCreditsSchema,
@@ -224,6 +242,10 @@ export function getJobIdFromAction(action: MutationAction): number | null {
     case 'updateJobStatus':
       return action.payload.jobId
     case 'updateJobLanguageYouTube':
+      return action.payload.jobId
+    case 'startJobLanguageYouTubeUpload':
+      return action.payload.jobId
+    case 'failJobLanguageYouTubeUpload':
       return action.payload.jobId
     case 'deleteDubbingJob':
       return action.payload.jobId

--- a/src/lib/validators/perso.test.ts
+++ b/src/lib/validators/perso.test.ts
@@ -6,6 +6,7 @@ import {
   mediaValidateBodySchema,
   translateBodySchema,
   scriptPatchBodySchema,
+  generateAudioBodySchema,
   downloadTargetSchema,
 } from './perso'
 
@@ -61,7 +62,7 @@ describe('uploadRegisterBodySchema', () => {
 describe('mediaValidateBodySchema', () => {
   const valid = {
     spaceSeq: 1, durationMs: 5000, originalName: 'test.mp4',
-    mediaType: 'video', extension: 'mp4', size: 1000, width: 1920, height: 1080,
+    mediaType: 'video' as const, extension: 'mp4', size: 1000, width: 1920, height: 1080,
   }
   it('accepts valid body', () => {
     expect(mediaValidateBodySchema.safeParse(valid).success).toBe(true)
@@ -74,6 +75,15 @@ describe('mediaValidateBodySchema', () => {
   it('rejects negative size', () => {
     expect(mediaValidateBodySchema.safeParse({ ...valid, size: -1 }).success).toBe(false)
   })
+  it('accepts audio without dimensions', () => {
+    expect(mediaValidateBodySchema.safeParse({
+      spaceSeq: 1,
+      durationMs: 5000,
+      originalName: 'voice.mp3',
+      mediaType: 'audio',
+      extension: '.mp3',
+    }).success).toBe(true)
+  })
 })
 
 describe('translateBodySchema', () => {
@@ -85,13 +95,25 @@ describe('translateBodySchema', () => {
     expect(translateBodySchema.safeParse(valid).success).toBe(true)
   })
   it('accepts optional fields', () => {
-    expect(translateBodySchema.safeParse({ ...valid, withLipSync: true, srtBlobPath: '/p' }).success).toBe(true)
+    expect(translateBodySchema.safeParse({
+      ...valid,
+      withLipSync: true,
+      srtBlobPath: '/p',
+      ttsModel: 'ELEVEN_V2',
+      title: 'Project title',
+    }).success).toBe(true)
+  })
+  it('rejects empty title when present', () => {
+    expect(translateBodySchema.safeParse({ ...valid, title: '' }).success).toBe(false)
   })
   it('rejects empty targetLanguageCodes', () => {
     expect(translateBodySchema.safeParse({ ...valid, targetLanguageCodes: [] }).success).toBe(false)
   })
   it('rejects invalid preferredSpeedType', () => {
     expect(translateBodySchema.safeParse({ ...valid, preferredSpeedType: 'BLUE' }).success).toBe(false)
+  })
+  it('rejects invalid ttsModel', () => {
+    expect(translateBodySchema.safeParse({ ...valid, ttsModel: 'OTHER' }).success).toBe(false)
   })
 })
 
@@ -107,10 +129,22 @@ describe('scriptPatchBodySchema', () => {
   })
 })
 
+describe('generateAudioBodySchema', () => {
+  it('accepts targetText', () => {
+    expect(generateAudioBodySchema.safeParse({ targetText: 'hello' }).success).toBe(true)
+  })
+  it('rejects empty targetText', () => {
+    expect(generateAudioBodySchema.safeParse({ targetText: '' }).success).toBe(false)
+  })
+})
+
 describe('downloadTargetSchema', () => {
   it.each([
     'video', 'dubbingVideo', 'lipSyncVideo', 'originalSubtitle',
-    'translatedSubtitle', 'voiceAudio', 'backgroundAudio', 'all',
+    'translatedSubtitle', 'originalVoiceAudio', 'voiceAudio',
+    'backgroundAudio', 'voicewithBackgroundAudio', 'translatedAudio',
+    'all', 'originalVoiceSpeakers', 'speakerSegmentExcel',
+    'speakerSegmentWithTranslationExcel', 'audioScript',
   ])('accepts "%s"', (target) => {
     expect(downloadTargetSchema.safeParse(target).success).toBe(true)
   })

--- a/src/lib/validators/perso.ts
+++ b/src/lib/validators/perso.ts
@@ -1,15 +1,18 @@
 import { z } from 'zod'
 
+const trimmedNonEmptyString = z.string().trim().min(1)
+export const ttsModelSchema = z.enum(['ELEVEN_V2', 'ELEVEN_V3'])
+
 export const externalMetadataBodySchema = z.object({
   spaceSeq: z.number().int().positive(),
   url: z.string().url(),
-  lang: z.string().min(1).optional(),
+  lang: trimmedNonEmptyString.optional(),
 })
 
 export const externalUploadBodySchema = z.object({
   spaceSeq: z.number().int().positive(),
   url: z.string().url(),
-  lang: z.string().min(1).optional(),
+  lang: trimmedNonEmptyString.optional(),
 })
 
 export const uploadRegisterBodySchema = z.object({
@@ -21,28 +24,51 @@ export const uploadRegisterBodySchema = z.object({
 export const mediaValidateBodySchema = z.object({
   spaceSeq: z.number().int().positive(),
   durationMs: z.number().nonnegative(),
-  originalName: z.string().min(1),
-  mediaType: z.string().min(1),
-  extension: z.string().min(1),
-  size: z.number().nonnegative(),
-  width: z.number().nonnegative(),
-  height: z.number().nonnegative(),
+  originalName: trimmedNonEmptyString,
+  mediaType: z.enum(['video', 'audio']),
+  extension: trimmedNonEmptyString,
+  size: z.number().nonnegative().optional(),
+  width: z.number().int().min(201).max(7999).optional(),
+  height: z.number().int().min(201).max(7999).optional(),
+  thumbnailFilePath: z.string().nullable().optional(),
+}).superRefine((value, ctx) => {
+  if (value.mediaType !== 'video') return
+  if (value.width === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['width'],
+      message: 'width is required for video media',
+    })
+  }
+  if (value.height === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['height'],
+      message: 'height is required for video media',
+    })
+  }
 })
 
 export const translateBodySchema = z.object({
   mediaSeq: z.number().int().positive(),
   isVideoProject: z.boolean(),
-  sourceLanguageCode: z.string().min(1),
-  targetLanguageCodes: z.array(z.string().min(1)).min(1),
+  sourceLanguageCode: trimmedNonEmptyString,
+  targetLanguageCodes: z.array(trimmedNonEmptyString).min(1),
   numberOfSpeakers: z.number().int().positive(),
   withLipSync: z.boolean().optional(),
   preferredSpeedType: z.enum(['GREEN', 'RED']),
-  customDictionaryBlobPath: z.string().optional(),
-  srtBlobPath: z.string().optional(),
+  customDictionaryBlobPath: trimmedNonEmptyString.optional(),
+  srtBlobPath: trimmedNonEmptyString.optional(),
+  ttsModel: ttsModelSchema.optional(),
+  title: trimmedNonEmptyString.optional(),
 })
 
 export const scriptPatchBodySchema = z.object({
   translatedText: z.string().min(1),
+})
+
+export const generateAudioBodySchema = z.object({
+  targetText: z.string().min(1),
 })
 
 export const downloadTargetSchema = z.enum([
@@ -51,8 +77,14 @@ export const downloadTargetSchema = z.enum([
   'lipSyncVideo',
   'originalSubtitle',
   'translatedSubtitle',
-  'audioScript',
+  'originalVoiceAudio',
   'voiceAudio',
   'backgroundAudio',
+  'voicewithBackgroundAudio',
+  'translatedAudio',
   'all',
+  'originalVoiceSpeakers',
+  'speakerSegmentExcel',
+  'speakerSegmentWithTranslationExcel',
+  'audioScript',
 ])

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -49,6 +49,7 @@ export const metadataUpdateBodySchema = z.object({
   sourceLang: z.string().min(1),
   title: z.string().min(1).max(2000),
   description: z.string().max(20000).default(''),
+  tags: z.array(z.string().min(1)).optional(),
   localizations: z.record(
     z.string().min(1),
     z.object({

--- a/src/lib/youtube/metadata.test.ts
+++ b/src/lib/youtube/metadata.test.ts
@@ -110,4 +110,54 @@ describe('youtube metadata', () => {
     })
     expect(result.localizations.en.title).toBe('Updated')
   })
+
+  it('updates tags when provided', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          items: [
+            {
+              id: 'v1',
+              snippet: {
+                title: '원문',
+                description: '설명',
+                categoryId: '22',
+                tags: ['keep'],
+                defaultLanguage: 'ko',
+              },
+              localizations: {},
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          id: 'v1',
+          snippet: {
+            title: '원문',
+            description: '설명',
+            categoryId: '22',
+            tags: ['keep', 'Dubtube'],
+            defaultLanguage: 'ko',
+          },
+          localizations: {},
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await updateVideoLocalizations({
+      accessToken: 'token',
+      videoId: 'v1',
+      sourceLang: 'ko',
+      title: '원문',
+      description: '설명',
+      tags: ['keep', 'Dubtube'],
+      localizations: {},
+    })
+
+    const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body as string)
+    expect(updateBody.snippet.tags).toEqual(['keep', 'Dubtube'])
+    expect(result.tags).toEqual(['keep', 'Dubtube'])
+  })
 })

--- a/src/lib/youtube/metadata.ts
+++ b/src/lib/youtube/metadata.ts
@@ -76,6 +76,7 @@ export async function updateVideoLocalizations(input: {
   sourceLang: string
   title: string
   description: string
+  tags?: string[]
   localizations: Record<string, YouTubeLocalization>
 }): Promise<YouTubeVideoMetadata> {
   const current = await fetchVideoMetadata(input.accessToken, input.videoId)
@@ -91,7 +92,7 @@ export async function updateVideoLocalizations(input: {
       title: input.title || current.title,
       description: input.description,
       categoryId: current.categoryId || '22',
-      tags: current.tags,
+      tags: input.tags ?? current.tags,
       defaultLanguage,
     },
     localizations: mergedLocalizations,

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -141,35 +141,82 @@ describe('fetchMyVideos', () => {
     mockFetch
       .mockResolvedValueOnce(
         jsonResponse({
+          items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
           items: [{
-            id: { videoId: 'v1' },
-            snippet: { title: 'T1', publishedAt: '2026-01-01', thumbnails: { medium: { url: 'http://thumb' } } },
+            snippet: {
+              title: 'T1',
+              publishedAt: '2026-01-01',
+              thumbnails: { medium: { url: 'http://thumb' } },
+              resourceId: { videoId: 'v1' },
+            },
           }],
         }),
       )
       .mockResolvedValueOnce(
         jsonResponse({ items: [{ id: 'v1', status: { privacyStatus: 'public' } }] }),
-      )
+    )
     const vids = await fetchMyVideos('tok', 5)
     expect(vids).toEqual([{ videoId: 'v1', title: 'T1', thumbnail: 'http://thumb', publishedAt: '2026-01-01', privacyStatus: 'public' }])
+    expect(String(mockFetch.mock.calls[0][0])).toContain('/youtube/v3/channels?part=contentDetails&mine=true')
+    expect(String(mockFetch.mock.calls[1][0])).toContain('/youtube/v3/playlistItems?part=snippet&playlistId=UU1&maxResults=5')
   })
 
-  it('returns empty array on non-ok response', async () => {
+  it('throws YouTubeError on non-ok channel response', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 500))
+    await expect(fetchMyVideos('tok')).rejects.toMatchObject({
+      status: 500,
+      code: 'MY_VIDEOS_CHANNEL_FAILED',
+    })
+  })
+
+  it('returns empty array when uploads playlist is missing', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ items: [{}] }))
     expect(await fetchMyVideos('tok')).toEqual([])
   })
 
   it('handles undefined items in response', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}))
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }] }),
+      )
+      .mockResolvedValueOnce(jsonResponse({}))
     expect(await fetchMyVideos('tok')).toEqual([])
   })
 
   it('defaults missing snippet fields and unknown privacy', async () => {
     mockFetch
-      .mockResolvedValueOnce(jsonResponse({ items: [{ id: { videoId: 'v1' } }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }] }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ items: [{ snippet: { resourceId: { videoId: 'v1' } } }] }))
       .mockResolvedValueOnce(jsonResponse({ items: [] }))
     const vids = await fetchMyVideos('tok')
     expect(vids).toEqual([{ videoId: 'v1', title: '', thumbnail: '', publishedAt: '', privacyStatus: 'unknown' }])
+  })
+
+  it('throws quotaExceeded message for playlist response', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }] }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          error: {
+            message: 'quota exceeded',
+            errors: [{ reason: 'quotaExceeded' }],
+          },
+        }, 403),
+      )
+    const promise = fetchMyVideos('tok')
+    await expect(promise).rejects.toMatchObject({
+      status: 403,
+      code: 'MY_VIDEOS_FAILED',
+    })
+    await expect(promise).rejects.toThrow(/quota/)
   })
 })
 
@@ -282,6 +329,11 @@ describe('uploadVideoToYouTube', () => {
     })
     expect(result).toEqual({ videoId: 'yt-abc', title: 'My Vid', status: 'uploaded' })
     const initBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string)
+    expect(initBody.snippet).toMatchObject({
+      title: 'My Vid',
+      description: 'Desc',
+      tags: ['tag1'],
+    })
     expect(initBody.status).toMatchObject({
       privacyStatus: 'private',
       selfDeclaredMadeForKids: true,

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -5,6 +5,38 @@ import { YouTubeError } from '@/lib/youtube/error'
 
 const YOUTUBE_API_BASE = 'https://www.googleapis.com'
 
+async function youtubeResponseError(
+  res: Response,
+  fallbackMessage: string,
+  code: string,
+): Promise<YouTubeError> {
+  const body = await res.text().catch(() => '')
+  let message = fallbackMessage
+
+  if (body) {
+    try {
+      const parsed = JSON.parse(body) as {
+        error?: {
+          message?: string
+          errors?: Array<{ reason?: string }>
+        }
+      }
+      const reason = parsed.error?.errors?.[0]?.reason
+      const googleMessage = parsed.error?.message
+      if (reason === 'quotaExceeded') {
+        message =
+          'YouTube API quota가 초과되어 내 영상을 불러올 수 없습니다. quota가 리셋된 뒤 다시 시도해주세요.'
+      } else if (googleMessage) {
+        message = fallbackMessage
+      }
+    } catch {
+      message = fallbackMessage
+    }
+  }
+
+  return new YouTubeError(res.status, message, code)
+}
+
 export async function fetchVideoStatistics(
   accessToken: string,
   videoIds: string[],
@@ -43,10 +75,9 @@ export async function fetchChannelStatistics(
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
   if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    throw new YouTubeError(
-      res.status,
-      `Channel fetch failed: ${body}`,
+    throw await youtubeResponseError(
+      res,
+      'YouTube 채널 정보를 불러오지 못했습니다',
       'CHANNEL_FETCH_FAILED',
     )
   }
@@ -78,31 +109,67 @@ export async function fetchMyVideos(
   accessToken: string,
   maxResults = 10,
 ): Promise<MyVideoItem[]> {
-  const res = await fetch(
-    `${YOUTUBE_API_BASE}/youtube/v3/search?forMine=true&type=video&part=snippet&order=date&maxResults=${maxResults}`,
+  const channelRes = await fetch(
+    `${YOUTUBE_API_BASE}/youtube/v3/channels?part=contentDetails&mine=true`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
-  if (!res.ok) return []
+  if (!channelRes.ok) {
+    throw await youtubeResponseError(
+      channelRes,
+      'YouTube 채널 정보를 불러오지 못했습니다',
+      'MY_VIDEOS_CHANNEL_FAILED',
+    )
+  }
+
+  const channelData = (await channelRes.json()) as {
+    items?: Array<{
+      contentDetails?: {
+        relatedPlaylists?: {
+          uploads?: string
+        }
+      }
+    }>
+  }
+  const uploadsPlaylistId = channelData.items?.[0]?.contentDetails?.relatedPlaylists?.uploads
+  if (!uploadsPlaylistId) return []
+
+  const res = await fetch(
+    `${YOUTUBE_API_BASE}/youtube/v3/playlistItems?part=snippet&playlistId=${encodeURIComponent(uploadsPlaylistId)}&maxResults=${maxResults}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) {
+    throw await youtubeResponseError(
+      res,
+      'YouTube 영상 목록을 불러오지 못했습니다',
+      'MY_VIDEOS_FAILED',
+    )
+  }
 
   const data = (await res.json()) as {
     items?: Array<{
-      id: { videoId: string }
       snippet?: {
         title?: string
         publishedAt?: string
         thumbnails?: { medium?: { url?: string } }
+        resourceId?: { videoId?: string }
       }
     }>
   }
 
-  const base = (data.items || []).map((item) => ({
-    videoId: item.id.videoId,
-    title: item.snippet?.title || '',
-    thumbnail: item.snippet?.thumbnails?.medium?.url || '',
-    publishedAt: item.snippet?.publishedAt || '',
-  }))
+  const base = (data.items || [])
+    .map((item) => {
+      const videoId = item.snippet?.resourceId?.videoId
+      if (!videoId) return null
+      return {
+        videoId,
+        title: item.snippet?.title || '',
+        thumbnail: item.snippet?.thumbnails?.medium?.url || '',
+        publishedAt: item.snippet?.publishedAt || '',
+      }
+    })
+    .filter((item): item is Omit<MyVideoItem, 'privacyStatus'> => item !== null)
 
-  // search.list는 status를 안 돌려주므로 videos.list로 privacyStatus 보강.
+  // playlistItems.list does not include privacy status, so fetch it separately.
   const privacyById = await fetchPrivacyStatuses(accessToken, base.map((v) => v.videoId))
 
   return base.map((v) => ({
@@ -122,7 +189,13 @@ async function fetchPrivacyStatuses(
     `${YOUTUBE_API_BASE}/youtube/v3/videos?part=status&id=${videoIds.join(',')}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
-  if (!res.ok) return result
+  if (!res.ok) {
+    throw await youtubeResponseError(
+      res,
+      'YouTube 영상 공개 상태를 불러오지 못했습니다',
+      'MY_VIDEOS_STATUS_FAILED',
+    )
+  }
 
   const data = (await res.json()) as {
     items?: Array<{ id: string; status?: { privacyStatus?: string } }>


### PR DESCRIPTION
## 요약
- 더빙 업로드 설정/최종 확인 UI 문구를 정리하고 Shorts, 자막, AI 합성 고지 동작을 다듬었습니다.
- YouTube 업로드 태그 전달을 보강하고, 기존 영상 자막 업로드 흐름에서도 태그를 병합 적용하도록 했습니다.
- 업로드 완료 상태를 더빙 store에 유지해 페이지 재진입 시 자동/수동 중복 업로드를 막았습니다.
- Perso translate/progress/script/SRT/download 관련 요청 파라미터와 응답 처리 규칙을 API에 맞게 보정했습니다.
- 다중 언어 프로젝트 저장 시 두 번째 언어가 잘못 매핑되던 DB 저장 로직을 수정했습니다.

## 배경 / 원인
- `UploadStep`의 YouTube 업로드 상태가 컴포넌트 로컬 state에만 있어, 페이지를 벗어났다가 돌아오면 자동 업로드가 다시 실행될 수 있었습니다.
- 기존 YouTube 영상에 자막만 올리는 모드는 새 영상 업로드가 아니어서 태그 메타데이터 업데이트가 별도로 필요했습니다.
- Perso API 요청 일부는 필수 필드와 target 값이 문서/실제 API 기대값과 맞지 않아 400 또는 리소스 조회 실패를 만들 수 있었습니다.
- job language 저장 시 마지막 insert id 기반 매핑이 다중 언어 삽입에서 잘못된 job id를 참조할 수 있었습니다.

## 검증
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `git diff --check` (`.env.example` CRLF 경고만 확인)

Closes #237