### PR TITLE
fix: 자막 푸시 버튼을 자막 변경 시 항상 노출하도록 단순화

### DIFF
--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -805,7 +805,7 @@ export function SubtitleScriptEditor({
                       <RotateCcw className="h-3.5 w-3.5" />
                       {t('features.dubbing.components.subtitleScriptEditor.restoreGeneratedCaptions')}
                     </Button>
-                    {youtubeVideoId && (
+                    {captionDirty && (
                       <Button
                         size="sm"
                         variant="primary"


### PR DESCRIPTION
Closes #287

## 변경 사항

`src/features/dubbing/components/SubtitleScriptEditor.tsx`의 \"YouTube에 자막 올리기\" 버튼 노출 조건을 `youtubeVideoId`에서 `captionDirty`로 변경했습니다.

## 사용자 영향

- 영상 업로드 여부와 무관하게, 자막에 미저장 변경이 있으면 버튼이 노출됩니다.
- 자막 변경이 없는 상태에서는 버튼이 숨겨져 액션 영역이 더 깔끔합니다.
- 시간 입력 오류(`hasInvalidCaptionTiming`) 시 disabled 처리는 그대로 유지됩니다.

## 검증

- [ ] 영상 업로드된 상태에서 자막 수정 → 버튼 노출
- [ ] 영상 미업로드 상태에서도 자막 수정 → 버튼 노출
- [ ] 자막 변경이 없을 때 → 버튼 미노출
- [ ] 시간 입력 오류 시 → 버튼 disabled
- [ ] `npm run lint` 통과 (로컬 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)