### PR TITLE
fix: 자막 편집기 액션 영역 텍스트 정리와 버튼 가로 정렬

### DIFF
--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -780,27 +780,13 @@ export function SubtitleScriptEditor({
               )}
 
               {cues && cues.length > 0 && (
-                <div className="flex flex-col gap-3 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-surface-900 dark:text-white">
-                      {captionDirty
-                        ? t('features.dubbing.components.subtitleScriptEditor.captionChangesPending')
-                        : t('features.dubbing.components.subtitleScriptEditor.captionFileReady')}
+                <div className="space-y-2 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
+                  {hasInvalidCaptionTiming && (
+                    <p className="text-xs text-red-600 dark:text-red-400">
+                      {t('features.dubbing.components.subtitleScriptEditor.fixCaptionTimingBeforeExport')}
                     </p>
-                    <p className={cn(
-                      'mt-0.5 text-xs',
-                      hasInvalidCaptionTiming
-                        ? 'text-red-600 dark:text-red-400'
-                        : 'text-surface-500 dark:text-surface-300',
-                    )}>
-                      {hasInvalidCaptionTiming
-                        ? t('features.dubbing.components.subtitleScriptEditor.fixCaptionTimingBeforeExport')
-                        : youtubeVideoId
-                          ? t('features.dubbing.components.subtitleScriptEditor.captionActionsHelp')
-                          : t('features.dubbing.components.subtitleScriptEditor.theYouTubeCaptionButtonBecomesAvailableAfterThis')}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
+                  )}
+                  <div className="flex flex-wrap items-center gap-2">
                     <Button
                       size="sm"
                       variant="outline"


### PR DESCRIPTION
Closes #282

## 변경 사항

`src/features/dubbing/components/SubtitleScriptEditor.tsx` — 자막 편집 탭 하단 액션 영역만 손봤습니다.

- 좌측 안내 카드를 제거했습니다.
  - "자막 파일 준비됨" / "자막 변경 있음" (`captionFileReady` / `captionChangesPending`)
  - 영상 업로드 후 자막 적용 안내 (`theYouTubeCaptionButtonBecomesAvailableAfterThis`)
  - 자막 액션 보조 설명 (`captionActionsHelp`)
- 시간 입력 오류가 있을 때만 빨간 경고 한 줄(`fixCaptionTimingBeforeExport`)을 유지합니다.
- 버튼(다운로드 · 미리보기 · 자동 자막 복원 · YouTube에 자막 올리기)을 한 줄로 가로 정렬하고, 좁은 화면에서는 `flex-wrap`으로 줄바꿈됩니다.
- `captionDirty` 변수는 상단 탭 뱃지에서 계속 사용되므로 유지합니다.

## 사용자 영향

- 자막 편집 후 액션 영역이 깔끔해지고 버튼이 일정한 위치에 배치됩니다.
- 버튼 노출 조건(`youtubeVideoId` 유무)은 그대로 유지됩니다 — 영상이 아직 YouTube에 없으면 자막 업로드 버튼은 계속 숨겨집니다(자막은 영상 위에 얹는 구조이므로 영상이 먼저 올라가야 동작).

## 검증

- [ ] 자막 수정 전/후 모두 액션 버튼이 한 줄로 정렬되어 보임
- [ ] 시간 입력 오류 시 빨간 경고 한 줄만 노출
- [ ] YouTube 영상이 업로드된 언어에서는 자막 업로드 버튼이 노출
- [ ] `npm run typecheck` / `npm run lint` 통과 (로컬 lint 통과 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)