### PR TITLE
fix: 어드민이 아닌 사용자의 /api/ops/alerts 폴링 제거

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -12,7 +12,7 @@ export default async function AppLayout({
     <div className="min-h-screen">
       <Sidebar isOpsAdmin={isOpsAdmin} />
       <div className="ml-64">
-        <Topbar />
+        <Topbar isOpsAdmin={isOpsAdmin} />
         <main className="p-6">{children}</main>
       </div>
     </div>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -9,7 +9,11 @@ import { Button } from '@/components/ui'
 import { useRouter } from 'next/navigation'
 import { OpsAlertButton } from '@/features/ops/components/OpsAlertButton'
 
-export function Topbar() {
+interface TopbarProps {
+  isOpsAdmin?: boolean
+}
+
+export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
   const { mode, toggle } = useThemeStore()
   const { user, clear } = useAuthStore()
   const router = useRouter()
@@ -29,7 +33,7 @@ export function Topbar() {
         <Button variant="ghost" size="sm" onClick={toggle} aria-label="테마 전환">
           {mode === 'dark' ? <Sun className="h-4.5 w-4.5" /> : <Moon className="h-4.5 w-4.5" />}
         </Button>
-        <OpsAlertButton />
+        {isOpsAdmin && <OpsAlertButton />}
 
         {user && (
           <div className="ml-2 flex items-center gap-3">


### PR DESCRIPTION
## 요약

- \`Topbar\`의 \`OpsAlertButton\`이 모든 로그인 사용자에게 노출되어 60초마다 \`/api/ops/alerts\`를 폴링, 비어드민은 매번 403을 받아 네트워크 탭과 observability 로그가 가득 차던 문제 해결
- 레이아웃이 이미 계산하던 \`isOpsAdmin\`을 \`Topbar\`로 prop 전달, 어드민이 아닐 때는 \`OpsAlertButton\` 자체를 렌더하지 않도록 게이팅

## 변경 파일

| 파일 | 변경 |
|---|---|
| \`src/app/(app)/layout.tsx\` | \`<Topbar isOpsAdmin={isOpsAdmin} />\`로 prop 전달 |
| \`src/components/layout/Topbar.tsx\` | \`isOpsAdmin?: boolean\` prop 추가, \`{isOpsAdmin && <OpsAlertButton />}\`로 조건부 렌더 |

## 효과

- 비어드민: \`/api/ops/alerts\` 호출 **0회**. 벨 아이콘도 미노출 → UX 정돈.
- 어드민: 기존 동작 그대로 (60초 폴링 + 카운트 뱃지).
- 권한 체크는 서버(\`requireOperationsAdmin\`) + 클라이언트(렌더 게이트) 이중으로 유지.

## Closes

#246

## Test plan
- [ ] 비어드민 계정(\`OPERATIONS_ADMIN_EMAILS\`에 미포함)으로 로그인 → DevTools 네트워크 탭에 \`/api/ops/alerts\` 호출 없음 확인
- [ ] 비어드민에게 Topbar 우측에 벨 아이콘 미노출 확인
- [ ] 어드민 계정으로 로그인 → 벨 아이콘 노출 + 60초마다 \`/api/ops/alerts\` 폴링 정상 동작 확인
- [ ] 어드민 alert가 있을 때 빨간 카운트 뱃지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)