### PR TITLE
설정 출시 언어 선택과 저장 방식 개선

### DIFF
--- a/migrations/0004_user_preferences.sql
+++ b/migrations/0004_user_preferences.sql
@@ -1,5 +1,5 @@
 -- 사용자별 워크플로우 설정을 서버에 저장.
 -- 클라이언트(localStorage) 의존을 줄이고, 같은 계정이면 어느 디바이스/브라우저든 동일 설정을 보장한다.
--- 현재 저장 대상: defaultPrivacy, defaultLanguage, defaultTags (youtubeSettingsStore).
+-- 현재 저장 대상: appLocale, metadataTargetPreset, metadataTargetLanguages, defaultPrivacy, defaultLanguage, defaultTags.
 -- 향후 새 키가 추가돼도 마이그레이션 없이 JSON 안에서 확장 가능.
 ALTER TABLE users ADD COLUMN preferences TEXT NOT NULL DEFAULT '{}';

--- a/src/app/[locale]/(app)/layout.tsx
+++ b/src/app/[locale]/(app)/layout.tsx
@@ -1,13 +1,25 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 import { Sidebar } from '@/components/layout/Sidebar'
 import { Topbar } from '@/components/layout/Topbar'
 import { ClientMessagesProvider } from '@/lib/i18n/clientMessages'
 import { appShellMessages } from '@/lib/i18n/client-messages/appShell'
+import { SESSION_COOKIE, verifySessionCookie } from '@/lib/auth/session-cookie'
+import { resolveAppLocale } from '@/lib/i18n/config'
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: Promise<{ locale: string }>
 }) {
+  const [{ locale }, cookieStore] = await Promise.all([params, cookies()])
+  const rawSession = cookieStore.get(SESSION_COOKIE)?.value
+  if (!rawSession || !(await verifySessionCookie(rawSession))) {
+    redirect(`/${resolveAppLocale(locale)}`)
+  }
+
   return (
     <ClientMessagesProvider messages={appShellMessages}>
       <div className="min-h-screen">

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -45,13 +45,14 @@ export async function PUT(req: NextRequest) {
     // 부분 업데이트 지원 — 기존 저장 값에 머지해 누락된 키는 유지한다.
     const existingRaw = await getUserPreferencesRaw(auth.session.uid)
     const existing = parseUserPreferences(existingRaw)
-    const next = {
+    const next = parseUserPreferences(JSON.stringify({
       appLocale: parsed.data.appLocale ?? existing.appLocale,
       metadataTargetPreset: parsed.data.metadataTargetPreset ?? existing.metadataTargetPreset,
+      metadataTargetLanguages: parsed.data.metadataTargetLanguages ?? existing.metadataTargetLanguages,
       defaultPrivacy: parsed.data.defaultPrivacy ?? existing.defaultPrivacy,
       defaultLanguage: parsed.data.defaultLanguage ?? existing.defaultLanguage,
       defaultTags: parsed.data.defaultTags ?? existing.defaultTags,
-    }
+    }))
     await setUserPreferencesRaw(auth.session.uid, JSON.stringify(next))
     return apiOk(next)
   } catch (err) {

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -145,7 +145,7 @@ function ScrollToTopOnNavigation() {
   return null
 }
 
-/** youtubeSettingsStore ↔ /api/user/preferences 양방향 동기화. QueryClientProvider 안쪽에서 mount되어야 함. */
+/** /api/user/preferences 서버 설정을 클라이언트 store에 hydrate한다. QueryClientProvider 안쪽에서 mount되어야 함. */
 function UserPreferencesSync() {
   useUserPreferencesSync()
   return null

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -11,7 +11,11 @@ import {
   ytUploadVideo,
 } from '@/lib/api-client/youtube'
 import type { MetadataTranslation } from '@/lib/api-client/translate'
-import { getMarketLanguagePreset, MARKET_LANGUAGE_PRESETS } from '@/lib/i18n/config'
+import {
+  getMarketLanguagePreset,
+  getMetadataTargetLanguageCodes,
+  METADATA_TARGET_PRESET_OPTIONS,
+} from '@/lib/i18n/config'
 import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
 import { useI18nStore } from '@/stores/i18nStore'
 import { useNotificationStore } from '@/stores/notificationStore'
@@ -22,15 +26,24 @@ import { cn } from '@/utils/cn'
 
 type Mode = 'new' | 'existing'
 
-function buildInitialTargets(presetId: string, sourceLang: string, exclude: Set<string> = new Set()) {
-  return getMarketLanguagePreset(presetId)
-    .languageCodes
+function buildInitialTargets(
+  presetId: string,
+  customLanguageCodes: readonly string[],
+  sourceLang: string,
+  exclude: Set<string> = new Set(),
+) {
+  return getMetadataTargetLanguageCodes(presetId, customLanguageCodes)
     .filter((code) => code !== sourceLang && !exclude.has(code))
 }
 
 export function MetadataLocalizationTool() {
   const addToast = useNotificationStore((state) => state.addToast)
-  const { metadataTargetPreset, setMetadataTargetPreset } = useI18nStore()
+  const {
+    metadataTargetPreset,
+    metadataTargetLanguages,
+    setMetadataTargetPreset,
+    setMetadataTargetLanguages,
+  } = useI18nStore()
   const appLocale = useAppLocale()
   const t = useLocaleText()
   const isEnglish = appLocale === 'en'
@@ -40,7 +53,7 @@ export function MetadataLocalizationTool() {
       ? `${language.flag} ${language.name} (${language.nativeName})`
       : `${language.flag} ${language.nativeName} (${language.name})`,
   }))
-  const presetOptions = MARKET_LANGUAGE_PRESETS.map((preset) => ({
+  const presetOptions = METADATA_TARGET_PRESET_OPTIONS.map((preset) => ({
     value: preset.id,
     label: t(preset.labelKey),
   }))
@@ -74,7 +87,7 @@ export function MetadataLocalizationTool() {
     setTags(parsed)
   }
   const [targetLangs, setTargetLangs] = useState<string[]>(
-    () => buildInitialTargets(metadataTargetPreset, defaultLanguage),
+    () => buildInitialTargets(metadataTargetPreset, metadataTargetLanguages, defaultLanguage),
   )
   const [translations, setTranslations] = useState<Record<string, MetadataTranslation>>({})
   /** 내 영상 모드에서 YouTube로부터 가져온 기존 localization 언어 코드 (Perso 코드 기준). */
@@ -137,7 +150,7 @@ export function MetadataLocalizationTool() {
     setTranslations({})
     setExistingLocalizationLangs(new Set())
     setMetadataLoaded(false)
-    setTargetLangs(buildInitialTargets(metadataTargetPreset, sourceLang))
+    setTargetLangs(buildInitialTargets(metadataTargetPreset, metadataTargetLanguages, sourceLang))
   }
 
   const handleLoadMetadata = async () => {
@@ -174,7 +187,7 @@ export function MetadataLocalizationTool() {
       setTranslations(normalizedTranslations)
 
       // 이미 번역된 언어는 picker 기본 선택에서 제외 — 사용자는 추가하고 싶은 것만 선택.
-      setTargetLangs(buildInitialTargets(metadataTargetPreset, nextSourceLang, existingPersoCodes))
+      setTargetLangs(buildInitialTargets(metadataTargetPreset, metadataTargetLanguages, nextSourceLang, existingPersoCodes))
       setMetadataLoaded(true)
 
       addToast({ type: 'success', title: t('features.metadata.components.metadataLocalizationTool.loadedYouTubeTitleAndDescription') })
@@ -490,7 +503,7 @@ export function MetadataLocalizationTool() {
             onChange={(event) => {
               const nextSourceLang = event.target.value
               setSourceLang(nextSourceLang)
-              setTargetLangs(buildInitialTargets(metadataTargetPreset, nextSourceLang, existingLocalizationLangs))
+              setTargetLangs(buildInitialTargets(metadataTargetPreset, metadataTargetLanguages, nextSourceLang, existingLocalizationLangs))
             }}
             options={languageOptions}
           />
@@ -499,8 +512,10 @@ export function MetadataLocalizationTool() {
             value={metadataTargetPreset}
             onChange={(event) => {
               const nextPreset = event.target.value
+              const nextTargetLanguages = getMetadataTargetLanguageCodes(nextPreset, metadataTargetLanguages)
               setMetadataTargetPreset(nextPreset)
-              setTargetLangs(buildInitialTargets(nextPreset, sourceLang, existingLocalizationLangs))
+              setMetadataTargetLanguages(nextTargetLanguages)
+              setTargetLangs(buildInitialTargets(nextPreset, nextTargetLanguages, sourceLang, existingLocalizationLangs))
             }}
             options={presetOptions}
           />

--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -1,13 +1,18 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
-import { Globe, Globe2, Loader2, Settings, Unlink, Video } from 'lucide-react'
-import { Card, CardTitle, Select, Button, Badge, Input } from '@/components/ui'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Check, Globe, Globe2, Languages, Loader2, Save, Settings, Unlink, Video } from 'lucide-react'
+import { Card, CardTitle, Select, Button, Badge, Input, Modal } from '@/components/ui'
 import {
   APP_LOCALE_LABELS,
   APP_LOCALES,
+  CUSTOM_METADATA_TARGET_PRESET,
+  getMarketLanguagePreset,
+  getMetadataTargetLanguageCodes,
   MARKET_LANGUAGE_PRESETS,
+  normalizeMetadataTargetLanguages,
   type AppLocale,
 } from '@/lib/i18n/config'
 import { useI18nStore } from '@/stores/i18nStore'
@@ -22,17 +27,55 @@ import { signInWithGoogle } from '@/lib/google-auth'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
 import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
+import { saveUserPreferences } from '@/lib/api-client/user-preferences'
 
 const APP_LOCALE_OPTIONS = APP_LOCALES.map((locale) => ({
   value: locale,
   label: `${APP_LOCALE_LABELS[locale].nativeLabel} / ${APP_LOCALE_LABELS[locale].label}`,
 }))
 
+function formatTags(tags: readonly string[]) {
+  return tags.join(', ')
+}
+
+function parseTagsInput(value: string): string[] {
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+}
+
+function sameLanguageSet(a: readonly string[], b: readonly string[]) {
+  if (a.length !== b.length) return false
+  const bSet = new Set(b)
+  return a.every((code) => bSet.has(code))
+}
+
+function orderLanguageCodes(codes: readonly string[]) {
+  const selected = new Set(codes)
+  return SUPPORTED_LANGUAGES
+    .filter((language) => selected.has(language.code))
+    .map((language) => language.code)
+}
+
+function resolvePresetForLanguageSet(languageCodes: readonly string[]) {
+  return MARKET_LANGUAGE_PRESETS.find((preset) => sameLanguageSet(preset.languageCodes, languageCodes))
+}
+
 export function SettingsClient() {
   const t = useLocaleText()
-  const { metadataTargetPreset, setAppLocale, setMetadataTargetPreset } = useI18nStore()
+  const {
+    metadataTargetPreset,
+    metadataTargetLanguages,
+    setAppLocale,
+    setMetadataTargetPreset,
+    setMetadataTargetLanguages,
+  } = useI18nStore()
   const { preference: themePreference, setPreference: setThemePreference } = useThemeStore()
   const appLocale = useAppLocale()
+  const user = useAuthStore((s) => s.user)
+  const queryClient = useQueryClient()
+  const addToast = useNotificationStore((state) => state.addToast)
   const {
     defaultPrivacy,
     defaultLanguage,
@@ -49,17 +92,54 @@ export function SettingsClient() {
       ? `${language.flag} ${language.name} (${language.nativeName})`
       : `${language.flag} ${language.nativeName} (${language.name})`,
   }))
-  const presetOptions = MARKET_LANGUAGE_PRESETS.map((preset) => ({
-    value: preset.id,
-    label: t(preset.labelKey),
-  }))
-  const [defaultTagsInput, setDefaultTagsInput] = useState(() => defaultTags.join(', '))
+  const [draftAppLocale, setDraftAppLocale] = useState<AppLocale>(appLocale)
+  const [draftDefaultPrivacy, setDraftDefaultPrivacy] = useState<PrivacyStatus>(defaultPrivacy)
+  const [draftDefaultLanguage, setDraftDefaultLanguage] = useState(defaultLanguage)
+  const [draftMetadataTargetPreset, setDraftMetadataTargetPreset] = useState(metadataTargetPreset)
+  const [draftMetadataTargetLanguages, setDraftMetadataTargetLanguages] = useState<string[]>(
+    () => getMetadataTargetLanguageCodes(metadataTargetPreset, metadataTargetLanguages),
+  )
+  const [defaultTagsInput, setDefaultTagsInput] = useState(() => formatTags(defaultTags))
+  const [languageModalOpen, setLanguageModalOpen] = useState(false)
+  const [modalLanguageCodes, setModalLanguageCodes] = useState<string[]>(
+    () => getMetadataTargetLanguageCodes(metadataTargetPreset, metadataTargetLanguages),
+  )
   const youtubeSectionRef = useRef<HTMLDivElement>(null)
 
-  const selectedPreset = MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === metadataTargetPreset)
-  const presetLanguages = selectedPreset
-    ? selectedPreset.languageCodes.map((code) => getLanguageByCode(code)).filter(Boolean)
-    : []
+  const draftTags = useMemo(() => parseTagsInput(defaultTagsInput), [defaultTagsInput])
+  const targetLanguageCodes = useMemo(
+    () => getMetadataTargetLanguageCodes(draftMetadataTargetPreset, draftMetadataTargetLanguages),
+    [draftMetadataTargetLanguages, draftMetadataTargetPreset],
+  )
+  const selectedPreset = getMarketLanguagePreset(draftMetadataTargetPreset)
+  const presetLanguages = targetLanguageCodes.map((code) => getLanguageByCode(code)).filter(Boolean)
+  const persistedPreferenceSnapshot = useMemo(() => ({
+    appLocale,
+    metadataTargetPreset,
+    metadataTargetLanguages: getMetadataTargetLanguageCodes(metadataTargetPreset, metadataTargetLanguages),
+    defaultPrivacy,
+    defaultLanguage,
+    defaultTags,
+  }), [appLocale, defaultLanguage, defaultPrivacy, defaultTags, metadataTargetLanguages, metadataTargetPreset])
+  const draftPreferenceSnapshot = useMemo(() => ({
+    appLocale: draftAppLocale,
+    metadataTargetPreset: draftMetadataTargetPreset,
+    metadataTargetLanguages: targetLanguageCodes,
+    defaultPrivacy: draftDefaultPrivacy,
+    defaultLanguage: draftDefaultLanguage,
+    defaultTags: draftTags,
+  }), [
+    draftAppLocale,
+    draftDefaultLanguage,
+    draftDefaultPrivacy,
+    draftMetadataTargetPreset,
+    draftTags,
+    targetLanguageCodes,
+  ])
+  const hasPendingPreferenceChanges = JSON.stringify(persistedPreferenceSnapshot) !== JSON.stringify(draftPreferenceSnapshot)
+  const selectedModalPresetId = resolvePresetForLanguageSet(modalLanguageCodes)?.id ?? null
+
+  const saveMutation = useMutation({ mutationFn: saveUserPreferences })
 
   useEffect(() => {
     if (new URLSearchParams(window.location.search).get('section') !== 'youtube') return
@@ -73,17 +153,65 @@ export function SettingsClient() {
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
-      setDefaultTagsInput(defaultTags.join(', '))
+      setDraftAppLocale(appLocale)
+      setDraftDefaultPrivacy(defaultPrivacy)
+      setDraftDefaultLanguage(defaultLanguage)
+      setDraftMetadataTargetPreset(metadataTargetPreset)
+      setDraftMetadataTargetLanguages(getMetadataTargetLanguageCodes(metadataTargetPreset, metadataTargetLanguages))
+      setDefaultTagsInput(formatTags(defaultTags))
     }, 0)
     return () => window.clearTimeout(timeout)
-  }, [defaultTags])
+  }, [appLocale, defaultLanguage, defaultPrivacy, defaultTags, metadataTargetLanguages, metadataTargetPreset])
 
-  const commitDefaultTags = () => {
-    const parsed = defaultTagsInput
-      .split(',')
-      .map((tag) => tag.trim())
-      .filter(Boolean)
-    setDefaultTags(parsed)
+  const openLaunchLanguageModal = () => {
+    setModalLanguageCodes(targetLanguageCodes)
+    setLanguageModalOpen(true)
+  }
+
+  const toggleModalLanguage = (code: string) => {
+    setModalLanguageCodes((current) => {
+      if (current.includes(code)) {
+        if (current.length <= 1) return current
+        return current.filter((item) => item !== code)
+      }
+      return orderLanguageCodes([...current, code])
+    })
+  }
+
+  const applyLanguagePreset = (languageCodes: readonly string[]) => {
+    setModalLanguageCodes(orderLanguageCodes(languageCodes))
+  }
+
+  const applyLaunchLanguages = () => {
+    const normalized = normalizeMetadataTargetLanguages(modalLanguageCodes)
+    const matchedPreset = resolvePresetForLanguageSet(normalized)
+    setDraftMetadataTargetLanguages(normalized)
+    setDraftMetadataTargetPreset(matchedPreset?.id ?? CUSTOM_METADATA_TARGET_PRESET)
+    setLanguageModalOpen(false)
+  }
+
+  const savePreferences = async () => {
+    try {
+      const saved = await saveMutation.mutateAsync(draftPreferenceSnapshot)
+      queryClient.setQueryData(['user-preferences', user?.uid ?? null], saved)
+      setDefaultPrivacy(saved.defaultPrivacy)
+      setDefaultLanguage(saved.defaultLanguage)
+      setDefaultTags(saved.defaultTags)
+      setAppLocale(saved.appLocale)
+      setMetadataTargetPreset(saved.metadataTargetPreset)
+      setMetadataTargetLanguages(saved.metadataTargetLanguages)
+      setDefaultTagsInput(formatTags(saved.defaultTags))
+      addToast({ type: 'success', title: t('settings.preferences.saved') })
+      if (saved.appLocale !== appLocale) {
+        localeRouter.replaceLocale(saved.appLocale)
+      }
+    } catch (error) {
+      addToast({
+        type: 'error',
+        title: t('settings.preferences.saveFailed'),
+        message: error instanceof Error ? error.message : t('common.unknownError'),
+      })
+    }
   }
 
   return (
@@ -104,11 +232,10 @@ export function SettingsClient() {
         <div className="grid gap-4 md:grid-cols-2">
           <Select
             label={t('settings.appLocale')}
-            value={appLocale}
+            value={draftAppLocale}
             onChange={(event) => {
               const nextLocale = event.target.value as AppLocale
-              setAppLocale(nextLocale)
-              localeRouter.replaceLocale(nextLocale)
+              setDraftAppLocale(nextLocale)
             }}
             options={APP_LOCALE_OPTIONS}
           />
@@ -124,14 +251,14 @@ export function SettingsClient() {
           />
           <Select
             label={t('settings.metadataLanguage')}
-            value={defaultLanguage}
-            onChange={(event) => setDefaultLanguage(event.target.value)}
+            value={draftDefaultLanguage}
+            onChange={(event) => setDraftDefaultLanguage(event.target.value)}
             options={languageOptions}
           />
           <Select
             label={t('app.app.youtube.page.defaultVisibility')}
-            value={defaultPrivacy}
-            onChange={(event) => setDefaultPrivacy(event.target.value as PrivacyStatus)}
+            value={draftDefaultPrivacy}
+            onChange={(event) => setDraftDefaultPrivacy(event.target.value as PrivacyStatus)}
             options={[
               { value: 'public', label: t('app.app.youtube.page.public') },
               { value: 'unlisted', label: t('app.app.youtube.page.unlisted') },
@@ -142,39 +269,139 @@ export function SettingsClient() {
             label={t('app.app.youtube.page.defaultTags')}
             value={defaultTagsInput}
             onChange={(event) => setDefaultTagsInput(event.target.value)}
-            onBlur={commitDefaultTags}
             placeholder={t('app.app.youtube.page.commaSeparatedEGDubtubeAIDubbingVlog')}
           />
-          <Select
-            label={t('settings.recommendedLanguageSet')}
-            value={metadataTargetPreset}
-            onChange={(event) => setMetadataTargetPreset(event.target.value)}
-            options={presetOptions}
-            className="md:col-span-2"
-          />
+          <div className="md:col-span-2">
+            <div className="mb-1.5 flex items-center justify-between gap-3">
+              <label className="block text-sm font-medium text-surface-700 dark:text-surface-300">
+                {t('settings.launchLanguageSelection')}
+              </label>
+              <Button type="button" variant="outline" size="sm" onClick={openLaunchLanguageModal}>
+                <Languages className="h-4 w-4" />
+                {t('settings.launchLanguageSelection.edit')}
+              </Button>
+            </div>
+            <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-850">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium text-surface-900 dark:text-surface-100">
+                    {t(selectedPreset.labelKey)}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-surface-600 dark:text-surface-300">
+                    {t('settings.launchLanguageSelection.selectedCount', { count: targetLanguageCodes.length })}
+                  </p>
+                </div>
+                <Badge variant="brand">{t(selectedPreset.labelKey)}</Badge>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {presetLanguages.map((language) => language && (
+                  <span
+                    key={language.code}
+                    className="max-w-full rounded-full bg-white px-2.5 py-1 text-xs font-medium text-surface-700 ring-1 ring-surface-200 dark:bg-surface-900 dark:text-surface-200 dark:ring-surface-700"
+                  >
+                    {language.flag} {isEnglish ? language.name : language.nativeName}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
 
-        {selectedPreset && (
-          <div className="mt-4 rounded-lg border border-surface-200 bg-surface-100/70 p-3 dark:border-surface-700 dark:bg-surface-850">
-            <p className="text-sm font-medium text-surface-800 dark:text-surface-100">
-              {t(selectedPreset.labelKey)}
+        {hasPendingPreferenceChanges && (
+          <div className="mt-4 flex flex-col gap-3 rounded-lg border border-brand-200 bg-brand-50 p-3 dark:border-brand-500/60 dark:bg-surface-850 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm font-medium text-brand-800 dark:text-surface-100">
+              {t('settings.preferences.unsavedChanges')}
             </p>
-            <p className="mt-1 text-xs leading-5 text-surface-600 dark:text-surface-300">
-              {t(selectedPreset.descriptionKey)}
-            </p>
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {presetLanguages.map((language) => language && (
-                <span
-                  key={language.code}
-                  className="max-w-full rounded-full bg-white px-2.5 py-1 text-xs font-medium text-surface-700 ring-1 ring-surface-200 dark:bg-surface-900 dark:text-surface-200 dark:ring-surface-700"
-                >
-                  {language.flag} {isEnglish ? language.name : language.nativeName}
-                </span>
-              ))}
-            </div>
+            <Button onClick={savePreferences} loading={saveMutation.isPending} className="w-full sm:w-auto">
+              <Save className="h-4 w-4" />
+              {t('settings.preferences.saveChanges')}
+            </Button>
           </div>
         )}
       </Card>
+
+      <Modal
+        open={languageModalOpen}
+        onClose={() => setLanguageModalOpen(false)}
+        title={t('settings.launchLanguages.modalTitle')}
+        size="xl"
+      >
+        <div className="space-y-5">
+          <div>
+            <p className="mb-2 text-sm font-medium text-surface-800 dark:text-surface-100">
+              {t('settings.launchLanguages.presets')}
+            </p>
+            <div className="grid gap-2 md:grid-cols-3">
+              {MARKET_LANGUAGE_PRESETS.map((preset) => {
+                const active = selectedModalPresetId === preset.id
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => applyLanguagePreset(preset.languageCodes)}
+                    className={`rounded-lg border p-3 text-left transition focus-ring ${
+                      active
+                        ? 'border-brand-500 bg-brand-50 text-brand-900 dark:border-brand-400 dark:bg-surface-800 dark:text-surface-50'
+                        : 'border-surface-200 bg-white text-surface-800 hover:bg-surface-50 dark:border-surface-600 dark:bg-surface-850 dark:text-surface-100 dark:hover:bg-surface-800'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-semibold">{t(preset.labelKey)}</span>
+                      {active && <Check className="h-4 w-4" />}
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-surface-600 dark:text-surface-300">
+                      {t(preset.descriptionKey)}
+                    </p>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <p className="text-sm font-medium text-surface-800 dark:text-surface-100">
+                {t('settings.launchLanguages.allLanguages')}
+              </p>
+              <Badge variant="brand">
+                {t('settings.launchLanguageSelection.selectedCount', { count: modalLanguageCodes.length })}
+              </Badge>
+            </div>
+            <div className="grid max-h-[320px] gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+              {SUPPORTED_LANGUAGES.map((language) => {
+                const selected = modalLanguageCodes.includes(language.code)
+                return (
+                  <button
+                    key={language.code}
+                    type="button"
+                    onClick={() => toggleModalLanguage(language.code)}
+                    className={`flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-sm transition focus-ring ${
+                      selected
+                        ? 'border-brand-400 bg-brand-50 text-brand-800 dark:border-brand-400 dark:bg-surface-800 dark:text-surface-50'
+                        : 'border-surface-200 bg-white text-surface-700 hover:bg-surface-50 dark:border-surface-600 dark:bg-surface-850 dark:text-surface-200 dark:hover:bg-surface-800'
+                    }`}
+                  >
+                    <span className="min-w-0 truncate">
+                      {language.flag} {isEnglish ? `${language.name} (${language.nativeName})` : `${language.nativeName} (${language.name})`}
+                    </span>
+                    {selected && <Check className="h-4 w-4 shrink-0" />}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={() => setLanguageModalOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="button" onClick={applyLaunchLanguages}>
+              <Check className="h-4 w-4" />
+              {t('settings.launchLanguages.applySelection')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
       <div ref={youtubeSectionRef} id="youtube-settings" className="scroll-mt-20">
         <YouTubeConnectionCard />

--- a/src/hooks/useUserPreferencesSync.ts
+++ b/src/hooks/useUserPreferencesSync.ts
@@ -1,25 +1,20 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useI18nStore } from '@/stores/i18nStore'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
-import {
-  fetchUserPreferences,
-  saveUserPreferences,
-} from '@/lib/api-client/user-preferences'
-
-const SAVE_DEBOUNCE_MS = 800
+import { fetchUserPreferences } from '@/lib/api-client/user-preferences'
 
 /**
- * youtubeSettingsStore와 서버(/api/user/preferences) 간 양방향 동기화.
+ * youtubeSettingsStore와 i18nStore에 서버(/api/user/preferences) 설정을 주입한다.
  *
  * 1. 사용자 uid 변경(로그인/로그아웃/계정 전환) 시 store를 즉시 reset → 잔존 데이터 노출 방지
  * 2. 서버에서 preferences를 fetch해 store hydrate
- * 3. 사용자가 store를 변경하면 debounced로 서버에 PUT
  *
- * Providers에서 1회 마운트하면 앱 전역에서 자동 동작.
+ * 저장은 설정 화면에서 명시적으로 수행한다. 태그 입력 중 자동 PUT이 발생하지 않도록
+ * 이 훅은 더 이상 store 변경을 서버로 autosave하지 않는다.
  */
 export function useUserPreferencesSync() {
   const user = useAuthStore((s) => s.user)
@@ -27,8 +22,6 @@ export function useUserPreferencesSync() {
   const queryClient = useQueryClient()
 
   const previousUidRef = useRef<string | null>(uid)
-  /** 서버에서 받은 값을 store에 주입하는 동안엔 PUT을 트리거하지 않도록 잠그는 플래그. */
-  const hydratingRef = useRef(false)
 
   // ── 1. uid가 바뀌면 즉시 reset (서버 fetch 시작 전 stale 데이터 차단)
   useEffect(() => {
@@ -52,7 +45,6 @@ export function useUserPreferencesSync() {
   // ── 2b. 받은 값을 store에 주입
   useEffect(() => {
     if (!serverPrefs) return
-    hydratingRef.current = true
     const store = useYouTubeSettingsStore.getState()
     store.setDefaultPrivacy(serverPrefs.defaultPrivacy)
     store.setDefaultLanguage(serverPrefs.defaultLanguage)
@@ -60,52 +52,6 @@ export function useUserPreferencesSync() {
     const i18nStore = useI18nStore.getState()
     i18nStore.setAppLocale(serverPrefs.appLocale)
     i18nStore.setMetadataTargetPreset(serverPrefs.metadataTargetPreset)
-    // 다음 tick에 잠금 해제 — subscribe 콜백이 위 set 호출들을 처리한 뒤 PUT이 안 나가도록.
-    const handle = setTimeout(() => { hydratingRef.current = false }, 0)
-    return () => clearTimeout(handle)
+    i18nStore.setMetadataTargetLanguages(serverPrefs.metadataTargetLanguages)
   }, [serverPrefs])
-
-  // ── 3. store 변경 → debounced 서버 PUT
-  const saveMutation = useMutation({ mutationFn: saveUserPreferences })
-
-  useEffect(() => {
-    if (!uid) return
-    let timer: ReturnType<typeof setTimeout> | null = null
-    let lastSerialized = ''
-
-    const readSnapshot = () => {
-      const youtubeState = useYouTubeSettingsStore.getState()
-      const i18nState = useI18nStore.getState()
-      return {
-        appLocale: i18nState.appLocale,
-        metadataTargetPreset: i18nState.metadataTargetPreset,
-        defaultPrivacy: youtubeState.defaultPrivacy,
-        defaultLanguage: youtubeState.defaultLanguage,
-        defaultTags: youtubeState.defaultTags,
-      }
-    }
-
-    lastSerialized = JSON.stringify(readSnapshot())
-
-    const scheduleSave = () => {
-      if (hydratingRef.current) return
-      const next = readSnapshot()
-      const serialized = JSON.stringify(next)
-      if (serialized === lastSerialized) return
-      lastSerialized = serialized
-      if (timer) clearTimeout(timer)
-      timer = setTimeout(() => {
-        saveMutation.mutate(next)
-      }, SAVE_DEBOUNCE_MS)
-    }
-
-    const unsubscribeYoutube = useYouTubeSettingsStore.subscribe(scheduleSave)
-    const unsubscribeI18n = useI18nStore.subscribe(scheduleSave)
-
-    return () => {
-      unsubscribeYoutube()
-      unsubscribeI18n()
-      if (timer) clearTimeout(timer)
-    }
-  }, [uid, saveMutation])
 }

--- a/src/lib/i18n/client-messages/common.ts
+++ b/src/lib/i18n/client-messages/common.ts
@@ -236,6 +236,11 @@ export const commonMessages = {
     en: 'Prioritize languages with large YouTube audiences and practical localization potential.',
   },
   'marketPreset.creatorGrowth.label': { ko: '크리에이터 추천 언어', en: 'Creator language picks' },
+  'marketPreset.custom.description': {
+    ko: '직접 선택한 출시 대상 언어를 사용합니다.',
+    en: 'Use your selected launch languages.',
+  },
+  'marketPreset.custom.label': { ko: '내 설정', en: 'My settings' },
   'marketPreset.globalBroad.description': {
     ko: '초기 성과가 확인된 뒤 유럽과 중동 주요 언어까지 확장합니다.',
     en: 'Expand into major European and Middle Eastern languages after initial traction.',
@@ -287,9 +292,53 @@ export const commonMessages = {
     ko: '언어, 테마 및 YouTube 기본값',
     en: 'Language, theme, and YouTube defaults',
   },
+  'settings.launchLanguages.allLanguages': {
+    ko: '언어 직접 선택',
+    en: 'Choose languages',
+  },
+  'settings.launchLanguages.applySelection': {
+    ko: '선택 적용',
+    en: 'Apply selection',
+  },
+  'settings.launchLanguages.modalTitle': {
+    ko: '출시 언어 선택',
+    en: 'Select launch languages',
+  },
+  'settings.launchLanguages.presets': {
+    ko: '빠른 선택',
+    en: 'Quick presets',
+  },
+  'settings.launchLanguageSelection': {
+    ko: '출시 언어 선택',
+    en: 'Launch languages',
+  },
+  'settings.launchLanguageSelection.edit': {
+    ko: '변경',
+    en: 'Edit',
+  },
+  'settings.launchLanguageSelection.selectedCount': {
+    ko: '{count}개 언어 선택됨',
+    en: '{count} languages selected',
+  },
   'settings.metadataLanguage': {
     ko: '제목·설명 작성 기본 언어',
     en: 'Default metadata source language',
+  },
+  'settings.preferences.saveChanges': {
+    ko: '변경사항 저장',
+    en: 'Save changes',
+  },
+  'settings.preferences.saved': {
+    ko: '설정을 저장했습니다.',
+    en: 'Settings saved.',
+  },
+  'settings.preferences.saveFailed': {
+    ko: '설정 저장 실패',
+    en: 'Could not save settings',
+  },
+  'settings.preferences.unsavedChanges': {
+    ko: '저장하지 않은 설정 변경사항이 있습니다.',
+    en: 'You have unsaved settings changes.',
   },
   'settings.recommendedLanguageSet': {
     ko: '추천 대상 언어 묶음',

--- a/src/lib/i18n/config.test.ts
+++ b/src/lib/i18n/config.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   APP_LOCALES,
+  CUSTOM_METADATA_TARGET_PRESET,
   DEFAULT_APP_LOCALE,
   DEFAULT_METADATA_TARGET_PRESET,
+  getMetadataTargetLanguageCodes,
   getMarketLanguagePreset,
   isAppLocale,
   MARKET_LANGUAGE_PRESETS,
+  normalizeMetadataTargetLanguages,
   resolveAppLocale,
 } from './config'
 
@@ -32,5 +35,14 @@ describe('i18n config', () => {
     ])
     expect(getMarketLanguagePreset(DEFAULT_METADATA_TARGET_PRESET).languageCodes).toContain('en')
     expect(getMarketLanguagePreset('missing').id).toBe(DEFAULT_METADATA_TARGET_PRESET)
+  })
+
+  it('uses custom metadata target languages when the custom preset is selected', () => {
+    expect(getMarketLanguagePreset(CUSTOM_METADATA_TARGET_PRESET).id).toBe(CUSTOM_METADATA_TARGET_PRESET)
+    expect(getMetadataTargetLanguageCodes(CUSTOM_METADATA_TARGET_PRESET, ['ja', 'en'])).toEqual(['ja', 'en'])
+    expect(getMetadataTargetLanguageCodes('creator-growth', ['ja'])).toEqual(
+      getMarketLanguagePreset('creator-growth').languageCodes,
+    )
+    expect(normalizeMetadataTargetLanguages(['en', 'en', 'ko'])).toEqual(['en', 'ko'])
   })
 })

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -91,6 +91,16 @@ export interface MarketLanguagePreset {
   languageCodes: string[]
 }
 
+export const CUSTOM_METADATA_TARGET_PRESET = 'custom'
+export const DEFAULT_METADATA_TARGET_LANGUAGES = ['ko', 'en']
+
+export const CUSTOM_MARKET_LANGUAGE_PRESET: MarketLanguagePreset = {
+  id: CUSTOM_METADATA_TARGET_PRESET,
+  labelKey: 'marketPreset.custom.label',
+  descriptionKey: 'marketPreset.custom.description',
+  languageCodes: [...DEFAULT_METADATA_TARGET_LANGUAGES],
+}
+
 export const MARKET_LANGUAGE_PRESETS: MarketLanguagePreset[] = [
   {
     id: 'core',
@@ -113,11 +123,44 @@ export const MARKET_LANGUAGE_PRESETS: MarketLanguagePreset[] = [
 ]
 
 export const DEFAULT_METADATA_TARGET_PRESET = 'creator-growth'
+export const METADATA_TARGET_PRESET_OPTIONS: MarketLanguagePreset[] = [
+  CUSTOM_MARKET_LANGUAGE_PRESET,
+  ...MARKET_LANGUAGE_PRESETS,
+]
+
+export function normalizeMetadataTargetLanguages(languageCodes: readonly string[] | null | undefined): string[] {
+  const normalized = Array.from(new Set(
+    (languageCodes ?? [])
+      .map((code) => code.trim())
+      .filter(Boolean),
+  ))
+  return normalized.length > 0 ? normalized : [...DEFAULT_METADATA_TARGET_LANGUAGES]
+}
+
+export function resolveMetadataTargetPresetId(id: string | null | undefined): string {
+  if (id === CUSTOM_METADATA_TARGET_PRESET) return CUSTOM_METADATA_TARGET_PRESET
+  return (
+    MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === id)?.id ??
+    DEFAULT_METADATA_TARGET_PRESET
+  )
+}
 
 export function getMarketLanguagePreset(id: string): MarketLanguagePreset {
+  if (id === CUSTOM_METADATA_TARGET_PRESET) return CUSTOM_MARKET_LANGUAGE_PRESET
   return (
     MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === id) ??
     MARKET_LANGUAGE_PRESETS.find((preset) => preset.id === DEFAULT_METADATA_TARGET_PRESET) ??
     MARKET_LANGUAGE_PRESETS[0]
   )
+}
+
+export function getMetadataTargetLanguageCodes(
+  presetId: string,
+  customLanguageCodes: readonly string[] | null | undefined = DEFAULT_METADATA_TARGET_LANGUAGES,
+): string[] {
+  const preset = getMarketLanguagePreset(presetId)
+  if (preset.id === CUSTOM_METADATA_TARGET_PRESET) {
+    return normalizeMetadataTargetLanguages(customLanguageCodes)
+  }
+  return [...preset.languageCodes]
 }

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -44,6 +44,50 @@ const baseMessages = {
     ko: '추천 대상 언어 묶음',
     en: 'Recommended language set',
   },
+  'settings.launchLanguageSelection': {
+    ko: '출시 언어 선택',
+    en: 'Launch languages',
+  },
+  'settings.launchLanguageSelection.edit': {
+    ko: '변경',
+    en: 'Edit',
+  },
+  'settings.launchLanguageSelection.selectedCount': {
+    ko: '{count}개 언어 선택됨',
+    en: '{count} languages selected',
+  },
+  'settings.launchLanguages.modalTitle': {
+    ko: '출시 언어 선택',
+    en: 'Select launch languages',
+  },
+  'settings.launchLanguages.presets': {
+    ko: '빠른 선택',
+    en: 'Quick presets',
+  },
+  'settings.launchLanguages.allLanguages': {
+    ko: '언어 직접 선택',
+    en: 'Choose languages',
+  },
+  'settings.launchLanguages.applySelection': {
+    ko: '선택 적용',
+    en: 'Apply selection',
+  },
+  'settings.preferences.unsavedChanges': {
+    ko: '저장하지 않은 설정 변경사항이 있습니다.',
+    en: 'You have unsaved settings changes.',
+  },
+  'settings.preferences.saveChanges': {
+    ko: '변경사항 저장',
+    en: 'Save changes',
+  },
+  'settings.preferences.saved': {
+    ko: '설정을 저장했습니다.',
+    en: 'Settings saved.',
+  },
+  'settings.preferences.saveFailed': {
+    ko: '설정 저장 실패',
+    en: 'Could not save settings',
+  },
   'components.layout.sidebar.labelSettings': { ko: '설정', en: 'Settings' },
   'components.layout.sidebar.appNavigation': { ko: '앱 메뉴', en: 'App navigation' },
   'components.layout.topbar.subscriberCount': { ko: '구독자 {count}', en: '{count} subscribers' },
@@ -62,6 +106,11 @@ const baseMessages = {
   'marketPreset.core.description': {
     ko: '국내 사용자를 우선으로 하되 영어권 시청자까지 바로 대응합니다.',
     en: 'Start with Korea-first operations while covering English-speaking viewers.',
+  },
+  'marketPreset.custom.label': { ko: '내 설정', en: 'My settings' },
+  'marketPreset.custom.description': {
+    ko: '직접 선택한 출시 대상 언어를 사용합니다.',
+    en: 'Use your selected launch languages.',
   },
   'marketPreset.creatorGrowth.label': { ko: '크리에이터 추천 언어', en: 'Creator language picks' },
   'marketPreset.creatorGrowth.description': {

--- a/src/lib/validators/user-preferences.ts
+++ b/src/lib/validators/user-preferences.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 import {
   APP_LOCALES,
   DEFAULT_APP_LOCALE,
+  DEFAULT_METADATA_TARGET_LANGUAGES,
   DEFAULT_METADATA_TARGET_PRESET,
+  normalizeMetadataTargetLanguages,
+  resolveMetadataTargetPresetId,
 } from '@/lib/i18n/config'
 
 /**
@@ -14,6 +17,7 @@ import {
 export const userPreferencesSchema = z.object({
   appLocale: z.enum(APP_LOCALES).optional(),
   metadataTargetPreset: z.string().min(1).max(80).optional(),
+  metadataTargetLanguages: z.array(z.string().max(20)).max(50).optional(),
   defaultPrivacy: z.enum(['public', 'unlisted', 'private']).optional(),
   defaultLanguage: z.string().min(1).max(20).optional(),
   defaultTags: z.array(z.string().max(100)).max(50).optional(),
@@ -24,6 +28,7 @@ export type UserPreferences = z.infer<typeof userPreferencesSchema>
 const DEFAULT_USER_PREFERENCES: Required<UserPreferences> = {
   appLocale: DEFAULT_APP_LOCALE,
   metadataTargetPreset: DEFAULT_METADATA_TARGET_PRESET,
+  metadataTargetLanguages: [...DEFAULT_METADATA_TARGET_LANGUAGES],
   defaultPrivacy: 'private',
   defaultLanguage: 'ko',
   defaultTags: ['Dubtube', 'AI더빙', 'dubbed'],
@@ -31,17 +36,32 @@ const DEFAULT_USER_PREFERENCES: Required<UserPreferences> = {
 
 /** DB에서 읽은 raw JSON 문자열을 안전하게 파싱한다 — 깨졌거나 비어있으면 기본값 반환. */
 export function parseUserPreferences(raw: string | null): Required<UserPreferences> {
-  if (!raw) return { ...DEFAULT_USER_PREFERENCES, defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags] }
+  if (!raw) {
+    return {
+      ...DEFAULT_USER_PREFERENCES,
+      metadataTargetLanguages: [...DEFAULT_USER_PREFERENCES.metadataTargetLanguages],
+      defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags],
+    }
+  }
   try {
     const parsed = userPreferencesSchema.parse(JSON.parse(raw))
     return {
       appLocale: parsed.appLocale ?? DEFAULT_USER_PREFERENCES.appLocale,
-      metadataTargetPreset: parsed.metadataTargetPreset ?? DEFAULT_USER_PREFERENCES.metadataTargetPreset,
+      metadataTargetPreset: resolveMetadataTargetPresetId(
+        parsed.metadataTargetPreset ?? DEFAULT_USER_PREFERENCES.metadataTargetPreset,
+      ),
+      metadataTargetLanguages: parsed.metadataTargetLanguages
+        ? normalizeMetadataTargetLanguages(parsed.metadataTargetLanguages)
+        : [...DEFAULT_USER_PREFERENCES.metadataTargetLanguages],
       defaultPrivacy: parsed.defaultPrivacy ?? DEFAULT_USER_PREFERENCES.defaultPrivacy,
       defaultLanguage: parsed.defaultLanguage ?? DEFAULT_USER_PREFERENCES.defaultLanguage,
       defaultTags: parsed.defaultTags ?? [...DEFAULT_USER_PREFERENCES.defaultTags],
     }
   } catch {
-    return { ...DEFAULT_USER_PREFERENCES, defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags] }
+    return {
+      ...DEFAULT_USER_PREFERENCES,
+      metadataTargetLanguages: [...DEFAULT_USER_PREFERENCES.metadataTargetLanguages],
+      defaultTags: [...DEFAULT_USER_PREFERENCES.defaultTags],
+    }
   }
 }

--- a/src/stores/i18nStore.ts
+++ b/src/stores/i18nStore.ts
@@ -4,8 +4,10 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import {
   DEFAULT_APP_LOCALE,
+  DEFAULT_METADATA_TARGET_LANGUAGES,
   DEFAULT_METADATA_TARGET_PRESET,
-  getMarketLanguagePreset,
+  normalizeMetadataTargetLanguages,
+  resolveMetadataTargetPresetId,
   resolveAppLocale,
   type AppLocale,
 } from '@/lib/i18n/config'
@@ -13,8 +15,10 @@ import {
 interface I18nState {
   appLocale: AppLocale
   metadataTargetPreset: string
+  metadataTargetLanguages: string[]
   setAppLocale: (locale: AppLocale) => void
   setMetadataTargetPreset: (presetId: string) => void
+  setMetadataTargetLanguages: (languageCodes: string[]) => void
 }
 
 export const useI18nStore = create<I18nState>()(
@@ -22,14 +26,19 @@ export const useI18nStore = create<I18nState>()(
     (set) => ({
       appLocale: DEFAULT_APP_LOCALE,
       metadataTargetPreset: DEFAULT_METADATA_TARGET_PRESET,
+      metadataTargetLanguages: [...DEFAULT_METADATA_TARGET_LANGUAGES],
       setAppLocale: (locale) => set({ appLocale: resolveAppLocale(locale) }),
-      setMetadataTargetPreset: (presetId) => set({ metadataTargetPreset: getMarketLanguagePreset(presetId).id }),
+      setMetadataTargetPreset: (presetId) => set({ metadataTargetPreset: resolveMetadataTargetPresetId(presetId) }),
+      setMetadataTargetLanguages: (languageCodes) => set({
+        metadataTargetLanguages: normalizeMetadataTargetLanguages(languageCodes),
+      }),
     }),
     {
       name: 'dubtube-i18n',
       partialize: (state) => ({
         appLocale: state.appLocale,
         metadataTargetPreset: state.metadataTargetPreset,
+        metadataTargetLanguages: state.metadataTargetLanguages,
       }),
       merge: (persisted, current) => {
         const state = persisted as Partial<I18nState> | undefined
@@ -37,7 +46,8 @@ export const useI18nStore = create<I18nState>()(
           ...current,
           ...state,
           appLocale: resolveAppLocale(state?.appLocale),
-          metadataTargetPreset: getMarketLanguagePreset(state?.metadataTargetPreset || DEFAULT_METADATA_TARGET_PRESET).id,
+          metadataTargetPreset: resolveMetadataTargetPresetId(state?.metadataTargetPreset || DEFAULT_METADATA_TARGET_PRESET),
+          metadataTargetLanguages: normalizeMetadataTargetLanguages(state?.metadataTargetLanguages),
         }
       },
       skipHydration: true,

--- a/src/stores/youtubeSettingsStore.ts
+++ b/src/stores/youtubeSettingsStore.ts
@@ -30,7 +30,7 @@ const INITIAL_YOUTUBE_SETTINGS = {
 /**
  * 인메모리 캐시. 서버(/api/user/preferences)가 source of truth이며,
  * 로그인 직후 useUserPreferencesSync 훅이 hydrate한다.
- * 사용자가 값을 바꾸면 동일 훅이 debounced PUT으로 서버에 반영한다.
+ * 저장은 설정 화면에서 명시적으로 수행한다.
  *
  * localStorage 영속화는 일부러 사용하지 않는다 — 다른 사용자가 같은 브라우저로
  * 로그인했을 때 이전 사용자의 설정이 새는 것을 방지하기 위함.


### PR DESCRIPTION
## 작업 내용
- 설정 화면에 출시 언어 선택 모달을 추가했습니다.
- 기본 출시, 크리에이터 추천 언어, 다국어 확장 프리셋과 직접 언어 선택을 지원합니다.
- 선택한 출시 언어를 사용자 선호 설정에 저장하도록 서버 스키마와 store를 확장했습니다.
- 태그/공개범위/기본 언어/출시 언어는 설정 화면의 저장 버튼으로만 서버에 저장되도록 변경했습니다.
- 메타데이터 번역 도구가 저장된 출시 언어 설정을 사용하도록 연동했습니다.
- 내부 앱 레이아웃에 서버 세션 가드를 추가해 미로그인 상태에서 앱 내부 페이지가 렌더링되지 않도록 했습니다.
- 설정 변경 배너와 출시 언어 모달의 다크 모드 대비를 보정했습니다.

## 검증
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #264