### PR TITLE
feat: YouTube 설정 페이지 정리 — 자막 토글·Multi-Audio 카드 제거, 기본 태그 추가, 작성 언어 설명 갱신

### DIFF
--- a/src/app/(app)/youtube/page.tsx
+++ b/src/app/(app)/youtube/page.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import { Video, ExternalLink, Unlink, AlertTriangle, Settings, Globe, Loader2 } from 'lucide-react'
-import { Card, CardTitle, CardDescription, Button, Badge, Select, Toggle } from '@/components/ui'
+import { Video, Unlink, Settings, Globe, Loader2 } from 'lucide-react'
+import { Card, CardTitle, CardDescription, Button, Badge, Input, Select } from '@/components/ui'
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
@@ -14,10 +14,19 @@ export default function YouTubeSettingsPage() {
   const router = useRouter()
   const defaultVisibility = useYouTubeSettingsStore((s) => s.defaultPrivacy)
   const setDefaultVisibility = useYouTubeSettingsStore((s) => s.setDefaultPrivacy)
-  const autoSubtitles = useYouTubeSettingsStore((s) => s.autoSubtitles)
-  const setAutoSubtitles = useYouTubeSettingsStore((s) => s.setAutoSubtitles)
   const defaultLanguage = useYouTubeSettingsStore((s) => s.defaultLanguage)
   const setDefaultLanguage = useYouTubeSettingsStore((s) => s.setDefaultLanguage)
+  const defaultTags = useYouTubeSettingsStore((s) => s.defaultTags)
+  const setDefaultTags = useYouTubeSettingsStore((s) => s.setDefaultTags)
+  const defaultTagsString = defaultTags.join(', ')
+
+  const handleDefaultTagsChange = (value: string) => {
+    const parsed = value
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    setDefaultTags(parsed)
+  }
 
   const { data: channel, isLoading: channelLoading, error: channelError } = useChannelStats()
   const isConnected = !!channel
@@ -90,33 +99,6 @@ export default function YouTubeSettingsPage() {
         )}
       </Card>
 
-      {/* Multi-Audio Eligibility */}
-      <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-900/10">
-        <div className="flex gap-3">
-          <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500" />
-          <div>
-            <p className="font-medium text-amber-900 dark:text-amber-300">Multi-Audio Track 요구사항</p>
-            <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
-              YouTube Multi-Audio Track 업로드는 구독자 수, 커뮤니티 가이드라인 준수 등 채널 자격 요건을 충족해야 합니다. YouTube Studio에서 자격 여부를 확인하세요.
-            </p>
-            <a
-              href={
-                channel?.channelId
-                  ? `https://studio.youtube.com/channel/${channel.channelId}/editing/details`
-                  : 'https://studio.youtube.com'
-              }
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button variant="outline" size="sm" className="mt-3">
-                <ExternalLink className="h-3.5 w-3.5" />
-                YouTube Studio에서 확인
-              </Button>
-            </a>
-          </div>
-        </div>
-      </Card>
-
       {/* Default Upload Settings */}
       <Card>
         <div className="flex items-center gap-2 mb-4">
@@ -149,16 +131,18 @@ export default function YouTubeSettingsPage() {
             }))}
           />
           <p className="-mt-3 text-xs text-surface-400">
-            업로드 제목·설명을 이 언어로 작성한다고 간주합니다. 다른 대상 언어들은 Gemini로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.
+            편한 언어를 선택해주세요. 작성하신 내용은 선택하신 언어로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.
           </p>
 
-          <div className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
-            <div>
-              <p className="text-sm font-medium text-surface-900 dark:text-white">자막(SRT) 자동 업로드</p>
-              <p className="text-xs text-surface-500">각 더빙 언어에 대해 SRT 파일을 자동 업로드합니다</p>
-            </div>
-            <Toggle checked={autoSubtitles} onChange={setAutoSubtitles} />
-          </div>
+          <Input
+            label="기본 태그"
+            value={defaultTagsString}
+            onChange={(e) => handleDefaultTagsChange(e.target.value)}
+            placeholder="콤마로 구분 (예: Dubtube, AI더빙, dubbed)"
+          />
+          <p className="-mt-3 text-xs text-surface-400">
+            새 더빙 시작 시 이 태그들이 기본값으로 채워집니다. 더빙별로도 변경할 수 있습니다.
+          </p>
         </div>
       </Card>
 

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -36,12 +36,24 @@ const readDefaultLanguage = (): string => {
   }
 }
 
+const FALLBACK_DEFAULT_TAGS = ['Dubtube', 'AI더빙', 'dubbed']
+
+const readDefaultTags = (): string[] => {
+  if (typeof window === 'undefined') return [...FALLBACK_DEFAULT_TAGS]
+  try {
+    const stored = useYouTubeSettingsStore.getState().defaultTags
+    return Array.isArray(stored) ? [...stored] : [...FALLBACK_DEFAULT_TAGS]
+  } catch {
+    return [...FALLBACK_DEFAULT_TAGS]
+  }
+}
+
 const buildDefaultUploadSettings = (): UploadSettings => ({
   autoUpload: true,
   attachOriginalLink: true,
   title: '',
   description: '',
-  tags: ['Dubtube', 'AI더빙', 'dubbed'],
+  tags: readDefaultTags(),
   privacyStatus: readDefaultPrivacy(),
   uploadCaptions: true,
   selfDeclaredMadeForKids: false,

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -6,26 +6,30 @@ import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 interface YouTubeSettingsState {
   defaultPrivacy: PrivacyStatus
-  autoSubtitles: boolean
   /**
    * 사용자가 제목·설명을 작성할 기본 언어 (perso.ai 코드 기반).
    * 업로드 시 이 언어로 작성된 텍스트를 기준 삼아 다른 대상 언어로 자동 번역한다.
    */
   defaultLanguage: string
+  /**
+   * 새 더빙 세션 시작 시 업로드 태그의 기본값으로 적용된다.
+   * 사용자가 더빙별로 override 가능.
+   */
+  defaultTags: string[]
   setDefaultPrivacy: (v: PrivacyStatus) => void
-  setAutoSubtitles: (v: boolean) => void
   setDefaultLanguage: (v: string) => void
+  setDefaultTags: (v: string[]) => void
 }
 
 export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
   persist(
     (set) => ({
       defaultPrivacy: 'private',
-      autoSubtitles: true,
       defaultLanguage: 'ko',
+      defaultTags: ['Dubtube', 'AI더빙', 'dubbed'],
       setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
-      setAutoSubtitles: (v) => set({ autoSubtitles: v }),
       setDefaultLanguage: (v) => set({ defaultLanguage: v }),
+      setDefaultTags: (v) => set({ defaultTags: v }),
     }),
     { name: 'dubtube-youtube-settings' },
   ),


### PR DESCRIPTION
## 요약

\`/youtube\` 설정 페이지의 \`기본 업로드 설정\` 카드와 안내 영역을 정리하고, 새로 \`기본 태그\` 입력을 추가.

## 변경 항목

### 1. 자막(SRT) 자동 업로드 토글 제거
\`youtubeSettingsStore\`의 \`autoSubtitles\` 필드와 페이지 토글이 어디에서도 실제로 소비되지 않던 dead code. 자막 업로드 동작은 \`uploadSettings.uploadCaptions\`(\`dubbingStore\`)가 별도로 제어 중. → store 필드/setter, UI 모두 제거.

### 2. 기본 태그 입력 추가
- \`youtubeSettingsStore\`에 \`defaultTags: string[]\` 추가 (초기값 \`['Dubtube', 'AI더빙', 'dubbed']\` — 기존 하드코딩 동작 유지)
- \`/youtube\` 페이지에 콤마 구분 \`Input\` 추가
- \`dubbingStore.buildDefaultUploadSettings\`가 settings store에서 \`defaultTags\`를 읽어 새 세션의 \`uploadSettings.tags\` 기본값으로 적용
- SSR / store 접근 실패 시 동일한 fallback 배열로 안전하게 처리

### 3. \`기본 작성 언어\` 설명 문구 갱신
- 기존: \`업로드 제목·설명을 이 언어로 작성한다고 간주합니다. 다른 대상 언어들은 Gemini로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.\`
- 변경: \`편한 언어를 선택해주세요. 작성하신 내용은 선택하신 언어로 자동 번역되어 함께 업로드됩니다. 더빙별로도 변경할 수 있습니다.\`

### 4. Multi-Audio Track 요구사항 안내 카드 제거
현재 운영하지 않는 기능에 대한 안내라 페이지에서 제거.

## 미변경 — 정상 동작 확인됨

\`기본 공개 설정\`은 이미 정상 연동 중:
- \`/youtube\` 페이지: \`setDefaultPrivacy\` → \`youtubeSettingsStore\`
- \`UploadSettingsStep.tsx\`: 마운트 시 \`syncPrivacyFromGlobalDefault()\` 호출
- \`dubbingStore.syncPrivacyFromGlobalDefault\`: \`privacyOverridden\`이 false일 때만 store 값으로 갱신
- 신규 세션은 \`buildDefaultUploadSettings\`가 store에서 직접 읽음

## Closes

#248

## Test plan
- [ ] \`/youtube\`에서 \`기본 공개 설정\` 변경 후 새 더빙 시작 → \`UploadSettingsStep\`의 공개 설정 기본값이 일치하는지 확인
- [ ] \`/youtube\`에서 \`기본 작성 언어\` 변경 후 새 더빙 시작 → 메타데이터 언어 기본값 일치 확인
- [ ] \`/youtube\`에서 \`기본 태그\`를 \`A, B, C\`로 저장 후 새 더빙 시작 → \`UploadSettingsStep\`의 태그 입력에 \`A, B, C\` 채워져 있는지 확인
- [ ] 더빙 진행 중 태그를 수정 → 해당 세션엔 반영되지만 settings store의 \`defaultTags\`엔 영향 없는지 확인
- [ ] \`자막(SRT) 자동 업로드\` 토글이 사라졌는지 확인
- [ ] Multi-Audio Track 요구사항 카드가 사라졌는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)