### PR TITLE
chore: 업로드 큐 cron을 Vercel에서 GitHub Actions로 이관

### DIFF
--- a/.github/workflows/upload-cron.yml
+++ b/.github/workflows/upload-cron.yml
@@ -1,0 +1,47 @@
+name: Process upload queue
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upload-cron
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate config
+        run: |
+          if [ -z "${{ vars.PROD_BASE_URL }}" ]; then
+            echo "::error::Missing repo variable PROD_BASE_URL (Settings → Secrets and variables → Actions → Variables)"
+            exit 1
+          fi
+          if [ -z "${{ secrets.CRON_SECRET }}" ]; then
+            echo "::error::Missing repo secret CRON_SECRET"
+            exit 1
+          fi
+
+      - name: Hit upload-queue endpoint
+        env:
+          BASE_URL: ${{ vars.PROD_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          URL="${BASE_URL%/}/api/cron/process-uploads"
+          echo "Calling $URL"
+          HTTP_CODE=$(curl -sS -o /tmp/body.txt -w "%{http_code}" \
+            -X POST "$URL" \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            --max-time 280)
+          echo "HTTP $HTTP_CODE"
+          cat /tmp/body.txt
+          echo
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            exit 1
+          fi

--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,5 @@
       "feature/*": false,
       "fix/*": false
     }
-  },
-  "crons": [
-    {
-      "path": "/api/cron/process-uploads",
-      "schedule": "*/5 * * * *"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Vercel Hobby 플랜이 sub-daily cron(`*/5 * * * *`)을 막아 배포 자체가 차단되던 문제 해결
- 5분 간격은 업로드 큐 안전망(즉시 호출 실패 복구, access token refresh, stale claim 회수)에 필수라 제거 대신 **GitHub Actions cron**으로 이관
- `vercel.json`의 `crons` 블록 제거 + `.github/workflows/upload-cron.yml` 추가

## How it works
GitHub Actions가 5분마다 ubuntu 컨테이너 1개 띄워서 `curl -X POST $PROD_BASE_URL/api/cron/process-uploads`만 호출. 배포/빌드 X — 외부 알람시계가 프로덕션 서버를 깨우는 구조. 라우트는 기존대로 `Authorization: Bearer $CRON_SECRET`로 인증.

## Required setup (머지 전에 GitHub repo Settings에서)
- **Variables** → `PROD_BASE_URL` = `https://youtube_subtitle.vercel.app` (도메인 바뀌면 여기만 수정)
- **Secrets** → `CRON_SECRET` = 강한 랜덤 값 (`openssl rand -hex 32`)
- **Vercel Env** → 동일한 `CRON_SECRET` 등록 후 재배포 (현재 `.env.local`의 `test`는 dev 전용)

세 값이 일치해야 GitHub Actions 호출이 라우트 인증 통과함.

## Test plan
- [ ] 머지 후 `Actions` 탭 → "Process upload queue" → "Run workflow"로 수동 실행, HTTP 200 + `{"data":{"processed":N,...}}` 응답 확인
- [ ] schedule 트리거가 5~15분 내 자동 실행되는지 확인 (GitHub 부하에 따라 약간 지연 가능)
- [ ] 잘못된 `CRON_SECRET`으로 호출 시 401 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)