### PR TITLE
release: 태그 기본값 동기화 · 자막 편집기 액션 정리

### DIFF
--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -780,27 +780,13 @@ export function SubtitleScriptEditor({
               )}
 
               {cues && cues.length > 0 && (
-                <div className="flex flex-col gap-3 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-surface-900 dark:text-white">
-                      {captionDirty
-                        ? t('features.dubbing.components.subtitleScriptEditor.captionChangesPending')
-                        : t('features.dubbing.components.subtitleScriptEditor.captionFileReady')}
+                <div className="space-y-2 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
+                  {hasInvalidCaptionTiming && (
+                    <p className="text-xs text-red-600 dark:text-red-400">
+                      {t('features.dubbing.components.subtitleScriptEditor.fixCaptionTimingBeforeExport')}
                     </p>
-                    <p className={cn(
-                      'mt-0.5 text-xs',
-                      hasInvalidCaptionTiming
-                        ? 'text-red-600 dark:text-red-400'
-                        : 'text-surface-500 dark:text-surface-300',
-                    )}>
-                      {hasInvalidCaptionTiming
-                        ? t('features.dubbing.components.subtitleScriptEditor.fixCaptionTimingBeforeExport')
-                        : youtubeVideoId
-                          ? t('features.dubbing.components.subtitleScriptEditor.captionActionsHelp')
-                          : t('features.dubbing.components.subtitleScriptEditor.theYouTubeCaptionButtonBecomesAvailableAfterThis')}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
+                  )}
+                  <div className="flex flex-wrap items-center gap-2">
                     <Button
                       size="sm"
                       variant="outline"

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -19,6 +19,7 @@ export function UploadSettingsStep() {
     setUploadSettings,
     syncPrivacyFromGlobalDefault,
     syncMetadataLanguageFromGlobalDefault,
+    syncTagsFromGlobalDefault,
     prevStep,
     nextStep,
   } = useDubbingStore()
@@ -40,7 +41,8 @@ export function UploadSettingsStep() {
   useEffect(() => {
     syncPrivacyFromGlobalDefault()
     syncMetadataLanguageFromGlobalDefault()
-  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault])
+    syncTagsFromGlobalDefault()
+  }, [syncPrivacyFromGlobalDefault, syncMetadataLanguageFromGlobalDefault, syncTagsFromGlobalDefault])
 
   const originalYouTubeId =
     videoSource?.type === 'url' && videoSource.url ? extractVideoId(videoSource.url) : null

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -150,10 +150,13 @@ interface DubbingState {
   privacyOverridden: boolean
   /** Wizard 세션 내에서 사용자가 metadataLanguage를 직접 변경했는지 여부. */
   metadataLanguageOverridden: boolean
+  /** Wizard 세션 내에서 사용자가 tags를 직접 변경했는지 여부. */
+  tagsOverridden: boolean
   setUploadSettings: (patch: Partial<UploadSettings>) => void
   /** YouTube 설정 페이지의 기본값을 wizard에 동기화한다 (사용자 override 없을 때만). */
   syncPrivacyFromGlobalDefault: () => void
   syncMetadataLanguageFromGlobalDefault: () => void
+  syncTagsFromGlobalDefault: () => void
 
   // Glossary
   glossary: GlossaryEntry[]
@@ -189,6 +192,7 @@ const initialState = {
   uploadSettings: buildDefaultUploadSettings() as UploadSettings,
   privacyOverridden: false,
   metadataLanguageOverridden: false,
+  tagsOverridden: false,
 }
 
 export const useDubbingStore = create<DubbingState>((set) => ({
@@ -284,6 +288,8 @@ export const useDubbingStore = create<DubbingState>((set) => ({
         patch.privacyStatus !== undefined ? true : s.privacyOverridden,
       metadataLanguageOverridden:
         patch.metadataLanguage !== undefined ? true : s.metadataLanguageOverridden,
+      tagsOverridden:
+        patch.tags !== undefined ? true : s.tagsOverridden,
     }
   }),
 
@@ -302,6 +308,16 @@ export const useDubbingStore = create<DubbingState>((set) => ({
     if (s.uploadSettings.metadataLanguage === next) return s
     return {
       uploadSettings: { ...s.uploadSettings, metadataLanguage: next, uploadReviewConfirmed: false },
+    }
+  }),
+
+  syncTagsFromGlobalDefault: () => set((s) => {
+    if (s.tagsOverridden) return s
+    const next = readDefaultTags()
+    const current = s.uploadSettings.tags
+    if (current.length === next.length && current.every((tag, index) => tag === next[index])) return s
+    return {
+      uploadSettings: { ...s.uploadSettings, tags: next, uploadReviewConfirmed: false },
     }
   }),
 


### PR DESCRIPTION
develop의 누적 변경을 운영(main)에 반영합니다. **머지 전 아래 QA 체크리스트로 회귀 점검**해주세요.

## 포함된 PR

- #281 — fix: 원본+자막 업로드 모드에서 저장된 태그 기본값 복원 (Closes #280)
- #283 — fix: 자막 편집기 액션 영역 텍스트 정리와 버튼 가로 정렬 (Closes #282)

## 사용자 영향

### 태그 기본값 동기화 (#281)
- 새 워크플로우 시작 시 `originalWithMultiAudio`(원본 영상 + 자막 업로드) 모드에서도 YouTube 설정 페이지에 저장된 기본 태그가 자동으로 표시됩니다.
- `newDubbedVideos`(새 더빙 영상 업로드) 모드의 기존 동작도 그대로 유지됩니다.
- 사용자가 wizard 안에서 태그를 직접 수정한 뒤에는 글로벌 기본값으로 덮어쓰이지 않습니다.

### 자막 편집기 액션 정리 (#283)
- 자막 편집 탭 하단의 안내 카드(자막 파일 준비됨 / 자막 변경 있음 / 영상 업로드 후 자막 적용 안내 / 자막 액션 보조 설명)를 모두 제거했습니다.
- 시간 입력 오류가 있을 때만 빨간 경고 한 줄을 노출합니다.
- 액션 버튼(다운로드 · 미리보기 · 자동 자막 복원 · YouTube에 자막 올리기)을 한 줄로 가로 정렬했습니다. 좁은 화면에서는 줄바꿈됩니다.
- 버튼 노출 조건은 동일합니다 — YouTube 영상이 아직 올라가지 않은 언어는 자막 업로드 버튼이 계속 숨겨집니다(자막은 영상 위에 얹는 구조).

## QA 체크리스트

### 태그 동기화
- [ ] 새 워크플로우 진입 → `newDubbedVideos` 모드 → 저장된 태그가 자동 표시 (회귀 없음)
- [ ] 새 워크플로우 진입 → `originalWithMultiAudio` 모드 → 저장된 태그가 자동 표시
- [ ] wizard 안에서 태그를 수정한 뒤 단계 이동 → 사용자 입력 유지

### 자막 편집기
- [ ] 자막 편집 탭에서 액션 버튼들이 한 줄로 정렬되어 보임
- [ ] 시간 입력 오류 시 빨간 경고 한 줄만 노출
- [ ] YouTube 영상이 업로드된 언어에서는 자막 업로드 버튼이 정상 노출

### 빌드·테스트
- [ ] `npm run typecheck` 통과
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] Vercel 배포 후 `/api/health` 스모크 시나리오 정상

## 후속 메모

`uploadSettings`의 글로벌 기본값을 따라가는 필드(`tags` / `privacyStatus` / `metadataLanguage`)를 `dubbingStore`에서 분리하고 `youtubeSettingsStore`를 직접 참조하는 single source of truth 패턴으로 리팩토링하는 안이 논의되었습니다. 이번 릴리스에 포함하지 않으며 별도 이슈로 후속 작업 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)