### PR TITLE
fix: 원본+자막 업로드 모드에서 저장된 태그 기본값 복원

### DIFF
--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -19,6 +19,7 @@ export function UploadSettingsStep() {
     setUploadSettings,
     syncPrivacyFromGlobalDefault,
     syncMetadataLanguageFromGlobalDefault,
+    syncTagsFromGlobalDefault,
     prevStep,
     nextStep,
   } = useDubbingStore()
@@ -40,7 +41,8 @@ export function UploadSettingsStep() {
   useEffect(() => {
     syncPrivacyFromGlobalDefault()
     syncMetadataLanguageFromGlobalDefault()
-  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault])
+    syncTagsFromGlobalDefault()
+  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault, syncTagsFromGlobalDefault])
 
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -150,10 +150,13 @@ interface DubbingState {
   privacyOverridden: boolean
   /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
   metadataLanguageOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 tags를 직접 변경했는지 여부. */
+  tagsOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
   syncMetadataLanguageFromGlobalDefault: () => void
+  syncTagsFromGlobalDefault: () => void
 
   // Glossary
   glossary: GlossaryEntry[]
@@ -189,6 +192,7 @@ const initialState = {
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
   metadataLanguageOverridden: false,
+  tagsOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -284,6 +288,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
         patch.privacyStatus !== undefined ? true : s.privacyOverridden,
       metadataLanguageOverridden:
         patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
+      tagsOverridden:
+        patch.tags !== undefined ? true : s.tagsOverridden,
     }
   }),
 
@@ -302,6 +308,16 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     if (s.uploadSettings.metadataLanguage === next) return s
     return {
       uploadSettings: { ...s.uploadSettings, metadataLanguage: next, uploadReviewConfirmed: false },
+    }
+  }),
+
+  syncTagsFromGlobalDefault: () => set((s) => {
+    if (s.tagsOverridden) return s
+    const next = readDefaultTags()
+    const current = s.uploadSettings.tags
+    if (current.length === next.length && current.every((tag, index) => tag === next[index])) return s
+    return {
+      uploadSettings: { ...s.uploadSettings, tags: next, uploadReviewConfirmed: false },
     }
   }),
 


### PR DESCRIPTION
Closes #280

## 변경 사항

- `src/features/dubbing/store/dubbingStore.ts`
  - `tagsOverridden: boolean` 상태와 `syncTagsFromGlobalDefault()` 함수를 추가했습니다 (기존 `syncPrivacy*` / `syncMetadataLanguage*` 패턴과 동일).
  - `setUploadSettings`가 `patch.tags`를 받으면 `tagsOverridden = true`로 표시해 사용자가 직접 입력한 태그를 보호합니다.
  - `reset()`에서 `tagsOverridden`이 `false`로 초기화됩니다.
- `src/features/dubbing/components/steps/UploadSettingsStep.tsx`
  - 마운트 useEffect에 `syncTagsFromGlobalDefault()` 호출을 추가했습니다.

## 사용자 영향

- 새 워크플로우 시작 시 `originalWithMultiAudio`(원본 영상 + 자막 업로드) 모드에서도 YouTube 설정 페이지에 저장한 기본 태그가 자동으로 입력란에 표시됩니다.
- `newDubbedVideos`(새 더빙 영상 업로드) 모드의 기존 동작도 동일하게 유지됩니다.
- 사용자가 태그를 직접 수정한 뒤에는 글로벌 기본값으로 덮어쓰이지 않습니다.

## 원인 요약

`buildDefaultUploadSettings()`는 store 생성 시점에 한 번만 `readDefaultTags()`를 호출합니다. 이때 `useUserPreferencesSync`가 서버에서 사용자 기본 태그를 가져오기 전이면 `FALLBACK_DEFAULT_TAGS`만 적용되고, 이후 `youtubeSettings.defaultTags`가 hydrate되어도 `uploadSettings.tags`는 갱신되지 않았습니다. `privacy`/`metadataLanguage`는 같은 문제를 막기 위한 sync 함수가 존재했지만 `tags`만 빠져 있었습니다.

## 검증

- [ ] 신규 워크플로우 진입 → `newDubbedVideos` → 저장된 태그 자동 표시 (회귀 없음)
- [ ] 신규 워크플로우 진입 → `originalWithMultiAudio` → 저장된 태그 자동 표시
- [ ] 태그 입력란을 직접 수정한 뒤 단계 이동 → 사용자 입력이 유지됨
- [ ] `npm run typecheck` 통과
- [ ] `npm run lint` 통과 (로컬 확인 완료)
- [ ] `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)