### PR TITLE
feat: 메타데이터 번역 새 영상 업로드 흐름 + 사용자 설정 서버 저장

### DIFF
--- a/migrations/0004_user_preferences.sql
+++ b/migrations/0004_user_preferences.sql
@@ -1,0 +1,5 @@
+-- 사용자별 워크플로우 설정을 서버에 저장.
+-- 클라이언트(localStorage) 의존을 줄이고, 같은 계정이면 어느 디바이스/브라우저든 동일 설정을 보장한다.
+-- 현재 저장 대상: defaultPrivacy, defaultLanguage, defaultTags (youtubeSettingsStore).
+-- 향후 새 키가 추가돼도 마이그레이션 없이 JSON 안에서 확장 가능.
+ALTER TABLE users ADD COLUMN preferences TEXT NOT NULL DEFAULT '{}';

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { apiOk, apiFail, apiFailFromError } from '@/lib/api/response'
+import { getUserPreferencesRaw, setUserPreferencesRaw } from '@/lib/db/queries'
+import {
+  parseUserPreferences,
+  userPreferencesSchema,
+} from '@/lib/validators/user-preferences'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  try {
+    const raw = await getUserPreferencesRaw(auth.session.uid)
+    return apiOk(parseUserPreferences(raw))
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return apiFail('INVALID_BODY', 'Invalid JSON body', 400)
+  }
+
+  const parsed = userPreferencesSchema.safeParse(body)
+  if (!parsed.success) {
+    const details = parsed.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ')
+    return apiFail('INVALID_BODY', `Invalid preferences: ${details}`, 400)
+  }
+
+  try {
+    // 부분 업데이트 지원 — 기존 저장 값에 머지해 누락된 키는 유지한다.
+    const existingRaw = await getUserPreferencesRaw(auth.session.uid)
+    const existing = parseUserPreferences(existingRaw)
+    const next = {
+      defaultPrivacy: parsed.data.defaultPrivacy ?? existing.defaultPrivacy,
+      defaultLanguage: parsed.data.defaultLanguage ?? existing.defaultLanguage,
+      defaultTags: parsed.data.defaultTags ?? existing.defaultTags,
+    }
+    await setUserPreferencesRaw(auth.session.uid, JSON.stringify(next))
+    return apiOk(next)
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -8,6 +8,7 @@ import { signOut } from '@/lib/google-auth'
 import { Button } from '@/components/ui'
 import { useRouter } from 'next/navigation'
 import { OpsAlertButton } from '@/features/ops/components/OpsAlertButton'
+import { useChannelStats } from '@/hooks/useYouTubeData'
 
 interface TopbarProps {
   isOpsAdmin?: boolean
@@ -17,6 +18,11 @@ export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
   const { mode, toggle } = useThemeStore()
   const { user, clear } = useAuthStore()
   const router = useRouter()
+  const { data: channel } = useChannelStats()
+  const accountName = channel?.title || user?.displayName || '사용자'
+  const subscriberLabel = channel
+    ? `구독자 ${channel.subscriberCount.toLocaleString('ko-KR')}`
+    : null
 
   const handleSignOut = async () => {
     signOut()
@@ -39,14 +45,16 @@ export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
           <div className="ml-2 flex items-center gap-3">
             <div className="hidden sm:block text-right">
               <p className="text-sm font-medium text-surface-900 dark:text-white leading-tight">
-                {user.displayName || '사용자'}
+                {accountName}
               </p>
-              <p className="text-xs text-surface-400 leading-tight">{user.email}</p>
+              {subscriberLabel && (
+                <p className="text-xs text-surface-400 leading-tight">{subscriberLabel}</p>
+              )}
             </div>
             {user.photoURL ? (
               <Image
                 src={user.photoURL}
-                alt={user.displayName || ''}
+                alt={accountName}
                 width={32}
                 height={32}
                 className="rounded-full object-cover"
@@ -54,7 +62,7 @@ export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
               />
             ) : (
               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-brand-500 to-brand-600 text-sm font-bold text-white">
-                {(user.displayName || user.email || 'U')[0].toUpperCase()}
+                {accountName[0].toUpperCase()}
               </div>
             )}
             <Button variant="ghost" size="sm" onClick={handleSignOut} aria-label="로그아웃">

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -8,6 +8,7 @@ import { useThemeStore } from '@/stores/themeStore'
 import { useAuthStore } from '@/stores/authStore'
 import { useI18nStore } from '@/stores/i18nStore'
 import { restoreSession } from '@/lib/google-auth'
+import { useUserPreferencesSync } from '@/hooks/useUserPreferencesSync'
 
 function ThemeHydrator() {
   useEffect(() => {
@@ -58,6 +59,12 @@ function I18nHydrator() {
   return null
 }
 
+/** youtubeSettingsStore ↔ /api/user/preferences 양방향 동기화. QueryClientProvider 안쪽에서 mount되어야 함. */
+function UserPreferencesSync() {
+  useUserPreferencesSync()
+  return null
+}
+
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => queryClient)
   return (
@@ -65,6 +72,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ThemeHydrator />
       <I18nHydrator />
       <AuthHydrator />
+      <UserPreferencesSync />
       {children}
       <ToastContainer />
     </QueryClientProvider>

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -6,6 +6,7 @@ import { Button, Card, Badge } from '@/components/ui'
 import { cn } from '@/utils/cn'
 import { getLanguageByCode } from '@/utils/languages'
 import { useAuthStore } from '@/stores/authStore'
+import { useChannelStats } from '@/hooks/useYouTubeData'
 import { useDubbingStore } from '../../store/dubbingStore'
 import type { PrivacyStatus } from '../../types/dubbing.types'
 
@@ -26,11 +27,14 @@ export function TranslationEditStep() {
     nextStep,
   } = useDubbingStore()
   const user = useAuthStore((s) => s.user)
+  const { data: channel } = useChannelStats()
 
   const needsAutoUploadReview = uploadSettings.autoUpload
   const canStart = !needsAutoUploadReview || uploadSettings.uploadReviewConfirmed
   const privacyLabel = PRIVACY_LABELS[uploadSettings.privacyStatus] ?? uploadSettings.privacyStatus
-  const targetChannelLabel = user?.email ?? 'Google 로그인 후 연결된 YouTube 채널'
+  const targetChannelLabel = channel
+    ? `${channel.title} · 구독자 ${channel.subscriberCount.toLocaleString('ko-KR')}`
+    : user?.displayName ?? 'Google 로그인 후 연결된 YouTube 채널'
   const uploadsVideoToYouTube =
     deliverableMode === 'newDubbedVideos' ||
     (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Check, FileVideo, Languages, Loader2, RefreshCw, Search, Send, Upload } from 'lucide-react'
-import { Badge, Button, Card, CardTitle, Input, Select } from '@/components/ui'
-import { useMyVideos } from '@/hooks/useYouTubeData'
+import { Badge, Button, Card, CardTitle, Input, Modal, Select, Toggle } from '@/components/ui'
+import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { translateMetadata } from '@/lib/api-client/translate'
 import {
   ytFetchVideoMetadata,
@@ -15,6 +15,7 @@ import { getMarketLanguagePreset, MARKET_LANGUAGE_PRESETS } from '@/lib/i18n/con
 import { useI18nStore } from '@/stores/i18nStore'
 import { useNotificationStore } from '@/stores/notificationStore'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 import { SUPPORTED_LANGUAGES, fromBcp47, getLanguageByCode, toBcp47 } from '@/utils/languages'
 import { cn } from '@/utils/cn'
 
@@ -39,7 +40,8 @@ function buildInitialTargets(presetId: string, sourceLang: string, exclude: Set<
 export function MetadataLocalizationTool() {
   const addToast = useNotificationStore((state) => state.addToast)
   const { metadataTargetPreset, setMetadataTargetPreset } = useI18nStore()
-  const { defaultLanguage, defaultTags } = useYouTubeSettingsStore()
+  const { defaultLanguage, defaultTags, defaultPrivacy } = useYouTubeSettingsStore()
+  const { data: channel } = useChannelStats()
 
   const [mode, setMode] = useState<Mode>('existing')
   const { data: videos = [], isLoading: loadingVideos, error: videosError } = useMyVideos(50, mode === 'existing')
@@ -62,6 +64,25 @@ export function MetadataLocalizationTool() {
   const [saving, setSaving] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [query, setQuery] = useState('')
+
+  // 새 영상 업로드 확인 모달 상태. 채널·태그·대상 언어는 읽기전용으로 보여주고,
+  // 공개 범위(기본: 사용자 설정)와 유아용 여부(기본: false)만 모달에서 조정한다.
+  const [showUploadModal, setShowUploadModal] = useState(false)
+  const [uploadPrivacy, setUploadPrivacy] = useState<PrivacyStatus>(defaultPrivacy)
+  const [uploadMadeForKids, setUploadMadeForKids] = useState(false)
+  const [uploadConfirmed, setUploadConfirmed] = useState(false)
+  useEffect(() => {
+    // 사용자가 /youtube에서 기본 공개 설정을 바꾸면 모달 미열림 상태에서 동기화.
+    if (!showUploadModal) setUploadPrivacy(defaultPrivacy)
+  }, [defaultPrivacy, showUploadModal])
+
+  const openUploadModal = () => {
+    setUploadPrivacy(defaultPrivacy)
+    setUploadMadeForKids(false)
+    setUploadConfirmed(false)
+    setShowUploadModal(true)
+  }
+  const closeUploadModal = () => setShowUploadModal(false)
 
   const filteredVideos = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -199,14 +220,19 @@ export function MetadataLocalizationTool() {
         title: title.trim(),
         description,
         tags,
-        privacyStatus: 'private',
+        privacyStatus: uploadPrivacy,
+        selfDeclaredMadeForKids: uploadMadeForKids,
         language: toBcp47(sourceLang),
         localizations,
       })
+      const privacyLabel =
+        uploadPrivacy === 'public' ? '공개'
+          : uploadPrivacy === 'unlisted' ? '일부 공개'
+            : '비공개'
       addToast({
         type: 'success',
         title: 'YouTube 업로드 완료',
-        message: `videoId: ${result.videoId} (비공개로 업로드되었습니다)`,
+        message: `videoId: ${result.videoId} (${privacyLabel}로 업로드되었습니다)`,
       })
       // 업로드 후 폼 초기화 — 같은 파일 중복 업로드 방지.
       setVideoFile(null)
@@ -214,6 +240,7 @@ export function MetadataLocalizationTool() {
       setDescription('')
       setTags([...defaultTags])
       setTranslations({})
+      setShowUploadModal(false)
     } catch (err) {
       addToast({
         type: 'error',
@@ -555,7 +582,7 @@ export function MetadataLocalizationTool() {
             </Button>
           ) : (
             <Button
-              onClick={handleUploadNew}
+              onClick={openUploadModal}
               loading={uploading}
               disabled={!canUpload || uploading}
             >
@@ -591,7 +618,7 @@ export function MetadataLocalizationTool() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handleUploadNew}
+                onClick={openUploadModal}
                 loading={uploading}
                 disabled={!canUpload || uploading}
               >
@@ -640,6 +667,93 @@ export function MetadataLocalizationTool() {
             })}
           </div>
         </Card>
+      )}
+
+      {mode === 'new' && (
+        <Modal
+          open={showUploadModal}
+          onClose={closeUploadModal}
+          title="YouTube 업로드 확인"
+          size="lg"
+        >
+          <div className="space-y-5">
+            <div className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <p className="text-xs font-medium text-surface-500 dark:text-surface-400">채널</p>
+              <p className="mt-1 text-sm text-surface-900 dark:text-surface-100">
+                {channel ? `${channel.title} · 구독자 ${channel.subscriberCount.toLocaleString('ko-KR')}` : '연결된 채널 정보 없음'}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <p className="text-xs font-medium text-surface-500 dark:text-surface-400">대상 언어 ({Object.keys(translations).length}개)</p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {Object.keys(translations).map((code) => {
+                  const lang = getLanguageByCode(code) ?? getLanguageByCode(code.split('-')[0])
+                  return (
+                    <Badge key={code} variant="brand">
+                      {lang ? `${lang.flag} ${lang.name}` : code}
+                    </Badge>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <p className="text-xs font-medium text-surface-500 dark:text-surface-400">태그</p>
+              <p className="mt-1 text-sm text-surface-900 dark:text-surface-100">
+                {tags.length > 0 ? tags.join(', ') : <span className="text-surface-400">없음</span>}
+              </p>
+            </div>
+
+            <Select
+              label="공개 범위"
+              value={uploadPrivacy}
+              onChange={(e) => setUploadPrivacy(e.target.value as PrivacyStatus)}
+              options={[
+                { value: 'private', label: '비공개 (private)' },
+                { value: 'unlisted', label: '일부 공개 (unlisted)' },
+                { value: 'public', label: '공개 (public)' },
+              ]}
+            />
+            <p className="-mt-3 text-xs text-surface-400">
+              YouTube 설정 페이지의 기본값으로 채워져 있습니다. 이 영상에만 적용할 값으로 변경 가능.
+            </p>
+
+            <div className="flex items-center justify-between rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <div>
+                <p className="text-sm font-medium text-surface-900 dark:text-white">아동용 영상</p>
+                <p className="text-xs text-surface-500">YouTube의 아동용 콘텐츠 정책(COPPA)에 따라 표시. 일반 영상은 끄세요.</p>
+              </div>
+              <Toggle checked={uploadMadeForKids} onChange={setUploadMadeForKids} />
+            </div>
+
+            <label className="flex cursor-pointer items-start gap-2 rounded-lg border border-surface-200 p-3 dark:border-surface-800">
+              <input
+                type="checkbox"
+                checked={uploadConfirmed}
+                onChange={(e) => setUploadConfirmed(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus-ring"
+              />
+              <span className="text-sm text-surface-700 dark:text-surface-300">
+                위 채널, 공개 범위, 태그, 아동용 등 설정들을 확인했으며 업로드는 진행합니다.
+              </span>
+            </label>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="outline" onClick={closeUploadModal} disabled={uploading}>
+              취소
+            </Button>
+            <Button
+              onClick={handleUploadNew}
+              loading={uploading}
+              disabled={!uploadConfirmed || uploading}
+            >
+              <Upload className="h-4 w-4" />
+              업로드
+            </Button>
+          </div>
+        </Modal>
       )}
     </div>
   )

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Check, FileVideo, Languages, Loader2, RefreshCw, Search, Upload } from 'lucide-react'
 import { Badge, Button, Card, CardTitle, Input, Modal, Select, Toggle } from '@/components/ui'
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
@@ -71,12 +71,9 @@ export function MetadataLocalizationTool() {
   const [uploadPrivacy, setUploadPrivacy] = useState<PrivacyStatus>(defaultPrivacy)
   const [uploadMadeForKids, setUploadMadeForKids] = useState(false)
   const [uploadConfirmed, setUploadConfirmed] = useState(false)
-  useEffect(() => {
-    // 사용자가 /youtube에서 기본 공개 설정을 바꾸면 모달 미열림 상태에서 동기화.
-    if (!showUploadModal) setUploadPrivacy(defaultPrivacy)
-  }, [defaultPrivacy, showUploadModal])
 
   const openUploadModal = () => {
+    // 모달 열 때마다 최신 store 값을 가져와 초기화 — 별도의 sync effect 불필요.
     setUploadPrivacy(defaultPrivacy)
     setUploadMadeForKids(false)
     setUploadConfirmed(false)

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Check, FileVideo, Languages, Loader2, RefreshCw, Search, Send, Upload } from 'lucide-react'
+import { Check, FileVideo, Languages, Loader2, RefreshCw, Search, Upload } from 'lucide-react'
 import { Badge, Button, Card, CardTitle, Input, Modal, Select, Toggle } from '@/components/ui'
 import { useChannelStats, useMyVideos } from '@/hooks/useYouTubeData'
 import { translateMetadata } from '@/lib/api-client/translate'
@@ -95,6 +95,14 @@ export function MetadataLocalizationTool() {
   const canTranslate = title.trim().length > 0 && targetLangs.length > 0
   const canApply = mode === 'existing' && videoId && title.trim().length > 0 && Object.keys(translations).length > 0
   const canUpload = mode === 'new' && videoFile && title.trim().length > 0 && Object.keys(translations).length > 0
+  /**
+   * 사용자가 선택한 대상 언어 모두에 대해 번역(title 채워짐)이 준비됐는지.
+   * 이 값이 true면 "업로드/적용" 버튼만, false면 "번역 생성" 버튼만 노출한다.
+   * 사용자가 새 언어를 추가하면 자연스럽게 false가 되어 다시 번역 생성으로 돌아간다.
+   */
+  const allTargetsTranslated =
+    targetLangs.length > 0 &&
+    targetLangs.every((code) => translations[code]?.title?.trim().length)
 
   const switchMode = (next: Mode) => {
     if (next === mode) return
@@ -562,16 +570,16 @@ export function MetadataLocalizationTool() {
         </div>
 
         <div className="mt-5 flex flex-wrap justify-end gap-2">
-          <Button
-            variant="outline"
-            onClick={handleTranslate}
-            loading={translating}
-            disabled={!canTranslate || translating}
-          >
-            <Languages className="h-4 w-4" />
-            번역 생성
-          </Button>
-          {mode === 'existing' ? (
+          {!allTargetsTranslated ? (
+            <Button
+              onClick={handleTranslate}
+              loading={translating}
+              disabled={!canTranslate || translating}
+            >
+              <Languages className="h-4 w-4" />
+              번역 생성
+            </Button>
+          ) : mode === 'existing' ? (
             <Button
               onClick={handleApply}
               loading={saving}
@@ -583,7 +591,6 @@ export function MetadataLocalizationTool() {
           ) : (
             <Button
               onClick={openUploadModal}
-              loading={uploading}
               disabled={!canUpload || uploading}
             >
               <Upload className="h-4 w-4" />
@@ -596,36 +603,11 @@ export function MetadataLocalizationTool() {
 
       {Object.keys(translations).length > 0 && (
         <Card>
-          <div className="mb-5 flex items-center justify-between gap-3">
-            <div>
-              <CardTitle>번역 검토</CardTitle>
-              <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
-                적용 전에 언어별 제목과 설명을 직접 수정할 수 있습니다.
-              </p>
-            </div>
-            {mode === 'existing' ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleApply}
-                loading={saving}
-                disabled={!canApply || saving}
-              >
-                <Send className="h-4 w-4" />
-                적용
-              </Button>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={openUploadModal}
-                loading={uploading}
-                disabled={!canUpload || uploading}
-              >
-                <Send className="h-4 w-4" />
-                업로드
-              </Button>
-            )}
+          <div className="mb-5">
+            <CardTitle>번역 검토</CardTitle>
+            <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+              적용 전에 언어별 제목과 설명을 직접 수정할 수 있습니다.
+            </p>
           </div>
 
           <div className="space-y-4">

--- a/src/hooks/useUserPreferencesSync.ts
+++ b/src/hooks/useUserPreferencesSync.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/authStore'
+import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
+import {
+  fetchUserPreferences,
+  saveUserPreferences,
+} from '@/lib/api-client/user-preferences'
+
+const SAVE_DEBOUNCE_MS = 800
+
+/**
+ * youtubeSettingsStore와 서버(/api/user/preferences) 간 양방향 동기화.
+ *
+ * 1. 사용자 uid 변경(로그인/로그아웃/계정 전환) 시 store를 즉시 reset → 잔존 데이터 노출 방지
+ * 2. 서버에서 preferences를 fetch해 store hydrate
+ * 3. 사용자가 store를 변경하면 debounced로 서버에 PUT
+ *
+ * Providers에서 1회 마운트하면 앱 전역에서 자동 동작.
+ */
+export function useUserPreferencesSync() {
+  const user = useAuthStore((s) => s.user)
+  const uid = user?.uid ?? null
+  const queryClient = useQueryClient()
+
+  const previousUidRef = useRef<string | null>(uid)
+  /** 서버에서 받은 값을 store에 주입하는 동안엔 PUT을 트리거하지 않도록 잠그는 플래그. */
+  const hydratingRef = useRef(false)
+
+  // ── 1. uid가 바뀌면 즉시 reset (서버 fetch 시작 전 stale 데이터 차단)
+  useEffect(() => {
+    if (previousUidRef.current !== uid) {
+      useYouTubeSettingsStore.getState().reset()
+      previousUidRef.current = uid
+      // 새 uid에 대한 캐시는 깨끗하게 시작
+      if (uid) queryClient.invalidateQueries({ queryKey: ['user-preferences', uid] })
+    }
+  }, [uid, queryClient])
+
+  // ── 2. 서버에서 preferences 가져오기 (uid별 캐시)
+  const { data: serverPrefs } = useQuery({
+    queryKey: ['user-preferences', uid],
+    queryFn: fetchUserPreferences,
+    enabled: !!uid,
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
+
+  // ── 2b. 받은 값을 store에 주입
+  useEffect(() => {
+    if (!serverPrefs) return
+    hydratingRef.current = true
+    const store = useYouTubeSettingsStore.getState()
+    store.setDefaultPrivacy(serverPrefs.defaultPrivacy)
+    store.setDefaultLanguage(serverPrefs.defaultLanguage)
+    store.setDefaultTags(serverPrefs.defaultTags)
+    // 다음 tick에 잠금 해제 — subscribe 콜백이 위 set 호출들을 처리한 뒤 PUT이 안 나가도록.
+    const handle = setTimeout(() => { hydratingRef.current = false }, 0)
+    return () => clearTimeout(handle)
+  }, [serverPrefs])
+
+  // ── 3. store 변경 → debounced 서버 PUT
+  const saveMutation = useMutation({ mutationFn: saveUserPreferences })
+
+  useEffect(() => {
+    if (!uid) return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let lastSerialized = ''
+
+    const unsubscribe = useYouTubeSettingsStore.subscribe((state) => {
+      if (hydratingRef.current) return
+      const next = {
+        defaultPrivacy: state.defaultPrivacy,
+        defaultLanguage: state.defaultLanguage,
+        defaultTags: state.defaultTags,
+      }
+      const serialized = JSON.stringify(next)
+      if (serialized === lastSerialized) return
+      lastSerialized = serialized
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        saveMutation.mutate(next)
+      }, SAVE_DEBOUNCE_MS)
+    })
+
+    return () => {
+      unsubscribe()
+      if (timer) clearTimeout(timer)
+    }
+  }, [uid, saveMutation])
+}

--- a/src/lib/api-client/user-preferences.ts
+++ b/src/lib/api-client/user-preferences.ts
@@ -1,0 +1,14 @@
+import { getJson, sendJson } from './shared'
+import type { UserPreferences } from '@/lib/validators/user-preferences'
+
+export type UserPreferencesPayload = Required<UserPreferences>
+
+export function fetchUserPreferences(): Promise<UserPreferencesPayload> {
+  return getJson<UserPreferencesPayload>('/api/user/preferences')
+}
+
+export function saveUserPreferences(
+  patch: UserPreferences,
+): Promise<UserPreferencesPayload> {
+  return sendJson<UserPreferencesPayload>('/api/user/preferences', 'PUT', patch)
+}

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -6,6 +6,8 @@ export {
   updateUserCredits,
   deductUserMinutes,
   addUserCredits,
+  getUserPreferencesRaw,
+  setUserPreferencesRaw,
 } from './users'
 
 export {

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -98,3 +98,22 @@ export async function addUserCredits(userId: string, minutes: number) {
     args: [minutes, userId],
   })
 }
+
+export async function getUserPreferencesRaw(userId: string): Promise<string | null> {
+  const db = getDb()
+  const result = await db.execute({
+    sql: 'SELECT preferences FROM users WHERE id = ?',
+    args: [userId],
+  })
+  const row = result.rows[0]
+  if (!row) return null
+  return (row.preferences as string | null) ?? null
+}
+
+export async function setUserPreferencesRaw(userId: string, preferences: string): Promise<void> {
+  const db = getDb()
+  await db.execute({
+    sql: `UPDATE users SET preferences = ?, updated_at = datetime('now') WHERE id = ?`,
+    args: [preferences, userId],
+  })
+}

--- a/src/lib/validators/user-preferences.ts
+++ b/src/lib/validators/user-preferences.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+/**
+ * 서버에 저장되는 사용자별 워크플로우 설정.
+ * youtubeSettingsStore와 동일한 형태 — UI는 이 값을 그대로 hydrate한다.
+ *
+ * 새 키 추가 시 이 스키마와 DEFAULT_USER_PREFERENCES, 그리고 클라이언트 store만 갱신하면 된다.
+ */
+export const userPreferencesSchema = z.object({
+  defaultPrivacy: z.enum(['public', 'unlisted', 'private']).optional(),
+  defaultLanguage: z.string().min(1).max(20).optional(),
+  defaultTags: z.array(z.string().max(100)).max(50).optional(),
+})
+
+export type UserPreferences = z.infer<typeof userPreferencesSchema>
+
+export const DEFAULT_USER_PREFERENCES: Required<UserPreferences> = {
+  defaultPrivacy: 'private',
+  defaultLanguage: 'ko',
+  defaultTags: ['Dubtube', 'AI더빙', 'dubbed'],
+}
+
+/** DB에서 읽은 raw JSON 문자열을 안전하게 파싱한다 — 깨졌거나 비어있으면 기본값 반환. */
+export function parseUserPreferences(raw: string | null): Required<UserPreferences> {
+  if (!raw) return { ...DEFAULT_USER_PREFERENCES, defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags] }
+  try {
+    const parsed = userPreferencesSchema.parse(JSON.parse(raw))
+    return {
+      defaultPrivacy: parsed.defaultPrivacy ?? DEFAULT_USER_PREFERENCES.defaultPrivacy,
+      defaultLanguage: parsed.defaultLanguage ?? DEFAULT_USER_PREFERENCES.defaultLanguage,
+      defaultTags: parsed.defaultTags ?? [...DEFAULT_USER_PREFERENCES.defaultTags],
+    }
+  } catch {
+    return { ...DEFAULT_USER_PREFERENCES, defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags] }
+  }
+}

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -1,7 +1,6 @@
 'use client'
 
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 interface YouTubeSettingsState {
@@ -19,18 +18,30 @@ interface YouTubeSettingsState {
   setDefaultPrivacy: (v: PrivacyStatus) => void
   setDefaultLanguage: (v: string) => void
   setDefaultTags: (v: string[]) => void
+  reset: () => void
 }
 
-export const useYouTubeSettingsStore = create<YouTubeSettingsState>()(
-  persist(
-    (set) => ({
-      defaultPrivacy: 'private',
-      defaultLanguage: 'ko',
-      defaultTags: ['Dubtube', 'AI더빙', 'dubbed'],
-      setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
-      setDefaultLanguage: (v) => set({ defaultLanguage: v }),
-      setDefaultTags: (v) => set({ defaultTags: v }),
-    }),
-    { name: 'dubtube-youtube-settings' },
-  ),
+const INITIAL_YOUTUBE_SETTINGS = {
+  defaultPrivacy: 'private' as PrivacyStatus,
+  defaultLanguage: 'ko',
+  defaultTags: ['Dubtube', 'AI더빙', 'dubbed'],
+}
+
+/**
+ * 인메모리 캐시. 서버(/api/user/preferences)가 source of truth이며,
+ * 로그인 직후 useUserPreferencesSync 훅이 hydrate한다.
+ * 사용자가 값을 바꾸면 동일 훅이 debounced PUT으로 서버에 반영한다.
+ *
+ * localStorage 영속화는 일부러 사용하지 않는다 — 다른 사용자가 같은 브라우저로
+ * 로그인했을 때 이전 사용자의 설정이 새는 것을 방지하기 위함.
+ */
+export const useYouTubeSettingsStore = create<YouTubeSettingsState>(
+  (set) => ({
+    ...INITIAL_YOUTUBE_SETTINGS,
+    setDefaultPrivacy: (v) => set({ defaultPrivacy: v }),
+    setDefaultLanguage: (v) => set({ defaultLanguage: v }),
+    setDefaultTags: (v) => set({ defaultTags: v }),
+    // 계정 전환 직후 서버에서 새 값을 받기 전, 이전 사용자 설정이 잠시 노출되지 않도록 초기값으로 되돌린다.
+    reset: () => set({ ...INITIAL_YOUTUBE_SETTINGS, defaultTags: [...INITIAL_YOUTUBE_SETTINGS.defaultTags] }),
+  }),
 )


### PR DESCRIPTION
## 요약

`MetadataLocalizationTool` 새 영상 업로드 흐름의 UX를 단계별로 정리하고, 사용자별 워크플로우 설정(공개 기본값·작성 언어·기본 태그)을 localStorage에서 서버 DB로 옮겨 계정/디바이스 무관 동기화.

## 포함 커밋

### 1. `babd4b3` 새 영상 업로드 전 확인 모달
- 업로드 직전 채널·대상 언어·태그·공개 범위·아동용을 한 화면에서 점검하는 모달
- 채널/대상 언어/태그는 읽기전용 표시
- 공개 범위는 `youtubeSettingsStore.defaultPrivacy`를 기본값으로 모달에서 변경 가능
- 아동용 토글, 기본 false
- 하단 체크박스 \"위 채널, 공개 범위, 태그, 아동용 등 설정들을 확인했으며 업로드는 진행합니다.\"를 켜야 업로드 버튼 활성화
- 기존 hardcoded `privacyStatus: 'private'` → 모달 선택 값으로 교체

### 2. `2f69743` 액션 버튼 단계별 토글
- 번역 끝나기 전: `번역 생성`만, 끝난 후: `업로드`(또는 `적용`)만
- `allTargetsTranslated` 도출(선택 대상 모두 title 채워졌는지) → 토글 트리거
- 사용자가 새 언어를 추가하면 자동으로 `번역 생성`으로 되돌아감
- Card 2(번역 검토) 헤더의 중복 액션 버튼 제거 — 액션은 Card 1로 통일
- 외부 `업로드` 버튼은 모달만 열고 실제 업로드는 모달 안 버튼만 트리거

### 3. `e984431` 이메일 노출 제거 → 채널명 + 구독자 수
- Topbar 우측 사용자 영역: 이메일 → 구독자 수
- TranslationEditStep `targetChannelLabel`: `user.email` → 채널명 · 구독자 수
- 채널 미연결 시 `user.displayName`으로 fallback
- `useChannelStats`는 React Query 5분 staleTime + uid 단위 캐시라 페이지 간 중복 fetch 없음

### 4. `38511ba` youtubeSettings 서버 저장
- `migrations/0004_user_preferences.sql`: `users.preferences TEXT NOT NULL DEFAULT '{}'` 컬럼 추가 (DB는 이미 적용 완료)
- DB queries: `getUserPreferencesRaw` / `setUserPreferencesRaw`
- validators: zod 스키마 + `parseUserPreferences` 안전 파싱
- `/api/user/preferences` GET/PUT (PUT은 기존 값에 머지 — 부분 업데이트 지원)
- `youtubeSettingsStore`에서 `persist` 제거(서버가 source of truth) + `reset` 액션 유지
- `useUserPreferencesSync` 훅: uid 변경 즉시 reset → 서버 fetch → store hydrate → store 변경을 800ms debounce로 PUT
- `Providers`에서 1회 mount

## 마이그레이션 안내

DB 마이그레이션은 본 PR 머지 시점이 아니라 **이미 프로덕션 Turso DB에 적용됨**(이전 작업 중 `npm run db:migrate`를 .env.local로 실행하면서 0004까지 함께 들어감). 컬럼은 `DEFAULT '{}'`라 기존 코드와 하위 호환 — 이 PR이 머지되기 전까지 DB만 앞서 있어도 안전.

머지 후 Vercel `main` 배포가 일어나면 신규 배포 인스턴스부터 GET/PUT으로 서버 동기화 시작.

## Test plan

### MetadataLocalizationTool — 업로드 흐름
- [ ] 영상 파일 + 제목/설명 입력, 대상 언어 선택 → \"번역 생성\"만 노출
- [ ] 번역 생성 클릭 → 모든 대상 번역 채워지면 \"번역 생성\" 사라지고 \"YouTube에 업로드\" 등장
- [ ] 새 언어 추가 → 다시 \"번역 생성\"으로 토글 복귀
- [ ] \"YouTube에 업로드\" 클릭 → 모달만 열림(업로드 X), 모달 안 \"업로드\" 버튼이 실제 업로드 트리거
- [ ] 모달 내 채널/대상 언어/태그 표시 확인, 공개 범위가 `/youtube`의 `defaultPrivacy`로 채워졌는지 확인
- [ ] 체크박스 미체크 시 모달 \"업로드\" 버튼 비활성화 확인

### 계정 표시
- [ ] Topbar 우측에 이메일 안 보이고 채널명 + 구독자 수 표시
- [ ] TranslationEditStep `채널` 행에 동일 포맷
- [ ] 채널 미연결 사용자에선 displayName fallback

### 서버 동기화
- [ ] `/youtube`에서 기본 태그 수정 → 800ms 후 DevTools에 PUT `/api/user/preferences` 떨어지는지
- [ ] 다른 브라우저/시크릿창에서 같은 계정 로그인 → 동일 값 자동 로드 확인
- [ ] 같은 브라우저에서 로그아웃 → 다른 계정 로그인 → 이전 사용자 설정이 새지 않고 새 계정 값 로드 확인
- [ ] 신규 사용자(첫 로그인) → DB에 row가 만들어지고 GET이 기본값(`['Dubtube','AI더빙','dubbed']`) 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)