### PR TITLE
release: 결과창 YouTube 미리보기 CSP 핫픽스 (#278)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@ const cspDirectives = [
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self' https://accounts.google.com",
+  "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
   "frame-ancestors 'none'",
   "upgrade-insecure-requests",
 ].join('; ');


### PR DESCRIPTION
직전 릴리스(#276) 이후 develop에 머지된 핫픽스를 main에 반영합니다.

## 포함된 PR

- #278 — fix: 결과창 YouTube 미리보기 차단 해결 (CSP `frame-src` 추가) — Closes #277

## 사용자 영향

- 결과창(`SubtitleScriptEditor`)의 YouTube 영상 미리보기에서 "이 콘텐츠는 차단되어 있습니다" 메시지가 더 이상 노출되지 않고 영상이 정상 재생됩니다.
- 콘솔의 `Framing 'https://www.youtube.com/' violates the following Content Security Policy directive` 에러가 사라집니다.
- 허용 도메인은 `youtube.com`과 `youtube-nocookie.com` 두 개로 한정되어, 그 외 임의 iframe은 여전히 차단됩니다.
- `frame-ancestors 'none'`은 그대로 유지되어 외부 사이트가 우리 페이지를 임베드하지 못하는 정책은 보존됩니다.

## QA 체크리스트

- [ ] 운영(main) 빌드 후 결과창에서 YouTube 영상 미리보기 정상 재생
- [ ] 브라우저 콘솔에 CSP 차단 에러 없음
- [ ] 다른 도메인 iframe(예: 임의 외부 URL)은 여전히 차단되는지 회귀 점검
- [ ] Vercel 배포 후 `/api/health` 스모크 시나리오 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)