### PR TITLE
feat: 기존 영상 자막 추가 시 메타데이터 다국어 번역 포함

### DIFF
--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -79,7 +79,7 @@ export function UploadStep() {
   const [audioTrackEnabled, setAudioTrackEnabled] = useState(false)
   const [studioOpenedLang, setStudioOpenedLang] = useState<string | null>(null)
   const autoChainTriggered = useRef(false)
-  const existingVideoTagSyncRef = useRef<Set<string>>(new Set())
+  const existingVideoMetadataSyncRef = useRef<Set<string>>(new Set())
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
   // ─── Metadata translations (Gemini) ─────────────────────────────────
@@ -160,40 +160,73 @@ export function UploadStep() {
     [attachOriginalLink, originalYouTubeUrl, shouldApplyAiDisclosure],
   )
 
-  const applyTagsToExistingVideo = useCallback(async (targetVideoId: string) => {
-    const requestedTags = Array.from(new Set(settingsTags.map((tag) => tag.trim()).filter(Boolean)))
-    if (!isAuthenticated || requestedTags.length === 0) return
+  const applyMetadataToExistingVideo = useCallback(async (targetVideoId: string) => {
+    if (!isAuthenticated) return
 
-    const syncKey = `${targetVideoId}:${requestedTags.join('\n')}`
-    if (existingVideoTagSyncRef.current.has(syncKey)) return
-    existingVideoTagSyncRef.current.add(syncKey)
+    const requestedTags = Array.from(new Set(settingsTags.map((tag) => tag.trim()).filter(Boolean)))
+
+    // selectedLanguages별 번역을 localizations 맵으로 변환. 번역 캐시 사용.
+    // 원본 제목/설명은 건드리지 않고 localizations에만 추가한다.
+    const allTranslations = await ensureTranslations()
+    const newLocalizations: Record<string, { title: string; description: string }> = {}
+    for (const code of selectedLanguages) {
+      const t = allTranslations[code]
+      if (t) {
+        newLocalizations[toBcp47(code)] = {
+          title: t.title,
+          description: applyDescriptionFooter(t.description, code),
+        }
+      }
+    }
+
+    const localizationKey = Object.keys(newLocalizations).sort().join(',')
+    const syncKey = `${targetVideoId}:${requestedTags.join('\n')}:${localizationKey}`
+    if (existingVideoMetadataSyncRef.current.has(syncKey)) return
+    existingVideoMetadataSyncRef.current.add(syncKey)
 
     try {
       const metadata = await ytFetchVideoMetadata(targetVideoId)
-      const mergedTags = Array.from(new Set([...metadata.tags, ...requestedTags]))
-      if (
-        mergedTags.length === metadata.tags.length &&
-        mergedTags.every((tag, index) => tag === metadata.tags[index])
-      ) {
-        return
-      }
+      const mergedTags = requestedTags.length === 0
+        ? metadata.tags
+        : Array.from(new Set([...metadata.tags, ...requestedTags]))
+      const mergedLocalizations = { ...metadata.localizations, ...newLocalizations }
 
+      const tagsChanged =
+        mergedTags.length !== metadata.tags.length ||
+        mergedTags.some((tag, index) => tag !== metadata.tags[index])
+      const localizationsChanged = Object.entries(newLocalizations).some(([lang, next]) => {
+        const existing = metadata.localizations[lang]
+        return !existing || existing.title !== next.title || existing.description !== next.description
+      })
+      if (!tagsChanged && !localizationsChanged) return
+
+      // 원본 제목/설명은 그대로 유지 — localizations와 tags만 갱신.
       await ytUpdateVideoLocalizations({
         videoId: targetVideoId,
         sourceLang: metadata.defaultLanguage || toBcp47(metadataLanguage),
         title: metadata.title || settingsTitle?.trim() || videoMetaTitle || 'Untitled',
         description: metadata.description,
         tags: mergedTags,
-        localizations: metadata.localizations,
+        localizations: mergedLocalizations,
       })
     } catch (err) {
       addToast({
         type: 'warning',
-        title: 'YouTube 태그 적용 실패',
+        title: 'YouTube 메타데이터 적용 실패',
         message: err instanceof Error ? err.message : '자막 업로드는 계속 진행합니다.',
       })
     }
-  }, [addToast, isAuthenticated, metadataLanguage, settingsTags, settingsTitle, videoMetaTitle])
+  }, [
+    addToast,
+    applyDescriptionFooter,
+    ensureTranslations,
+    isAuthenticated,
+    metadataLanguage,
+    selectedLanguages,
+    settingsTags,
+    settingsTitle,
+    videoMetaTitle,
+  ])
 
   const handleNewDubbing = () => reset()
   const handleGoToDashboard = () => { reset(); router.push('/dashboard') }
@@ -622,10 +655,10 @@ export function UploadStep() {
 
   const uploadCaptionsWithMetadata = useCallback(async (targetVideoId: string, langs: string[]) => {
     if (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'channel') {
-      await applyTagsToExistingVideo(targetVideoId)
+      await applyMetadataToExistingVideo(targetVideoId)
     }
     await uploadCaptions(targetVideoId, langs)
-  }, [applyTagsToExistingVideo, deliverableMode, uploadCaptions, videoSource?.type])
+  }, [applyMetadataToExistingVideo, deliverableMode, uploadCaptions, videoSource?.type])
 
   const handleUploadCaptionsToVideo = useCallback(async (targetVideoId: string) => {
     const pending = completedLangs.filter((code) => captionUploads[code] !== 'done')
@@ -652,7 +685,7 @@ export function UploadStep() {
       }
 
       if (targetVideoId && videoSource?.type === 'channel') {
-        await applyTagsToExistingVideo(targetVideoId)
+        await applyMetadataToExistingVideo(targetVideoId)
       }
 
       if (targetVideoId && shouldUploadCaptions) {


### PR DESCRIPTION
## 요약

- `기존 영상에 자막 추가` 모드(`originalWithMultiAudio` + sourceType `channel`)에서 자막만 다국어로 올라가고 제목·설명은 원본 언어 그대로였던 UX 갭 해소
- `applyTagsToExistingVideo`를 `applyMetadataToExistingVideo`로 확장 — 새 영상 업로드 모드에서 이미 쓰던 `ensureTranslations()`를 그대로 재사용해 번역 비용 추가 발생 X (캐시 hit)
- 번역 결과는 BCP-47 코드별 `localizations` 맵으로 변환해 기존 YouTube localizations와 머지 후 PUT
- **원본 `title`/`description`은 건드리지 않음** — 발행된 메인 제목·설명이 자막 추가 작업으로 바뀌지 않도록 안전 가드. 사용자가 봐 주는 메인 텍스트는 그대로 유지하고 시청자 로케일별 텍스트만 추가.

## 디자인 결정

| 항목 | 선택 |
|---|---|
| 번역 원문 소스 | `UploadSettingsStep`의 `settingsTitle`/`editableDescription` (새 영상 모드와 동일) |
| 원본 메타 덮어쓰기 | ❌ 안 함. localizations에만 추가 |
| 번역 캐시 | `ensureTranslations`의 캐시 그대로 재사용 (동일 step에서 자막 업로드용으로 이미 호출됨) |

## 멱등성 / 중복 방지

- `existingVideoMetadataSyncRef`의 syncKey에 `selectedLanguages` 시그니처 포함 → 같은 영상에 같은 (태그, 언어 셋) 조합으론 한 번만 PUT
- metadata fetch 후 실제 diff 비교 → 변경 없으면 PUT 자체 스킵 (API 절약)

## 실패 fallback

- 번역 실패 → `ensureTranslations` 자체의 fallback이 원문으로 채움 (warning toast 1회)
- PUT 실패 → warning toast 노출, 자막 업로드는 계속 진행 (기존 동작 유지)

## Closes

#243

## Test plan
- [ ] 채널에서 영상 선택 → `기존 영상에 자막 추가` 모드 → 다국어(예: ko, ja, en) 선택 → 업로드 진행
- [ ] YouTube Studio → 해당 영상 → 자막/번역 → 선택한 언어들에 제목·설명 추가됐는지 확인
- [ ] 영상 메인(원본) 제목·설명은 변경되지 않았는지 확인
- [ ] AI 고지 토글이 켜져 있을 때 description footer가 각 언어별로 적절히 붙는지 확인 (newDubbedVideos 모드와 다르게 originalWithMultiAudio에선 `shouldApplyAiDisclosure` false라 안 붙는 게 정상)
- [ ] 같은 영상에 같은 언어 셋으로 재시도해도 PUT이 한 번만 나가는지 네트워크 탭 확인

## 관련

- 의존: 새 영상 모드의 `ensureTranslations` 캐시 동작에 의존하나, 별도 변경 없이 기존 구조 그대로 활용

🤖 Generated with [Claude Code](https://claude.com/claude-code)