### PR TITLE
fix: 결과창 YouTube 미리보기 차단 해결 (CSP frame-src 추가)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@ const cspDirectives = [
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self' https://accounts.google.com",
+  "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
   "frame-ancestors 'none'",
   "upgrade-insecure-requests",
 ].join('; ');


### PR DESCRIPTION
Closes #277

## 변경 사항

- `next.config.ts`의 `cspDirectives`에 `frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com` 디렉티브를 추가했습니다.
- `frame-ancestors 'none'`는 그대로 유지하여, 다른 사이트가 우리 페이지를 iframe으로 임베드하지 못하게 막는 정책은 보존했습니다.

## 사용자 영향

- 결과창(`SubtitleScriptEditor`)의 YouTube 영상 미리보기에서 더 이상 "이 콘텐츠는 차단되어 있습니다" 메시지가 노출되지 않고 영상이 정상 재생됩니다.
- 콘솔의 `Framing 'https://www.youtube.com/' violates the following Content Security Policy directive` 에러가 사라집니다.
- 허용 도메인은 `youtube.com`과 `youtube-nocookie.com` 두 개뿐이며, 그 외 임의 외부 iframe은 여전히 차단됩니다.

## 검증

- [ ] 업로드 완료 후 결과창에서 YouTube 영상 미리보기가 정상 재생
- [ ] 브라우저 콘솔에 CSP 차단 에러 없음
- [ ] `npm run typecheck` 통과
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)