### PR TITLE
fix: 새 영상 업로드 시 Vercel 4.5MB body 한도 우회 — 브라우저 → YouTube 직접 resumable upload

### DIFF
--- a/src/app/api/youtube/upload-session/route.ts
+++ b/src/app/api/youtube/upload-session/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { initYouTubeResumableUpload } from '@/lib/youtube/server'
+import {
+  parseYtBody,
+  withTokenRetry,
+  ytHandle,
+} from '@/lib/youtube/route-helpers'
+import { uploadSessionBodySchema } from '@/lib/validators/youtube'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * YouTube resumable upload 세션 시작 전용 엔드포인트.
+ *
+ * 영상 바이너리는 받지 않는다 — 메타데이터만 받아 YouTube에서 session URI를 발급받고
+ * 클라이언트에 그대로 전달한다. 클라이언트는 받은 URI로 영상을 직접 PUT해서 Vercel 함수
+ * body 한도(4.5MB)를 우회한다.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return ytHandle(async () => {
+    const body = await parseYtBody(req, uploadSessionBodySchema)
+    return withTokenRetry(req, (accessToken) =>
+      initYouTubeResumableUpload({
+        accessToken,
+        contentType: body.contentType,
+        contentLength: body.contentLength,
+        title: body.title,
+        description: body.description,
+        tags: body.tags,
+        categoryId: body.categoryId,
+        privacyStatus: body.privacyStatus,
+        selfDeclaredMadeForKids: body.selfDeclaredMadeForKids,
+        containsSyntheticMedia: body.containsSyntheticMedia,
+        language: body.language,
+        localizations: body.localizations,
+      }),
+    )
+  })
+}

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -296,8 +296,15 @@ describe('Perso mutation endpoints', () => {
 // ── YouTube upload/caption wrappers ─────────────────────────
 
 describe('ytUploadVideo', () => {
-  it('sends FormData with all fields', async () => {
-    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'yt1' }))
+  it('binary 모드: /upload-session에 메타데이터 JSON을 보내고 받은 URL로 영상 PUT', async () => {
+    // 1) /upload-session 응답
+    mockFetch.mockResolvedValueOnce(okResponse({ uploadUrl: 'https://upload.googleapis.com/x/y' }))
+    // 2) YouTube로의 직접 PUT 응답 (envelope 아님 — 실제 YouTube 응답 형태)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'yt1', snippet: { title: 'Test' }, status: { uploadStatus: 'uploaded' } }),
+    } as unknown as Response)
+
     const blob = new Blob(['fake'], { type: 'video/mp4' })
     const result = await ytUploadVideo({
       video: blob,
@@ -311,19 +318,34 @@ describe('ytUploadVideo', () => {
       language: 'ko',
     })
     expect(result.videoId).toBe('yt1')
-    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/upload')
-    const body = mockFetch.mock.calls[0][1].body as FormData
-    expect(body.get('title')).toBe('Test')
-    expect(body.get('tags')).toBe('a,b')
-    expect(body.get('categoryId')).toBe('22')
-    expect(body.get('privacyStatus')).toBe('unlisted')
-    expect(body.get('selfDeclaredMadeForKids')).toBe('false')
-    expect(body.get('containsSyntheticMedia')).toBe('true')
-    expect(body.get('language')).toBe('ko')
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/upload-session')
+    const sessionBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    expect(sessionBody).toMatchObject({
+      contentType: 'video/mp4',
+      title: 'Test',
+      description: 'desc',
+      tags: ['a', 'b'],
+      categoryId: '22',
+      privacyStatus: 'unlisted',
+      selfDeclaredMadeForKids: false,
+      containsSyntheticMedia: true,
+      language: 'ko',
+    })
+    expect(sessionBody.contentLength).toBeGreaterThan(0)
+
+    expect(mockFetch.mock.calls[1][0]).toBe('https://upload.googleapis.com/x/y')
+    expect(mockFetch.mock.calls[1][1].method).toBe('PUT')
+    expect(mockFetch.mock.calls[1][1].body).toBe(blob)
   })
 
-  it('omits optional fields when not provided', async () => {
-    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'yt2' }))
+  it('binary 모드: 선택 필드는 정의되지 않은 채로 메타데이터 JSON에 포함', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ uploadUrl: 'https://upload.googleapis.com/x/y' }))
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'yt2' }),
+    } as unknown as Response)
+
     const blob = new Blob(['fake'], { type: 'video/mp4' })
     await ytUploadVideo({
       video: blob,
@@ -331,12 +353,28 @@ describe('ytUploadVideo', () => {
       description: '',
       tags: [],
     })
+    const sessionBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    expect(sessionBody.categoryId).toBeUndefined()
+    expect(sessionBody.privacyStatus).toBeUndefined()
+    expect(sessionBody.selfDeclaredMadeForKids).toBeUndefined()
+    expect(sessionBody.containsSyntheticMedia).toBeUndefined()
+    expect(sessionBody.language).toBeUndefined()
+  })
+
+  it('videoUrl 모드: FormData로 /upload에 POST (서버가 fetch + 업로드)', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'yt3' }))
+    const result = await ytUploadVideo({
+      videoUrl: 'https://example.blob.core.windows.net/x/y.mp4',
+      title: 'URL Mode',
+      description: 'd',
+      tags: ['x'],
+    })
+    expect(result.videoId).toBe('yt3')
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/upload')
     const body = mockFetch.mock.calls[0][1].body as FormData
-    expect(body.get('categoryId')).toBeNull()
-    expect(body.get('privacyStatus')).toBeNull()
-    expect(body.get('selfDeclaredMadeForKids')).toBeNull()
-    expect(body.get('containsSyntheticMedia')).toBeNull()
-    expect(body.get('language')).toBeNull()
+    expect(body.get('videoUrl')).toBe('https://example.blob.core.windows.net/x/y.mp4')
+    expect(body.get('title')).toBe('URL Mode')
+    expect(body.get('tags')).toBe('x')
   })
 })
 

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -25,33 +25,78 @@ export async function ytUploadVideo(params: {
   /** BCP-47 language code → { title, description } 맵. snippet.localizations로 전달. */
   localizations?: Record<string, { title: string; description: string }>
 }): Promise<YouTubeUploadResult> {
-  const form = new FormData()
+  // 1. 영상 URL이 있으면 서버가 fetch + 업로드 (더빙 흐름).
   if (params.videoUrl) {
+    const form = new FormData()
     form.append('videoUrl', params.videoUrl)
-  } else if (params.video) {
-    form.append('video', params.video)
-  }
-  form.append('title', params.title)
-  form.append('description', params.description)
-  form.append('tags', params.tags.join(','))
-  if (params.categoryId) form.append('categoryId', params.categoryId)
-  if (params.privacyStatus) form.append('privacyStatus', params.privacyStatus)
-  if (params.selfDeclaredMadeForKids !== undefined) {
-    form.append('selfDeclaredMadeForKids', String(params.selfDeclaredMadeForKids))
-  }
-  if (params.containsSyntheticMedia !== undefined) {
-    form.append('containsSyntheticMedia', String(params.containsSyntheticMedia))
-  }
-  if (params.language) form.append('language', params.language)
-  if (params.localizations && Object.keys(params.localizations).length > 0) {
-    form.append('localizations', JSON.stringify(params.localizations))
+    form.append('title', params.title)
+    form.append('description', params.description)
+    form.append('tags', params.tags.join(','))
+    if (params.categoryId) form.append('categoryId', params.categoryId)
+    if (params.privacyStatus) form.append('privacyStatus', params.privacyStatus)
+    if (params.selfDeclaredMadeForKids !== undefined) {
+      form.append('selfDeclaredMadeForKids', String(params.selfDeclaredMadeForKids))
+    }
+    if (params.containsSyntheticMedia !== undefined) {
+      form.append('containsSyntheticMedia', String(params.containsSyntheticMedia))
+    }
+    if (params.language) form.append('language', params.language)
+    if (params.localizations && Object.keys(params.localizations).length > 0) {
+      form.append('localizations', JSON.stringify(params.localizations))
+    }
+
+    const res = await fetch(`${YT}/upload`, {
+      method: 'POST',
+      body: form,
+    })
+    return json<YouTubeUploadResult>(res)
   }
 
-  const res = await fetch(`${YT}/upload`, {
+  // 2. 로컬 영상 파일은 브라우저 → YouTube 직접 resumable upload로 보낸다.
+  //    Vercel 함수의 4.5MB 본문 한도를 우회하고, 서버는 session URI 발급만 책임진다.
+  if (!params.video) {
+    throw new Error('영상 파일 또는 videoUrl이 필요합니다')
+  }
+  const video = params.video
+
+  const sessionRes = await fetch(`${YT}/upload-session`, {
     method: 'POST',
-    body: form,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contentType: video.type || 'video/mp4',
+      contentLength: video.size,
+      title: params.title,
+      description: params.description,
+      tags: params.tags,
+      categoryId: params.categoryId,
+      privacyStatus: params.privacyStatus,
+      selfDeclaredMadeForKids: params.selfDeclaredMadeForKids,
+      containsSyntheticMedia: params.containsSyntheticMedia,
+      language: params.language,
+      localizations: params.localizations,
+    }),
   })
-  return json<YouTubeUploadResult>(res)
+  const session = await json<{ uploadUrl: string }>(sessionRes)
+
+  const putRes = await fetch(session.uploadUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': video.type || 'video/mp4' },
+    body: video,
+  })
+  if (!putRes.ok) {
+    const errText = await putRes.text().catch(() => '')
+    throw new Error(`YouTube 업로드 실패: ${putRes.status} ${errText}`)
+  }
+  const data = (await putRes.json()) as {
+    id: string
+    snippet?: { title?: string }
+    status?: { uploadStatus?: string }
+  }
+  return {
+    videoId: data.id,
+    title: data.snippet?.title || params.title,
+    status: data.status?.uploadStatus || 'uploaded',
+  }
 }
 
 export async function ytUploadCaption(params: {

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -76,6 +76,20 @@ const formBooleanSchema = z
     return v === 'true'
   })
 
+export const uploadSessionBodySchema = z.object({
+  contentType: z.string().min(1).max(200),
+  contentLength: z.number().int().positive(),
+  title: z.string().default(''),
+  description: z.string().default(''),
+  tags: z.array(z.string()).default([]),
+  categoryId: z.string().optional(),
+  privacyStatus: z.enum(['public', 'unlisted', 'private']).optional(),
+  selfDeclaredMadeForKids: z.boolean().optional(),
+  containsSyntheticMedia: z.boolean().optional(),
+  language: z.string().optional(),
+  localizations: localizationsRecordSchema.optional(),
+})
+
 export const uploadFormSchema = z.object({
   title: z.string().default(''),
   description: z.string().default(''),

--- a/src/lib/youtube/server.ts
+++ b/src/lib/youtube/server.ts
@@ -4,7 +4,9 @@ export { YouTubeError } from '@/lib/youtube/error'
 export {
   uploadVideoToYouTube,
   uploadCaptionToYouTube,
+  initYouTubeResumableUpload,
   type YouTubeUploadInput,
+  type YouTubeUploadSessionInput,
   type CaptionUploadInput,
 } from '@/lib/youtube/upload'
 export {

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -23,12 +23,32 @@ export interface YouTubeUploadInput {
   localizations?: Record<string, YouTubeLocalization>
 }
 
-export async function uploadVideoToYouTube(
-  input: YouTubeUploadInput,
-): Promise<YouTubeUploadResult> {
+export interface YouTubeUploadSessionInput {
+  accessToken: string
+  contentLength: number
+  contentType: string
+  title: string
+  description: string
+  tags: string[]
+  categoryId?: string
+  privacyStatus?: 'public' | 'unlisted' | 'private'
+  selfDeclaredMadeForKids?: boolean
+  containsSyntheticMedia?: boolean
+  language?: string
+  localizations?: Record<string, YouTubeLocalization>
+}
+
+/**
+ * YouTube resumable upload 세션을 시작하고 Location 헤더의 session URI를 반환한다.
+ * 반환된 URI로 PUT하면 YouTube에 영상 바이너리가 직접 업로드된다 — Vercel 함수 body 한도(4.5MB)와 무관.
+ */
+export async function initYouTubeResumableUpload(
+  input: YouTubeUploadSessionInput,
+): Promise<{ uploadUrl: string }> {
   const {
     accessToken,
-    videoBlob,
+    contentLength,
+    contentType,
     title,
     description,
     tags,
@@ -59,7 +79,6 @@ export async function uploadVideoToYouTube(
   if (hasLocalizations) {
     metadata.localizations = localizations
   }
-  // localizations가 있으면 part에 포함되도록 아래 URL에서 동적으로 합친다.
   const parts = ['snippet', 'status', ...(hasLocalizations ? ['localizations'] : [])].join(',')
 
   const initRes = await fetch(
@@ -69,8 +88,8 @@ export async function uploadVideoToYouTube(
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json; charset=UTF-8',
-        'X-Upload-Content-Length': String(videoBlob.size),
-        'X-Upload-Content-Type': videoBlob.type || 'video/mp4',
+        'X-Upload-Content-Length': String(contentLength),
+        'X-Upload-Content-Type': contentType || 'video/mp4',
       },
       body: JSON.stringify(metadata),
     },
@@ -93,6 +112,29 @@ export async function uploadVideoToYouTube(
       'NO_UPLOAD_URL',
     )
   }
+
+  return { uploadUrl }
+}
+
+export async function uploadVideoToYouTube(
+  input: YouTubeUploadInput,
+): Promise<YouTubeUploadResult> {
+  const { accessToken, videoBlob, title } = input
+
+  const { uploadUrl } = await initYouTubeResumableUpload({
+    accessToken,
+    contentLength: videoBlob.size,
+    contentType: videoBlob.type || 'video/mp4',
+    title,
+    description: input.description,
+    tags: input.tags,
+    categoryId: input.categoryId,
+    privacyStatus: input.privacyStatus,
+    selfDeclaredMadeForKids: input.selfDeclaredMadeForKids,
+    containsSyntheticMedia: input.containsSyntheticMedia,
+    language: input.language,
+    localizations: input.localizations,
+  })
 
   const putRes = await fetch(uploadUrl, {
     method: 'PUT',


### PR DESCRIPTION
## 요약

\`MetadataLocalizationTool\`의 \"새 영상 업로드\" 모드에서 영상 + 번역 메타데이터로 업로드 시 \`413 FUNCTION_PAYLOAD_TOO_LARGE\` 발생. 영상 바이너리가 Vercel 함수 본문(4.5MB 한도)을 거쳐서 우리 \`/api/youtube/upload\`로 들어오던 구조 → YouTube API에 도달하기 전에 차단됨.

## 변경: 브라우저 → YouTube 직접 resumable upload

| 단계 | 이전 | 이후 |
|---|---|---|
| 1. 메타데이터 + 영상 → 우리 서버 | multipart/form-data 한 번에 (4.5MB↑이면 413) | JSON 메타데이터만 (작음) |
| 2. 서버 → YouTube init | resumable session 시작 | resumable session 시작 → \`uploadUrl\`만 클라이언트에 반환 |
| 3. 영상 바이너리 → YouTube | 서버가 PUT (이미 받은 영상 다시 전송) | **브라우저가 \`uploadUrl\`로 직접 PUT** |

서버는 토큰 발급·메타데이터 init만 책임지고, 영상 바이너리는 절대 우리 함수 메모리에 들어오지 않음.

## 변경 파일

| 파일 | 변경 |
|---|---|
| \`src/lib/youtube/upload.ts\` | \`uploadVideoToYouTube\`에서 init 단계 분리해 \`initYouTubeResumableUpload\` export. 기존 함수는 신규 함수 + PUT 조합으로 재구성 |
| \`src/lib/youtube/server.ts\` | \`initYouTubeResumableUpload\`, \`YouTubeUploadSessionInput\` 재export |
| \`src/lib/validators/youtube.ts\` | \`uploadSessionBodySchema\` 추가 |
| \`src/app/api/youtube/upload-session/route.ts\` | 신규 엔드포인트 — JSON 메타데이터(+contentType, contentLength) 받아 \`{ uploadUrl }\` 반환 |
| \`src/lib/api-client/youtube.ts\` | \`ytUploadVideo\`에서 \`video\` Blob 분기 시 신규 엔드포인트로 호출 후 직접 PUT. \`videoUrl\` 분기는 기존 \`/upload\` 엔드포인트 그대로 사용 |
| \`src/lib/api-client.test.ts\` | binary/videoUrl 두 경로 테스트 케이스로 갱신 |

## 미변경

- 더빙 플로우 (\`UploadStep\`의 \`uploadOriginalToYouTube\`) — 영상을 Perso 업로드 후 \`videoUrl\`로 \`/api/youtube/upload\`에 전달. 본 PR과 무관, 기존 동작 유지.
- \`/api/youtube/upload\` 엔드포인트도 유지 — \`videoUrl\` 경로용으로 계속 사용.
- 메타데이터(localizations 포함)는 모든 경로에서 동일하게 영상과 함께 한 번에 업로드.

## CORS

YouTube의 resumable session URI는 CORS 활성화 상태로 발급되어 브라우저 PUT이 정상 동작. (별도 \`Origin\` 헤더 forwarding 불필요)

## Closes

#250

## Test plan
- [ ] \`/metadata\` (또는 해당 도구) → \"새 영상 업로드\" 모드 → 5MB 이상 영상 파일 + 번역 메타데이터로 업로드 → 200 응답, YouTube에 영상 + 다국어 제목·설명 정상 노출
- [ ] DevTools 네트워크 탭: 첫 요청은 \`/api/youtube/upload-session\` (작은 JSON), 두 번째 요청이 \`https://www.googleapis.com/upload/youtube/...\`로 직접 PUT 되는지 확인
- [ ] 더빙 플로우(\"새 더빙 영상 업로드\") 회귀 테스트 — \`/api/youtube/upload\` videoUrl 경로 정상 동작
- [ ] 단위 테스트: \`npx vitest run src/lib/api-client.test.ts\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)