### PR TITLE
fix: perso_media_resources 마이그레이션 스키마 drift 수정

### DIFF
--- a/migrations/0002_billing_security_queue.sql
+++ b/migrations/0002_billing_security_queue.sql
@@ -51,13 +51,15 @@ CREATE INDEX IF NOT EXISTS idx_app_sessions_user
   ON app_sessions (user_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS perso_media_resources (
-  media_seq INTEGER NOT NULL,
-  space_seq INTEGER,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   user_id TEXT NOT NULL,
-  source TEXT NOT NULL,
+  space_seq INTEGER NOT NULL,
+  media_seq INTEGER NOT NULL UNIQUE,
+  source_type TEXT NOT NULL,
+  original_name TEXT,
+  file_url TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (media_seq, user_id)
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_perso_media_resources_user


### PR DESCRIPTION
## 요약

- 마이그레이션 `0002_billing_security_queue.sql`이 만든 `perso_media_resources` 테이블 스키마가 런타임 코드(`src/lib/perso/ownership.ts`)가 기대하는 컬럼과 달라, 신규 Turso DB에서 `PUT /api/perso/external/upload`(내 영상 가져오기) 호출 시 500 SQLITE_UNKNOWN 발생
- 마이그레이션 정의를 런타임 스키마(id autoincrement, user_id, space_seq, media_seq UNIQUE, source_type, original_name, file_url)와 일치하도록 수정

## 왜 기존 prod에선 안 터졌나

런타임 `ensureOwnershipTables`(`CREATE TABLE IF NOT EXISTS`)가 마이그레이션 0002보다 먼저 실행돼 올바른 스키마로 테이블이 만들어진 상태. 마이그레이션 0002는 IF NOT EXISTS라 no-op으로 통과되어 잘못된 스키마가 박히지 않음. 신규 DB에서는 마이그레이션이 먼저 도니 잘못된 스키마가 박혀 드러남.

## 영향 범위

- 기존 prod DB: `schema_migrations`에 0002가 이미 적용 기록되어 재실행 안 됨 → 영향 없음
- 신규 DB(`dubtube-alpaka206`): 본 작업 직전 직접 SQL `DROP` + 올바른 스키마로 `CREATE`해서 복구 완료
- 향후 fresh DB: 본 PR 머지 후 처음부터 일관된 스키마로 생성됨

## Closes

#242

## Test plan
- [ ] 신규 Turso DB 만들고 `npm run db:migrate` 후 `perso_media_resources` 컬럼 확인 → `id, user_id, space_seq, media_seq, source_type, original_name, file_url, created_at, updated_at`
- [ ] `내 영상 가져오기` 흐름 동작 확인 (200 응답)

🤖 Generated with [Claude Code](https://claude.com/claude-code)