### PR TITLE
fix: 다운로드만 모드 검토 단계에서 자동 업로드 행·확인 체크박스 숨김

### DIFF
--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -32,7 +32,7 @@ export function TranslationEditStep() {
   const locale = useAppLocale()
   const t = useLocaleText()
 
-  const needsAutoUploadReview = uploadSettings.autoUpload
+  const needsAutoUploadReview = uploadSettings.autoUpload && deliverableMode !== 'downloadOnly'
   const canStart = !needsAutoUploadReview || uploadSettings.uploadReviewConfirmed
   const privacyLabel = t(PRIVACY_LABELS[uploadSettings.privacyStatus] ?? uploadSettings.privacyStatus)
   const targetChannelLabel = channel
@@ -116,10 +116,12 @@ export function TranslationEditStep() {
 
           <SummaryRow label={t('features.dubbing.components.steps.translationEditStep.output')} value={deliverableModeLabel} />
 
-          <SummaryRow
-            label={t('features.dubbing.components.steps.translationEditStep.autoUpload')}
-            value={<StatusValue active={uploadSettings.autoUpload} />}
-          />
+          {deliverableMode !== 'downloadOnly' && (
+            <SummaryRow
+              label={t('features.dubbing.components.steps.translationEditStep.autoUpload')}
+              value={<StatusValue active={uploadSettings.autoUpload} />}
+            />
+          )}
 
           {showsCaptionSetting && (
             <SummaryRow


### PR DESCRIPTION
Closes #285

## 변경 사항

`src/features/dubbing/components/steps/TranslationEditStep.tsx`만 손봤습니다.

- `자동 업로드` SummaryRow를 `deliverableMode !== 'downloadOnly'` 조건으로 감쌌습니다.
- `needsAutoUploadReview`에 `deliverableMode !== 'downloadOnly'` 조건을 추가했습니다. 그 결과 downloadOnly 흐름에서는 노란색 확인 체크박스가 노출되지 않고 `canStart`가 자동 통과됩니다.

## 사용자 영향

- `다운로드만` 모드의 검토 단계가 다음과 같이 간결해집니다.
  - `자동 업로드: 켜짐` 행이 사라집니다.
  - "설정을 검토했고 다운로드하겠습니다" 확인 체크박스가 사라집니다.
  - `더빙 시작` 버튼이 추가 확인 없이 활성화됩니다.
- `새 더빙 영상 업로드`(`newDubbedVideos`) / `원본 영상 + 자막`(`originalWithMultiAudio`) 모드의 동작은 그대로 유지됩니다.

## 검증

- [ ] downloadOnly 모드 검토 단계에서 자동 업로드 행과 확인 체크박스가 보이지 않음
- [ ] downloadOnly 모드에서 `더빙 시작` 버튼이 추가 확인 없이 활성화됨
- [ ] newDubbedVideos / originalWithMultiAudio 모드의 검토 단계는 동일하게 동작
- [ ] `npm run lint` 통과 (로컬 확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)