### PR TITLE
feat: MetadataLocalizationTool 새 영상 업로드에 태그 입력 추가

### DIFF
--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -39,7 +39,7 @@ function buildInitialTargets(presetId: string, sourceLang: string, exclude: Set<
 export function MetadataLocalizationTool() {
   const addToast = useNotificationStore((state) => state.addToast)
   const { metadataTargetPreset, setMetadataTargetPreset } = useI18nStore()
-  const { defaultLanguage } = useYouTubeSettingsStore()
+  const { defaultLanguage, defaultTags } = useYouTubeSettingsStore()
 
   const [mode, setMode] = useState<Mode>('existing')
   const { data: videos = [], isLoading: loadingVideos, error: videosError } = useMyVideos(50, mode === 'existing')
@@ -50,6 +50,7 @@ export function MetadataLocalizationTool() {
   const [sourceLang, setSourceLang] = useState(defaultLanguage)
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
+  const [tags, setTags] = useState<string[]>(() => [...defaultTags])
   const [targetLangs, setTargetLangs] = useState<string[]>(
     () => buildInitialTargets(metadataTargetPreset, defaultLanguage),
   )
@@ -81,6 +82,7 @@ export function MetadataLocalizationTool() {
     setVideoFile(null)
     setTitle('')
     setDescription('')
+    setTags([...defaultTags])
     setTranslations({})
     setExistingLocalizationLangs(new Set())
     setMetadataLoaded(false)
@@ -196,7 +198,7 @@ export function MetadataLocalizationTool() {
         video: videoFile,
         title: title.trim(),
         description,
-        tags: [],
+        tags,
         privacyStatus: 'private',
         language: toBcp47(sourceLang),
         localizations,
@@ -210,6 +212,7 @@ export function MetadataLocalizationTool() {
       setVideoFile(null)
       setTitle('')
       setDescription('')
+      setTags([...defaultTags])
       setTranslations({})
     } catch (err) {
       addToast({
@@ -462,6 +465,25 @@ export function MetadataLocalizationTool() {
               className="w-full resize-none rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-400 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100"
             />
           </div>
+          {mode === 'new' && (
+            <div>
+              <Input
+                label="태그"
+                value={tags.join(', ')}
+                onChange={(event) => {
+                  const parsed = event.target.value
+                    .split(',')
+                    .map((t) => t.trim())
+                    .filter(Boolean)
+                  setTags(parsed)
+                }}
+                placeholder="콤마로 구분 (예: gaming, vlog)"
+              />
+              <p className="mt-1.5 text-xs text-surface-400">
+                YouTube 설정의 기본 태그가 채워져 있습니다. 이 영상에만 적용할 태그로 자유롭게 수정하세요.
+              </p>
+            </div>
+          )}
         </div>
 
         <div className="mt-4 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/60">


### PR DESCRIPTION
## 요약

\`MetadataLocalizationTool\`의 \"새 영상 업로드\" 모드에서 \`tags: []\`로 하드코딩되어 태그 없이 업로드되던 문제 해결. 사용자가 해당 영상에 적용할 태그를 직접 입력할 수 있고, 초기값은 \`/youtube\` 설정 페이지의 \`기본 태그\`를 그대로 가져옴.

## 변경

| 위치 | 내용 |
|---|---|
| state | \`tags: string[]\` 추가, 초기값 \`youtubeSettingsStore.defaultTags\` |
| UI | \`mode === 'new'\`일 때만 \`Input\`(콤마 구분) 노출. 안내 문구로 \"기본 태그가 채워져 있고 자유롭게 수정\" 가이드 |
| \`handleUploadNew\` | \`ytUploadVideo({ ..., tags })\`로 전달 |
| \`switchMode\` / 업로드 후 reset | \`defaultTags\`로 재초기화 |

## 왜 existing 모드엔 노출 안 함

\`existing\` 모드는 이미 게시된 영상에 번역만 추가하는 흐름. 태그 input을 노출하면 사용자가 의도치 않게 게시된 영상의 태그를 덮어쓸 위험. 게시된 영상의 태그 변경은 별도 작업으로 분리하는 게 안전.

## Closes

#253

## Test plan
- [ ] \`/youtube\`에서 \`기본 태그\`에 \`gaming, vlog\` 저장
- [ ] \`/metadata\` → \"새 영상 업로드\" 모드 → 영상 파일 선택 후 번역 카드 노출되면 \`태그\` Input에 \`gaming, vlog\`가 채워져 있는지 확인
- [ ] 태그를 \`gaming, vlog, 한국\`로 수정 후 업로드 → YouTube Studio에서 해당 영상 태그 확인
- [ ] \"내 영상\" 모드에서는 태그 Input이 노출되지 않는지 확인
- [ ] 모드 전환 시 / 업로드 성공 후 태그가 \`/youtube\`의 \`defaultTags\`로 다시 채워지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)