### PR TITLE
feat: 자막 편집기에 원본 영상 미리보기 추가

### DIFF
--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -255,6 +255,8 @@ interface SubtitleScriptEditorProps {
   allowDialogueEditing?: boolean
   youtubeVideoId?: string | null
   youtubePreviewVisibility?: PrivacyStatus
+  /** 원본 영상 URL. 자막 편집 시 영상을 직접 재생하기 위한 fallback player source. */
+  originalVideoUrl?: string | null
 }
 
 export function SubtitleScriptEditor({
@@ -264,6 +266,7 @@ export function SubtitleScriptEditor({
   allowDialogueEditing = true,
   youtubeVideoId,
   youtubePreviewVisibility,
+  originalVideoUrl,
 }: SubtitleScriptEditorProps) {
   const locale = useAppLocale()
   const t = useLocaleText()
@@ -611,7 +614,32 @@ export function SubtitleScriptEditor({
             </div>
           )}
 
-          {youtubeVideoId && youtubeWatchUrl && youtubeEmbedUrl && (
+          {originalVideoUrl ? (
+            <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
+              <div className="mb-3 flex min-w-0 items-start gap-2">
+                <Video className="mt-0.5 h-4 w-4 shrink-0 text-brand-600" />
+                <p className="text-sm font-medium text-surface-900 dark:text-white">
+                  {t('features.dubbing.components.subtitleScriptEditor.originalVideoPreview')}
+                </p>
+              </div>
+              <div className="aspect-video w-full max-w-xl overflow-hidden rounded-lg border border-surface-200 bg-black dark:border-surface-700">
+                <video controls preload="metadata" className="h-full w-full" src={originalVideoUrl}>
+                  <track kind="captions" />
+                </video>
+              </div>
+              {youtubeVideoId && youtubeWatchUrl && (
+                <a
+                  href={youtubeWatchUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-surface-300 bg-white px-3 text-sm font-medium text-surface-700 transition-all duration-200 hover:bg-surface-100 focus-ring dark:border-surface-700 dark:bg-transparent dark:text-surface-300 dark:hover:bg-surface-800"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t('features.dubbing.components.subtitleScriptEditor.openInYouTube')}
+                </a>
+              )}
+            </div>
+          ) : youtubeVideoId && youtubeWatchUrl && youtubeEmbedUrl && (
             <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex min-w-0 items-start gap-2">

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -1003,6 +1003,7 @@ export function UploadStep() {
                   allowDialogueEditing={allowDialogueEditingInOutput}
                   youtubeVideoId={ytUploads[code]?.videoId ?? null}
                   youtubePreviewVisibility={privacyStatus}
+                  originalVideoUrl={originalVideoUrl}
                 />
               )
             })}

--- a/src/lib/i18n/client-messages/dubbing.ts
+++ b/src/lib/i18n/client-messages/dubbing.ts
@@ -301,6 +301,7 @@ export const dubbingMessages = {
   "features.dubbing.components.subtitleScriptEditor.loadingDialogue": { ko: "대사를 불러오는 중...", en: "Loading dialogue..." },
   "features.dubbing.components.subtitleScriptEditor.noLinesToShow": { ko: "표시할 문장이 없습니다.", en: "No lines to show." },
   "features.dubbing.components.subtitleScriptEditor.openInYouTube": { ko: "YouTube에서 열기", en: "Open in YouTube" },
+  "features.dubbing.components.subtitleScriptEditor.originalVideoPreview": { ko: "원본 영상 미리보기", en: "Original video preview" },
   "features.dubbing.components.subtitleScriptEditor.previewCaptions": { ko: "자막 미리보기", en: "Preview captions" },
   "features.dubbing.components.subtitleScriptEditor.regenerateAudio": { ko: "오디오 다시 만들기", en: "Regenerate audio" },
   "features.dubbing.components.subtitleScriptEditor.restoreGeneratedCaptions": { ko: "되돌리기", en: "Restore" },

--- a/src/lib/i18n/generatedMessages.ts
+++ b/src/lib/i18n/generatedMessages.ts
@@ -509,6 +509,7 @@ export const generatedMessages = {
   "features.dubbing.components.subtitleScriptEditor.valueCaptionsAndDialogue": { ko: "{languageName} 자막 · 대사", en: "{languageName} captions and dialogue" },
   "features.dubbing.components.subtitleScriptEditor.yourTranslationEditHasBeenSaved": { ko: "수정한 번역을 저장했습니다.", en: "Your translation edit has been saved." },
   "features.dubbing.components.subtitleScriptEditor.youTubeCaptionsUpdated": { ko: "YouTube 자막 수정 완료", en: "YouTube captions updated" },
+  "features.dubbing.components.subtitleScriptEditor.originalVideoPreview": { ko: "원본 영상 미리보기", en: "Original video preview" },
   "features.dubbing.components.subtitleScriptEditor.youtubePreview": { ko: "YouTube 미리보기", en: "YouTube preview" },
   "features.dubbing.components.subtitleScriptEditor.youtubePreviewLoadFailed": { ko: "YouTube 미리보기를 불러오지 못했습니다", en: "Could not load YouTube preview" },
   "features.dubbing.components.subtitleScriptEditor.youtubePreviewMayBeUnavailableForPrivateVideos": { ko: "영상 공개 범위가 비공개이면 앱 안에서 재생되지 않을 수 있습니다. YouTube에서 열어 확인해 주세요.", en: "Private videos may not play inside the app. Open the video in YouTube to check it." },


### PR DESCRIPTION
Closes #289

## 변경 사항

`src/features/dubbing/components/SubtitleScriptEditor.tsx`
- `originalVideoUrl?: string | null` prop을 추가
- 자막 편집 영역 위 미리보기 카드를 다음 우선순위로 노출
  1. `originalVideoUrl`이 있으면 `<video controls>`로 원본 영상 직접 재생 (모든 언어 공유, YouTube 공개 여부 무관)
  2. 없을 때만 기존 YouTube `iframe` 미리보기로 fallback

`src/features/dubbing/components/steps/UploadStep.tsx`
- `SubtitleScriptEditor`에 `originalVideoUrl={originalVideoUrl}` prop을 전달

`src/lib/i18n/`
- `subtitleScriptEditor.originalVideoPreview` (\"원본 영상 미리보기\" / \"Original video preview\") 메시지 추가

## 사용자 영향

- 비공개로 업로드한 영상도 자막 편집 화면에서 원본 영상을 보면서 작업할 수 있습니다.
- 원본+자막 모드에서 `ytUploads`가 채워지기 전이라도 영상을 재생하며 자막을 편집할 수 있습니다.
- 자막은 번역 언어, 영상 음성은 원본 언어이지만 화면을 보며 타이밍·문구를 맞추는 본래 목적에 충분합니다.

## 검증

- [ ] 비공개 영상이어도 원본 영상 player가 노출된다
- [ ] 원본+자막 모드에서 원본 영상이 player에 노출된다
- [ ] `originalVideoUrl`이 없을 때는 기존 YouTube 미리보기가 그대로 동작한다
- [ ] `npm run lint` 통과 (로컬 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)