### PR TITLE
출시 전 업로드 및 운영 알림 보강

### DIFF
--- a/src/app/[locale]/(app)/layout.tsx
+++ b/src/app/[locale]/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { ClientMessagesProvider } from '@/lib/i18n/clientMessages'
 import { appShellMessages } from '@/lib/i18n/client-messages/appShell'
 import { SESSION_COOKIE, verifySessionCookie } from '@/lib/auth/session-cookie'
 import { resolveAppLocale } from '@/lib/i18n/config'
+import { isOperationsAdminFromCookies } from '@/lib/ops/admin'
 
 export default async function AppLayout({
   children,
@@ -19,13 +20,14 @@ export default async function AppLayout({
   if (!rawSession || !(await verifySessionCookie(rawSession))) {
     redirect(`/${resolveAppLocale(locale)}`)
   }
+  const isOpsAdmin = await isOperationsAdminFromCookies()
 
   return (
     <ClientMessagesProvider messages={appShellMessages}>
       <div className="min-h-screen">
-        <Sidebar />
+        <Sidebar isOpsAdmin={isOpsAdmin} />
         <div className="lg:ml-64">
-          <Topbar />
+          <Topbar isOpsAdmin={isOpsAdmin} />
           <main className="px-4 py-5 pb-24 sm:p-6 lg:pb-6">{children}</main>
         </div>
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -31,7 +31,7 @@ export function Sidebar({ isOpsAdmin = false }: { isOpsAdmin?: boolean }) {
   const pathname = usePathname()
   const activePathname = stripLocalePrefix(pathname || '/')
   const t = useLocaleText()
-  const opsAccess = useOperationsAccess()
+  const opsAccess = useOperationsAccess({ enabled: isOpsAdmin })
   const canViewOps = isOpsAdmin || opsAccess.data?.isOpsAdmin === true
   const visibleItems = navItems.filter((item) => !item.opsAdminOnly || canViewOps)
   const settingsLabel = t('components.layout.sidebar.labelSettings')

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -20,7 +20,7 @@ export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
   const { user, clear } = useAuthStore()
   const router = useLocaleRouter()
   const { data: channel } = useChannelStats()
-  const opsAccess = useOperationsAccess()
+  const opsAccess = useOperationsAccess({ enabled: isOpsAdmin })
   const locale = useAppLocale()
   const t = useLocaleText()
   const canViewOps = isOpsAdmin || opsAccess.data?.isOpsAdmin === true

--- a/src/features/ops/hooks/useOperationsAccess.ts
+++ b/src/features/ops/hooks/useOperationsAccess.ts
@@ -14,6 +14,10 @@ interface OperationsAccess {
 
 const OPS_ACCESS_QUERY_KEY = ['ops-access']
 
+interface UseOperationsAccessOptions {
+  enabled?: boolean
+}
+
 async function fetchOperationsAccess(): Promise<OperationsAccess> {
   const res = await fetch('/api/ops/alerts', { cache: 'no-store' })
 
@@ -32,15 +36,16 @@ async function fetchOperationsAccess(): Promise<OperationsAccess> {
   }
 }
 
-export function useOperationsAccess() {
+export function useOperationsAccess(options: UseOperationsAccessOptions = {}) {
   const user = useAuthStore((state) => state.user)
+  const enabled = Boolean(user) && (options.enabled ?? true)
 
   return useQuery({
     queryKey: OPS_ACCESS_QUERY_KEY,
     queryFn: fetchOperationsAccess,
-    enabled: !!user,
+    enabled,
     retry: false,
     staleTime: 30_000,
-    refetchInterval: 60_000,
+    refetchInterval: enabled ? 60_000 : false,
   })
 }

--- a/src/lib/dubbing/process.test.ts
+++ b/src/lib/dubbing/process.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { enqueueCompletedDubbingUpload } from './process'
+import {
+  getDubbingJobLanguageWorkItem,
+  updateJobLanguageCompleted,
+} from '@/lib/db/queries'
+import { persoFetch } from '@/lib/perso/client'
+import { enqueueYouTubeUpload } from '@/lib/upload-queue/enqueue'
+import { translateMetadata } from '@/lib/translate/gemini'
+
+vi.mock('@/lib/db/queries', () => ({
+  finalizeJobCredits: vi.fn(),
+  getDubbingJobLanguageWorkItem: vi.fn(),
+  getDubbingJobLanguageWorkItems: vi.fn(),
+  getJobLanguageTerminalSummary: vi.fn(),
+  updateJobLanguageCompleted: vi.fn(),
+  updateJobLanguageProgress: vi.fn(),
+  updateJobStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/perso/client', () => ({
+  persoFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/upload-queue/enqueue', () => ({
+  enqueueYouTubeUpload: vi.fn(),
+}))
+
+vi.mock('@/lib/translate/gemini', () => ({
+  translateMetadata: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@/lib/ops/observability', () => ({
+  recordOperationalEventSafe: vi.fn(),
+}))
+
+const uploadSettings = {
+  deliverableMode: 'newDubbedVideos' as const,
+  originalVideoUrl: null,
+  originalYouTubeUrl: null,
+  uploadSettings: {
+    autoUpload: false,
+    attachOriginalLink: false,
+    title: 'Base title',
+    description: 'Base description',
+    tags: ['dubtube'],
+    privacyStatus: 'private' as const,
+    uploadCaptions: false,
+    selfDeclaredMadeForKids: false,
+    containsSyntheticMedia: true,
+    uploadReviewConfirmed: true,
+    metadataLanguage: 'ko',
+  },
+}
+
+const workItem = {
+  jobId: 10,
+  userId: 'user-1',
+  videoTitle: 'Source video',
+  videoDurationMs: 120_000,
+  isShort: false,
+  spaceSeq: 7,
+  deliverableMode: 'newDubbedVideos' as const,
+  uploadSettings,
+  languageCode: 'en',
+  projectSeq: 99,
+  languageStatus: 'completed',
+  progress: 100,
+  progressReason: 'COMPLETED',
+  dubbedVideoUrl: null,
+  audioUrl: null,
+  srtUrl: null,
+  youtubeVideoId: null,
+  youtubeUploadStatus: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getDubbingJobLanguageWorkItem).mockResolvedValue(workItem)
+  vi.mocked(updateJobLanguageCompleted).mockResolvedValue()
+  vi.mocked(translateMetadata).mockResolvedValue({
+    en: { title: 'Translated title', description: 'Translated description' },
+  })
+  vi.mocked(enqueueYouTubeUpload).mockResolvedValue({ status: 'queued', queueId: 123 })
+})
+
+describe('enqueueCompletedDubbingUpload', () => {
+  it('uses target=dubbingVideo when target=all does not include the dubbed video URL', async () => {
+    vi.mocked(persoFetch).mockImplementation(async (_path, opts) => {
+      const target = opts?.query?.target
+      if (target === 'dubbingVideo') {
+        return { videoFile: { videoDownloadLink: '/files/dubbed.mp4' } }
+      }
+      if (target === 'all') {
+        return {
+          audioFile: { voiceAudioDownloadLink: '/files/voice.wav' },
+          srtFile: { translatedSubtitleDownloadLink: '/files/subtitle.srt' },
+        }
+      }
+      return {}
+    })
+
+    const result = await enqueueCompletedDubbingUpload(10, 'en', { force: true })
+
+    expect(result).toEqual({ status: 'queued', queueId: 123 })
+    expect(persoFetch).toHaveBeenCalledWith(
+      '/video-translator/api/v1/projects/99/spaces/7/download',
+      { baseURL: 'api', query: { target: 'dubbingVideo' } },
+    )
+    expect(updateJobLanguageCompleted).toHaveBeenCalledWith(10, 'en', {
+      dubbedVideoUrl: 'https://portal-media.perso.ai/files/dubbed.mp4',
+      audioUrl: 'https://portal-media.perso.ai/files/voice.wav',
+      srtUrl: 'https://portal-media.perso.ai/files/subtitle.srt',
+    })
+    expect(enqueueYouTubeUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 10,
+        langCode: 'en',
+        videoUrl: 'https://portal-media.perso.ai/files/dubbed.mp4',
+        title: 'Translated title',
+        resetFailed: true,
+      }),
+    )
+  })
+})

--- a/src/lib/dubbing/process.ts
+++ b/src/lib/dubbing/process.ts
@@ -11,7 +11,7 @@ import {
   type DubbingJobLanguageWorkItem,
 } from '@/lib/db/queries'
 import { persoFetch } from '@/lib/perso/client'
-import type { DownloadResponse, ProgressResponse } from '@/lib/perso/types'
+import type { DownloadResponse, DownloadTarget, ProgressResponse } from '@/lib/perso/types'
 import { getPersoFileUrl } from '@/lib/api-client/perso'
 import { enqueueYouTubeUpload } from '@/lib/upload-queue/enqueue'
 import { translateMetadata } from '@/lib/translate/gemini'
@@ -83,19 +83,43 @@ async function fetchProgress(item: DubbingJobLanguageWorkItem) {
   )
 }
 
-async function fetchDownloadLinks(item: DubbingJobLanguageWorkItem, target = 'all') {
+async function fetchDownloadLinks(item: DubbingJobLanguageWorkItem, target: DownloadTarget = 'all') {
   return persoFetch<DownloadResponse>(
     `/video-translator/api/v1/projects/${item.projectSeq}/spaces/${item.spaceSeq}/download`,
     { baseURL: 'api', query: { target } },
   )
 }
 
+async function tryFetchDownloadLinks(item: DubbingJobLanguageWorkItem, target: DownloadTarget) {
+  try {
+    return await fetchDownloadLinks(item, target)
+  } catch (err) {
+    logger.warn('perso download link fetch failed in dubbing worker', {
+      jobId: item.jobId,
+      langCode: item.languageCode,
+      target,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    })
+    return null
+  }
+}
+
 async function resolveCompletedAssets(item: DubbingJobLanguageWorkItem): Promise<CompletedAssets> {
-  const downloads = await fetchDownloadLinks(item, 'all')
+  const [dubbingDownloads, allDownloads] = await Promise.all([
+    tryFetchDownloadLinks(item, 'dubbingVideo'),
+    tryFetchDownloadLinks(item, 'all'),
+  ])
+  if (!dubbingDownloads && !allDownloads) {
+    throw new Error('Unable to fetch Perso download links')
+  }
+
   return {
-    dubbedVideoUrl: toAbsoluteUrl(downloads.videoFile?.videoDownloadLink),
-    audioUrl: toAbsoluteUrl(downloads.audioFile?.voiceAudioDownloadLink),
-    srtUrl: toAbsoluteUrl(downloads.srtFile?.translatedSubtitleDownloadLink),
+    dubbedVideoUrl: toAbsoluteUrl(
+      dubbingDownloads?.videoFile?.videoDownloadLink
+        ?? allDownloads?.videoFile?.videoDownloadLink,
+    ),
+    audioUrl: toAbsoluteUrl(allDownloads?.audioFile?.voiceAudioDownloadLink),
+    srtUrl: toAbsoluteUrl(allDownloads?.srtFile?.translatedSubtitleDownloadLink),
   }
 }
 

--- a/src/lib/i18n/client-messages/metadata.ts
+++ b/src/lib/i18n/client-messages/metadata.ts
@@ -63,7 +63,7 @@ export const metadataMessages = {
   "features.metadata.components.metadataLocalizationTool.uploadAndLocalizeNewVideo": { ko: "새 영상 업로드 번역", en: "Upload and localize new video" },
   "features.metadata.components.metadataLocalizationTool.uploadToYouTube": { ko: "YouTube에 업로드", en: "Upload to YouTube" },
   "features.metadata.components.metadataLocalizationTool.uploadWithTheseSettings": { ko: "설정대로 업로드", en: "Upload with these settings" },
-  "features.metadata.components.metadataLocalizationTool.useExistingVideo": { ko: "기존 영상 불러오기", en: "Use existing video" },
+  "features.metadata.components.metadataLocalizationTool.useExistingVideo": { ko: "내 영상 불러오기", en: "Load my videos" },
   "features.metadata.components.metadataLocalizationTool.usingYourDefaultLanguageValueIfThisIs": { ko: "사용자 기본 언어({nextSourceLang})로 설정했습니다. 실제와 다르면 위 \"원문 언어\" 드롭다운에서 변경하세요.", en: "Using your default language ({nextSourceLang}). If this is not correct, change the source language above." },
   "features.metadata.components.metadataLocalizationTool.valueExistingTranslationsCannotBeSelected": { ko: "기존 번역 {existingLocalizationLangsSize}개는 선택할 수 없습니다.", en: "{existingLocalizationLangsSize} existing translations cannot be selected." },
   "features.metadata.components.metadataLocalizationTool.valueSelected": { ko: "{targetLangsLength}개 선택", en: "{targetLangsLength} selected" },

--- a/src/lib/i18n/generatedMessages.ts
+++ b/src/lib/i18n/generatedMessages.ts
@@ -687,7 +687,7 @@ export const generatedMessages = {
   "features.metadata.components.metadataLocalizationTool.uploadAndLocalizeNewVideo": { ko: "새 영상 업로드 번역", en: "Upload and localize new video" },
   "features.metadata.components.metadataLocalizationTool.uploadToYouTube": { ko: "YouTube에 업로드", en: "Upload to YouTube" },
   "features.metadata.components.metadataLocalizationTool.uploadWithTheseSettings": { ko: "설정대로 업로드", en: "Upload with these settings" },
-  "features.metadata.components.metadataLocalizationTool.useExistingVideo": { ko: "기존 영상 불러오기", en: "Use existing video" },
+  "features.metadata.components.metadataLocalizationTool.useExistingVideo": { ko: "내 영상 불러오기", en: "Load my videos" },
   "features.metadata.components.metadataLocalizationTool.usingYourDefaultLanguageValueIfThisIs": { ko: "사용자 기본 언어({nextSourceLang})로 설정했습니다. 실제와 다르면 위 \"원문 언어\" 드롭다운에서 변경하세요.", en: "Using your default language ({nextSourceLang}). If this is not correct, change the source language above." },
   "features.metadata.components.metadataLocalizationTool.valueExistingTranslationsCannotBeSelected": { ko: "기존 번역 {existingLocalizationLangsSize}개는 선택할 수 없습니다.", en: "{existingLocalizationLangsSize} existing translations cannot be selected." },
   "features.metadata.components.metadataLocalizationTool.valueSelected": { ko: "{targetLangsLength}개 선택", en: "{targetLangsLength} selected" },

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -173,9 +173,33 @@ describe('fetchMyVideos', () => {
     })
   })
 
-  it('returns empty array when uploads playlist is missing', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({ items: [{}] }))
-    expect(await fetchMyVideos('tok')).toEqual([])
+  it('falls back to search when uploads playlist is missing', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ items: [{}] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{
+            id: { videoId: 'v-search' },
+            snippet: {
+              title: 'Search video',
+              publishedAt: '2026-02-01',
+              thumbnails: { medium: { url: 'http://search-thumb' } },
+            },
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ id: 'v-search', status: { privacyStatus: 'unlisted' } }] }),
+      )
+    expect(await fetchMyVideos('tok')).toEqual([{
+      videoId: 'v-search',
+      title: 'Search video',
+      thumbnail: 'http://search-thumb',
+      publishedAt: '2026-02-01',
+      privacyStatus: 'unlisted',
+    }])
+    expect(String(mockFetch.mock.calls[1][0])).toContain('/youtube/v3/search?')
+    expect(String(mockFetch.mock.calls[1][0])).toContain('forMine=true')
   })
 
   it('handles undefined items in response', async () => {
@@ -183,6 +207,7 @@ describe('fetchMyVideos', () => {
       .mockResolvedValueOnce(
         jsonResponse({ items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }] }),
       )
+      .mockResolvedValueOnce(jsonResponse({}))
       .mockResolvedValueOnce(jsonResponse({}))
     expect(await fetchMyVideos('tok')).toEqual([])
   })
@@ -217,6 +242,40 @@ describe('fetchMyVideos', () => {
       code: 'MY_VIDEOS_FAILED',
     })
     await expect(promise).rejects.toThrow(/quota/)
+  })
+
+  it('falls back to search when uploads playlist request fails for non-quota errors', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ contentDetails: { relatedPlaylists: { uploads: 'UU1' } } }] }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: { message: 'playlist forbidden' } }, 403))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{
+            id: { videoId: 'v2' },
+            snippet: {
+              title: 'Fallback',
+              publishedAt: '2026-03-01',
+              thumbnails: { default: { url: 'http://fallback-thumb' } },
+            },
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ id: 'v2', status: { privacyStatus: 'private' } }] }),
+      )
+
+    const vids = await fetchMyVideos('tok')
+
+    expect(vids).toEqual([{
+      videoId: 'v2',
+      title: 'Fallback',
+      thumbnail: 'http://fallback-thumb',
+      publishedAt: '2026-03-01',
+      privacyStatus: 'private',
+    }])
+    expect(String(mockFetch.mock.calls[2][0])).toContain('/youtube/v3/search?')
   })
 })
 

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -11,30 +11,48 @@ async function youtubeResponseError(
   code: string,
 ): Promise<YouTubeError> {
   const body = await res.text().catch(() => '')
+  return youtubeErrorFromBody(res.status, body, fallbackMessage, code)
+}
+
+function parseYouTubeErrorBody(body: string): {
+  reason?: string
+  message?: string
+} {
+  if (!body) return {}
+
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: {
+        message?: string
+        errors?: Array<{ reason?: string }>
+      }
+    }
+    return {
+      reason: parsed.error?.errors?.[0]?.reason,
+      message: parsed.error?.message,
+    }
+  } catch {
+    return {}
+  }
+}
+
+function youtubeErrorFromBody(
+  status: number,
+  body: string,
+  fallbackMessage: string,
+  code: string,
+): YouTubeError {
+  const parsed = parseYouTubeErrorBody(body)
   let message = fallbackMessage
 
-  if (body) {
-    try {
-      const parsed = JSON.parse(body) as {
-        error?: {
-          message?: string
-          errors?: Array<{ reason?: string }>
-        }
-      }
-      const reason = parsed.error?.errors?.[0]?.reason
-      const googleMessage = parsed.error?.message
-      if (reason === 'quotaExceeded') {
-        message =
-          'YouTube API quota가 초과되어 내 영상을 불러올 수 없습니다. quota가 리셋된 뒤 다시 시도해주세요.'
-      } else if (googleMessage) {
-        message = fallbackMessage
-      }
-    } catch {
-      message = fallbackMessage
-    }
+  if (parsed.reason === 'quotaExceeded') {
+    message =
+      'YouTube API quota가 초과되어 내 영상을 불러올 수 없습니다. quota가 리셋된 뒤 다시 시도해주세요.'
+  } else if (parsed.message) {
+    message = fallbackMessage
   }
 
-  return new YouTubeError(res.status, message, code)
+  return new YouTubeError(status, message, code)
 }
 
 export async function fetchVideoStatistics(
@@ -131,18 +149,24 @@ export async function fetchMyVideos(
     }>
   }
   const uploadsPlaylistId = channelData.items?.[0]?.contentDetails?.relatedPlaylists?.uploads
-  if (!uploadsPlaylistId) return []
+  if (!uploadsPlaylistId) return fetchMyVideosBySearch(accessToken, maxResults)
 
   const res = await fetch(
     `${YOUTUBE_API_BASE}/youtube/v3/playlistItems?part=snippet&playlistId=${encodeURIComponent(uploadsPlaylistId)}&maxResults=${maxResults}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
   if (!res.ok) {
-    throw await youtubeResponseError(
-      res,
-      'YouTube 영상 목록을 불러오지 못했습니다',
-      'MY_VIDEOS_FAILED',
-    )
+    const body = await res.text().catch(() => '')
+    const parsed = parseYouTubeErrorBody(body)
+    if (parsed.reason === 'quotaExceeded') {
+      throw youtubeErrorFromBody(
+        res.status,
+        body,
+        'YouTube 영상 목록을 불러오지 못했습니다',
+        'MY_VIDEOS_FAILED',
+      )
+    }
+    return fetchMyVideosBySearch(accessToken, maxResults)
   }
 
   const data = (await res.json()) as {
@@ -169,9 +193,67 @@ export async function fetchMyVideos(
     })
     .filter((item): item is Omit<MyVideoItem, 'privacyStatus'> => item !== null)
 
+  if (base.length === 0) return fetchMyVideosBySearch(accessToken, maxResults)
+
   // playlistItems.list does not include privacy status, so fetch it separately.
   const privacyById = await fetchPrivacyStatuses(accessToken, base.map((v) => v.videoId))
 
+  return base.map((v) => ({
+    ...v,
+    privacyStatus: privacyById.get(v.videoId) ?? 'unknown',
+  }))
+}
+
+async function fetchMyVideosBySearch(
+  accessToken: string,
+  maxResults: number,
+): Promise<MyVideoItem[]> {
+  const params = new URLSearchParams({
+    part: 'snippet',
+    forMine: 'true',
+    type: 'video',
+    order: 'date',
+    maxResults: String(maxResults),
+  })
+  const res = await fetch(
+    `${YOUTUBE_API_BASE}/youtube/v3/search?${params}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  )
+  if (!res.ok) {
+    throw await youtubeResponseError(
+      res,
+      'YouTube 영상 목록을 불러오지 못했습니다',
+      'MY_VIDEOS_FAILED',
+    )
+  }
+
+  const data = (await res.json()) as {
+    items?: Array<{
+      id?: { videoId?: string }
+      snippet?: {
+        title?: string
+        publishedAt?: string
+        thumbnails?: {
+          medium?: { url?: string }
+          default?: { url?: string }
+        }
+      }
+    }>
+  }
+  const base = (data.items || [])
+    .map((item) => {
+      const videoId = item.id?.videoId
+      if (!videoId) return null
+      return {
+        videoId,
+        title: item.snippet?.title || '',
+        thumbnail: item.snippet?.thumbnails?.medium?.url || item.snippet?.thumbnails?.default?.url || '',
+        publishedAt: item.snippet?.publishedAt || '',
+      }
+    })
+    .filter((item): item is Omit<MyVideoItem, 'privacyStatus'> => item !== null)
+
+  const privacyById = await fetchPrivacyStatuses(accessToken, base.map((v) => v.videoId))
   return base.map((v) => ({
     ...v,
     privacyStatus: privacyById.get(v.videoId) ?? 'unknown',


### PR DESCRIPTION
## 변경 내용
- 제목/설명 탭의 기존 영상 불러오기 문구를 내 영상 불러오기로 변경했습니다.
- YouTube 업로드 영상 목록 조회에서 업로드 재생목록을 사용할 수 없거나 비어 있는 경우 `search.list(forMine=true)`로 보강했습니다.
- 새 더빙 영상 업로드 큐 예약 시 Perso `target=all`에 영상 URL이 없으면 `target=dubbingVideo`까지 조회하도록 보강했습니다.
- ops 관리자가 아닌 계정은 탑바/사이드바에서 `/api/ops/alerts` 호출을 아예 하지 않도록 변경했습니다.

## 원인
- YouTube 채널의 uploads playlist 조회가 비어 있거나 실패하면 내 영상 목록이 비어 보일 수 있었습니다.
- Perso 다운로드 링크가 `all` 응답이 아니라 `dubbingVideo` 응답에만 있는 경우 `missing_video_url`로 업로드 큐 예약이 실패했습니다.
- 기존 ops 접근 확인 훅이 모든 로그인 사용자에게 alerts API를 호출해 비관리자 계정에서 403 로그가 노출됐습니다.

## 검증
- `npm test -- src/lib/youtube/server.test.ts`
- `npm test -- src/lib/dubbing/process.test.ts`
- `npm test -- src/app/api/ops/ops-routes.test.ts src/app/api/dashboard/dashboard-routes.test.ts src/lib/dubbing/process.test.ts`
- `npm run typecheck`
- 관련 파일 ESLint
- `npm run build`
