### PR TITLE
feat: STT 기반 자막 생성 흐름 추가

### DIFF
--- a/migrations/0006_generated_stt_captions.sql
+++ b/migrations/0006_generated_stt_captions.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS generated_captions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  job_id INTEGER NOT NULL,
+  language_code TEXT NOT NULL,
+  source_project_seq INTEGER,
+  source_type TEXT NOT NULL DEFAULT 'stt',
+  srt_content TEXT NOT NULL,
+  cue_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (job_id) REFERENCES dubbing_jobs(id) ON DELETE CASCADE,
+  UNIQUE (job_id, language_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_generated_captions_user_created
+  ON generated_captions (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_generated_captions_job_language
+  ON generated_captions (job_id, language_code);

--- a/src/app/api/perso/stt/captions/route.test.ts
+++ b/src/app/api/perso/stt/captions/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+}))
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/generated-captions', () => ({
+  getGeneratedCaption: vi.fn(),
+  upsertGeneratedCaption: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/jobs', () => ({
+  updateJobLanguageCompleted: vi.fn(),
+  updateJobLanguageProgress: vi.fn(),
+}))
+
+vi.mock('@/lib/perso/client', () => ({
+  persoFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/translate/gemini', () => ({
+  translateTimedSubtitles: vi.fn(),
+}))
+
+import { requireSession } from '@/lib/auth/session'
+import { getDb } from '@/lib/db/client'
+import { upsertGeneratedCaption } from '@/lib/db/queries/generated-captions'
+import { updateJobLanguageCompleted, updateJobLanguageProgress } from '@/lib/db/queries/jobs'
+import { persoFetch } from '@/lib/perso/client'
+import { translateTimedSubtitles } from '@/lib/translate/gemini'
+
+function mockAuth() {
+  vi.mocked(requireSession).mockResolvedValue({
+    ok: true,
+    session: { uid: 'user-1', email: 'user@example.com' },
+  })
+}
+
+function mockDb() {
+  vi.mocked(getDb).mockReturnValue({
+    execute: vi.fn(async ({ sql }: { sql: string }) => {
+      if (sql.includes('FROM dubbing_jobs')) return { rows: [{ user_id: 'user-1' }] }
+      if (sql.includes('project_seq')) return { rows: [{ id: 1 }] }
+      if (sql.includes('SELECT language_code')) {
+        return { rows: [{ language_code: 'en' }, { language_code: 'ja' }] }
+      }
+      return { rows: [] }
+    }),
+  } as never)
+}
+
+describe('/api/perso/stt/captions', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockAuth()
+    mockDb()
+    vi.mocked(persoFetch).mockResolvedValue({
+      hasNext: false,
+      sentences: [
+        {
+          seq: 1,
+          speakerOrderIndex: 1,
+          offsetMs: 0,
+          durationMs: 1200,
+          originalText: 'Hello world',
+        },
+      ],
+    })
+    vi.mocked(upsertGeneratedCaption).mockResolvedValue()
+    vi.mocked(updateJobLanguageCompleted).mockResolvedValue()
+    vi.mocked(updateJobLanguageProgress).mockResolvedValue()
+  })
+
+  it('generates captions per language and keeps partial failures isolated', async () => {
+    vi.mocked(translateTimedSubtitles).mockImplementation(async ({ targetLanguageCode }) => {
+      if (targetLanguageCode === 'ja') throw new Error('Gemini failed')
+      return [{ startMs: 0, endMs: 1200, text: 'Hello world' }]
+    })
+
+    const { POST } = await import('./route')
+    const req = new NextRequest('http://localhost/api/perso/stt/captions', {
+      method: 'POST',
+      body: JSON.stringify({
+        jobId: 10,
+        projectSeq: 99,
+        spaceSeq: 7,
+        targetLanguageCodes: ['en', 'ja'],
+        sourceLanguageCode: 'auto',
+      }),
+    })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.data.languages).toEqual([{ langCode: 'en', srtUrl: '/api/perso/stt/captions?jobId=10&langCode=en', cueCount: 1 }])
+    expect(body.data.failedLanguages).toEqual([{ langCode: 'ja', error: 'Gemini failed' }])
+    expect(updateJobLanguageCompleted).toHaveBeenCalledWith(10, 'en', {
+      srtUrl: '/api/perso/stt/captions?jobId=10&langCode=en',
+    })
+    expect(updateJobLanguageProgress).toHaveBeenCalledWith(10, 'ja', 'failed', 0, 'FAILED')
+  })
+})

--- a/src/app/api/perso/stt/captions/route.ts
+++ b/src/app/api/perso/stt/captions/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { getDb } from '@/lib/db/client'
+import { getGeneratedCaption, upsertGeneratedCaption } from '@/lib/db/queries/generated-captions'
+import { updateJobLanguageCompleted, updateJobLanguageProgress } from '@/lib/db/queries/jobs'
+import { persoFetch } from '@/lib/perso/client'
+import { PersoError } from '@/lib/perso/errors'
+import { fail, handle, parseBody, requireIntParam, requireStringParam } from '@/lib/perso/route-helpers'
+import { generateSttCaptionsBodySchema } from '@/lib/validators/perso'
+import type { SttScriptResponse, SttScriptSentence } from '@/lib/perso/types'
+import { translateTimedSubtitles, type TimedTranscriptSegment } from '@/lib/translate/gemini'
+import { buildSRT } from '@/utils/srt'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+async function assertJobOwner(userId: string, jobId: number) {
+  const result = await getDb().execute({
+    sql: 'SELECT user_id FROM dubbing_jobs WHERE id = ?',
+    args: [jobId],
+  })
+  const owner = result.rows[0]?.user_id
+  if (!owner) throw new PersoError('JOB_NOT_FOUND', 'Job not found', 404)
+  if (owner !== userId) throw new PersoError('FORBIDDEN', 'You do not own this job', 403)
+}
+
+async function assertProjectBelongsToJob(jobId: number, projectSeq: number) {
+  const result = await getDb().execute({
+    sql: 'SELECT id FROM job_languages WHERE job_id = ? AND project_seq = ? LIMIT 1',
+    args: [jobId, projectSeq],
+  })
+  if (!result.rows[0]) {
+    throw new PersoError('PERSO_RESOURCE_FORBIDDEN', 'Project is not linked to this job', 403)
+  }
+}
+
+async function assertLanguagesBelongToJob(jobId: number, languageCodes: string[]) {
+  const result = await getDb().execute({
+    sql: 'SELECT language_code FROM job_languages WHERE job_id = ?',
+    args: [jobId],
+  })
+  const allowed = new Set(result.rows.map((row) => String(row.language_code)))
+  const invalid = languageCodes.filter((code) => !allowed.has(code))
+  if (invalid.length > 0) {
+    throw new PersoError('LANGUAGE_NOT_LINKED_TO_JOB', 'Requested language is not linked to this job', 403, {
+      invalid,
+    })
+  }
+}
+
+async function fetchAllSttScript(projectSeq: number, spaceSeq: number): Promise<SttScriptSentence[]> {
+  const sentences: SttScriptSentence[] = []
+  let cursorId: number | null | undefined
+
+  for (let page = 0; page < 100; page += 1) {
+    const data = await persoFetch<SttScriptResponse>(
+      `/video-translator/api/v1/projects/${projectSeq}/spaces/${spaceSeq}/stt/script`,
+      {
+        baseURL: 'api',
+        query: {
+          size: 10000,
+          cursorId,
+        },
+      },
+    )
+
+    if (Array.isArray(data.sentences)) {
+      sentences.push(...data.sentences)
+    }
+
+    if (!data.hasNext || data.nextCursorId == null) break
+    cursorId = data.nextCursorId
+  }
+
+  return sentences
+}
+
+function mapSttSegments(sentences: SttScriptSentence[]): TimedTranscriptSegment[] {
+  return sentences
+    .map((sentence, index) => {
+      const startMs = Number(sentence.offsetMs ?? 0)
+      const durationMs = Number(sentence.durationMs ?? 0)
+      const endMs = startMs + durationMs
+      return {
+        id: Number(sentence.seq ?? index + 1),
+        startMs,
+        endMs,
+        text: String(sentence.originalText || sentence.originalDraftText || '').trim(),
+        speakerLabel: sentence.speakerOrderIndex ? `Speaker ${sentence.speakerOrderIndex}` : undefined,
+      }
+    })
+    .filter((segment) => segment.text.length > 0 && segment.endMs > segment.startMs)
+}
+
+function captionUrl(jobId: number, langCode: string) {
+  const params = new URLSearchParams({ jobId: String(jobId), langCode })
+  return `/api/perso/stt/captions?${params.toString()}`
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  try {
+    const url = new URL(req.url)
+    const jobId = requireIntParam(url, 'jobId')
+    const langCode = requireStringParam(url, 'langCode')
+    await assertJobOwner(auth.session.uid, jobId)
+
+    const caption = await getGeneratedCaption(jobId, langCode)
+    if (!caption) throw new PersoError('CAPTION_NOT_FOUND', 'Generated caption was not found', 404)
+    if (caption.userId !== auth.session.uid) throw new PersoError('FORBIDDEN', 'You do not own this caption', 403)
+
+    return new Response(caption.srtContent, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/x-subrip; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err) {
+    return fail(err)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return handle(async () => {
+    const body = await parseBody(req, generateSttCaptionsBodySchema)
+    await assertJobOwner(auth.session.uid, body.jobId)
+    await assertProjectBelongsToJob(body.jobId, body.projectSeq)
+    const targetLanguageCodes = Array.from(new Set(body.targetLanguageCodes))
+    await assertLanguagesBelongToJob(body.jobId, targetLanguageCodes)
+
+    const sentences = await fetchAllSttScript(body.projectSeq, body.spaceSeq)
+    const segments = mapSttSegments(sentences)
+    if (segments.length === 0) {
+      throw new PersoError('STT_SCRIPT_EMPTY', 'STT script is empty or not ready yet', 409)
+    }
+
+    const languages = []
+    const failedLanguages = []
+    for (const langCode of targetLanguageCodes) {
+      try {
+        await updateJobLanguageProgress(body.jobId, langCode, 'translating', 72, 'STT_CAPTION_TRANSLATING')
+        const cues = await translateTimedSubtitles({
+          sourceLanguageCode: body.sourceLanguageCode ?? 'auto',
+          targetLanguageCode: langCode,
+          segments,
+        })
+        const srtContent = buildSRT(cues)
+        await upsertGeneratedCaption({
+          userId: auth.session.uid,
+          jobId: body.jobId,
+          languageCode: langCode,
+          sourceProjectSeq: body.projectSeq,
+          srtContent,
+          cueCount: cues.length,
+        })
+        const srtUrl = captionUrl(body.jobId, langCode)
+        await updateJobLanguageCompleted(body.jobId, langCode, { srtUrl })
+        languages.push({
+          langCode,
+          srtUrl,
+          cueCount: cues.length,
+        })
+      } catch (err) {
+        await updateJobLanguageProgress(body.jobId, langCode, 'failed', 0, 'FAILED')
+        failedLanguages.push({
+          langCode,
+          error: err instanceof Error ? err.message : 'caption_generation_failed',
+        })
+      }
+    }
+
+    if (languages.length === 0) {
+      throw new PersoError('CAPTION_GENERATION_FAILED', 'Caption generation failed for all languages', 502, {
+        failedLanguages,
+      })
+    }
+
+    return { languages, failedLanguages }
+  })
+}

--- a/src/app/api/perso/stt/route.ts
+++ b/src/app/api/perso/stt/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { persoFetch } from '@/lib/perso/client'
+import { handle, parseBody, requireIntParam } from '@/lib/perso/route-helpers'
+import { sttBodySchema } from '@/lib/validators/perso'
+import type { SttResponse } from '@/lib/perso/types'
+import { assertPersoMediaOwner } from '@/lib/perso/ownership'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function normalizeSttResponse(raw: unknown): SttResponse {
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>
+    if (Array.isArray(data.startGenerateProjectIdList)) {
+      return {
+        startGenerateProjectIdList: data.startGenerateProjectIdList
+          .map((id) => Number(id))
+          .filter((id) => Number.isFinite(id) && id > 0),
+      }
+    }
+    const singleId = Number(data.projectSeq ?? data.projectId ?? data.sttProjectSeq)
+    if (Number.isFinite(singleId) && singleId > 0) {
+      return { startGenerateProjectIdList: [singleId] }
+    }
+  }
+  return { startGenerateProjectIdList: [] }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  return handle(async () => {
+    const url = new URL(req.url)
+    const spaceSeq = requireIntParam(url, 'spaceSeq')
+    const body = await parseBody(req, sttBodySchema)
+    await assertPersoMediaOwner(auth.session.uid, body.mediaSeq)
+
+    const title = body.title?.trim() || `Dubtube STT project ${body.mediaSeq}`
+    const raw = await persoFetch<unknown>(
+      `/video-translator/api/v1/projects/spaces/${spaceSeq}/stt`,
+      {
+        method: 'POST',
+        baseURL: 'api',
+        body: {
+          mediaSeq: body.mediaSeq,
+          isVideoProject: body.isVideoProject,
+          title,
+        },
+      },
+    )
+
+    return normalizeSttResponse(raw)
+  })
+}

--- a/src/components/feedback/Toast.tsx
+++ b/src/components/feedback/Toast.tsx
@@ -33,22 +33,22 @@ export function ToastContainer() {
   if (toasts.length === 0) return null
 
   return (
-    <div role="status" aria-live="polite" aria-atomic="false" className="fixed bottom-4 right-4 z-[100] flex max-w-[calc(100vw-2rem)] flex-col gap-2">
+    <div role="status" aria-live="polite" aria-atomic="false" className="fixed bottom-4 right-4 z-100 flex max-w-[calc(100vw-2rem)] flex-col gap-2">
       {toasts.map((toast) => {
         const Icon = icons[toast.type]
         return (
           <div
             key={toast.id}
             className={cn(
-              'flex w-[calc(100vw-2rem)] max-w-[420px] items-start gap-3 rounded-lg border p-4 shadow-lg animate-slide-up sm:w-[420px]',
+              'flex w-[calc(100vw-2rem)] max-w-105 items-start gap-3 rounded-lg border p-4 shadow-lg animate-slide-up sm:w-105',
               styles[toast.type],
             )}
           >
             <Icon className={cn('h-5 w-5 shrink-0 mt-0.5', iconColors[toast.type])} aria-hidden="true" />
             <div className="flex-1 min-w-0">
-              <p className="break-words text-sm font-medium text-surface-900 dark:text-surface-100">{toast.title}</p>
+              <p className="wrap-break-word text-sm font-medium text-surface-900 dark:text-surface-100">{toast.title}</p>
               {toast.message && (
-                <p className="mt-0.5 break-words text-sm text-surface-600 dark:text-surface-400">{toast.message}</p>
+                <p className="mt-0.5 wrap-break-word text-sm text-surface-600 dark:text-surface-400">{toast.message}</p>
               )}
             </div>
             <button

--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -20,6 +20,7 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import {
   getProjectScript,
   getTranslatedSrt,
+  getGeneratedSttCaptionSrt,
   regenerateSentenceAudio,
   updateSentenceTranslation,
   ytUploadCaption,
@@ -259,6 +260,7 @@ interface SubtitleScriptEditorProps {
    * - 원본+자막 모드: 원본 영상 URL (모든 언어 공유)
    * - 새 더빙 영상 모드: 해당 언어의 더빙 영상 URL */
   previewVideoUrl?: string | null
+  sttCaptionJobId?: number | null
 }
 
 export function SubtitleScriptEditor({
@@ -269,6 +271,7 @@ export function SubtitleScriptEditor({
   youtubeVideoId,
   youtubePreviewVisibility,
   previewVideoUrl,
+  sttCaptionJobId,
 }: SubtitleScriptEditorProps) {
   const locale = useAppLocale()
   const t = useLocaleText()
@@ -321,7 +324,9 @@ export function SubtitleScriptEditor({
 
     setSrtLoading(true)
     try {
-      const text = await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
+      const text = sttCaptionJobId
+        ? await getGeneratedSttCaptionSrt(sttCaptionJobId, langCode)
+        : await getTranslatedSrt(projectSeq, spaceSeq, 'translated')
       const parsed = parseSRT(text)
       const editableCues = parsed.map((c, i) => ({ ...c, id: i }))
       setCues(editableCues)
@@ -337,7 +342,7 @@ export function SubtitleScriptEditor({
     } finally {
       setSrtLoading(false)
     }
-  }, [projectSeq, spaceSeq, addToast, t])
+  }, [langCode, projectSeq, spaceSeq, sttCaptionJobId, addToast, t])
 
   const handleToggle = useCallback(() => {
     if (open) {
@@ -713,7 +718,7 @@ export function SubtitleScriptEditor({
               )}
 
               {!scriptLoading && sentences && sentences.length > 0 && (
-                <div className="max-h-[24rem] space-y-2 overflow-y-auto">
+                <div className="max-h-96 space-y-2 overflow-y-auto">
                   {sentences.map((s) => (
                     <ScriptRow
                       key={s.sentenceSeq}
@@ -787,7 +792,7 @@ export function SubtitleScriptEditor({
               )}
 
               {!srtLoading && cues && cues.length > 0 && (
-                <div className="max-h-[28rem] space-y-2 overflow-y-auto">
+                <div className="max-h-112 space-y-2 overflow-y-auto">
                   {cues.map((c) => (
                     <SrtRow
                       key={`${srtRevision}-${c.id}`}

--- a/src/features/dubbing/components/YouTubeExtensionUpload.tsx
+++ b/src/features/dubbing/components/YouTubeExtensionUpload.tsx
@@ -213,7 +213,7 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl, a
   if (extensionStatus === 'not-installed') {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-dashed border-surface-300 p-3 dark:border-surface-700">
-        <AlertCircle className="h-5 w-5 flex-shrink-0 text-surface-500 dark:text-surface-300" />
+        <AlertCircle className="h-5 w-5 shrink-0 text-surface-500 dark:text-surface-300" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-surface-700 dark:text-surface-200">
             {t('features.dubbing.components.youTubeExtensionUpload.chromeExtensionRequired')}

--- a/src/features/dubbing/components/steps/OutputModeStep.tsx
+++ b/src/features/dubbing/components/steps/OutputModeStep.tsx
@@ -99,7 +99,7 @@ export function OutputModeStep() {
 
       {isExternalUrl && (
         <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/10">
-          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500 mt-0.5" />
+          <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500 mt-0.5" />
           <div>
             <p className="text-sm font-medium text-amber-900 dark:text-amber-300">{t('features.dubbing.components.steps.outputModeStep.copyrightNotice')}</p>
             <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
@@ -112,7 +112,7 @@ export function OutputModeStep() {
       {youtubeUploadDisabled && (
         <div className="flex flex-col gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/10 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-start gap-3">
-            <AlertTriangle className="h-5 w-5 flex-shrink-0 text-amber-500 mt-0.5" />
+            <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500 mt-0.5" />
             <div>
               <p className="text-sm font-medium text-amber-900 dark:text-amber-300">{t('features.dubbing.components.steps.outputModeStep.youtubeConnectionRequired')}</p>
               <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">

--- a/src/features/dubbing/components/steps/ProcessingStep.tsx
+++ b/src/features/dubbing/components/steps/ProcessingStep.tsx
@@ -29,6 +29,7 @@ const reasonLabels: Record<string, MessageKey> = {
   READY_TARGET_LANGUAGES: 'dubbing.processing.reason.readyTargetLanguages',
   ENQUEUED: 'dubbing.processing.reason.enqueued',
   PROCESSING: 'dubbing.processing.reason.processing',
+  STT_CAPTION_TRANSLATING: 'dubbing.processing.reason.sttCaptionTranslating',
   COMPLETED: 'dubbing.processing.reason.completed',
   Completed: 'dubbing.processing.reason.completed',
   FAILED: 'dubbing.processing.reason.failed',
@@ -46,7 +47,7 @@ function getProgressLabel(t: ReturnType<typeof useLocaleText>, lp: { progressRea
 }
 
 export function ProcessingStep() {
-  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted, deliverableMode, reset } = useDubbingStore()
+  const { languageProgress, jobStatus, setStep, isSubmitted, setIsSubmitted, deliverableMode, uploadSettings, reset } = useDubbingStore()
   const { submitDubbing, startPolling, stopPolling, cancelAll } = usePersoFlow()
   const locale = useAppLocale()
   const t = useLocaleText()
@@ -90,6 +91,10 @@ export function ProcessingStep() {
     languageProgress.length > 0
       ? Math.round(languageProgress.reduce((acc, p) => acc + p.progress, 0) / languageProgress.length)
       : 0
+  const usesSttCaptionMode =
+    deliverableMode === 'originalWithMultiAudio' &&
+    uploadSettings.uploadCaptions &&
+    uploadSettings.captionGenerationMode === 'stt'
 
   return (
     <div className="mx-auto max-w-3xl space-y-6">
@@ -100,7 +105,9 @@ export function ProcessingStep() {
         <p className="mt-1 text-surface-500 dark:text-surface-300">
           {allCompleted
             ? t('features.dubbing.components.steps.processingStep.reviewTheFinishedFilesAndContinueWithThe')
-            : deliverableMode === 'originalWithMultiAudio'
+            : usesSttCaptionMode
+              ? t('features.dubbing.components.steps.processingStep.creatingCaptionsWithSttAndTranslation')
+              : deliverableMode === 'originalWithMultiAudio'
               ? t('features.dubbing.components.steps.processingStep.creatingCaptionsProcessingTimeDependsOnVideoLength')
               : t('features.dubbing.components.steps.processingStep.creatingCaptionsAndDubbedAudioProcessingTimeDepends')}
         </p>

--- a/src/features/dubbing/components/steps/TranslationEditStep.tsx
+++ b/src/features/dubbing/components/steps/TranslationEditStep.tsx
@@ -55,6 +55,10 @@ export function TranslationEditStep() {
     (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'upload')
   const showsAiDisclosureSetting = deliverableMode === 'newDubbedVideos'
   const showsCaptionSetting = deliverableMode === 'newDubbedVideos' || deliverableMode === 'originalWithMultiAudio'
+  const usesSttCaptionMode =
+    deliverableMode === 'originalWithMultiAudio' &&
+    uploadSettings.uploadCaptions &&
+    uploadSettings.captionGenerationMode === 'stt'
   const deliverableModeLabel = deliverableMode === 'newDubbedVideos'
     ? t('features.dubbing.components.steps.translationEditStep.uploadNewDubbedVideos')
     : deliverableMode === 'originalWithMultiAudio'
@@ -158,6 +162,15 @@ export function TranslationEditStep() {
             />
           )}
 
+          {showsCaptionSetting && uploadSettings.uploadCaptions && deliverableMode === 'originalWithMultiAudio' && (
+            <SummaryRow
+              label={t('features.dubbing.components.steps.translationEditStep.captionProcessing')}
+              value={usesSttCaptionMode
+                ? t('features.dubbing.components.steps.translationEditStep.sttCaptionGeneration')
+                : t('features.dubbing.components.steps.translationEditStep.dubbingCaptionGeneration')}
+            />
+          )}
+
           {uploadsVideoToYouTube && (
             <>
               <SummaryRow
@@ -203,7 +216,9 @@ export function TranslationEditStep() {
           {t('features.dubbing.components.steps.translationEditStep.back')}
         </Button>
         <Button onClick={nextStep} disabled={!canStart}>
-          {t('features.dubbing.components.steps.translationEditStep.startDubbing')}
+          {t(usesSttCaptionMode
+            ? 'features.dubbing.components.steps.translationEditStep.startCaptionProcessing'
+            : 'features.dubbing.components.steps.translationEditStep.startDubbing')}
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
@@ -228,7 +243,7 @@ function SummaryRow({
           <p className="mt-0.5 text-xs text-surface-500 dark:text-surface-300">{description}</p>
         )}
       </div>
-      <div className="max-w-[60%] break-words text-right text-sm font-medium text-surface-900 dark:text-white">
+      <div className="max-w-[60%] wrap-break-word text-right text-sm font-medium text-surface-900 dark:text-white">
         {value}
       </div>
     </div>

--- a/src/features/dubbing/components/steps/UploadSettingsStep.tsx
+++ b/src/features/dubbing/components/steps/UploadSettingsStep.tsx
@@ -50,6 +50,7 @@ export function UploadSettingsStep() {
     ? `https://www.youtube.com/watch?v=${originalYouTubeId}`
     : null
   const aiDisclosureText = getAiDisclosureText(uploadSettings.metadataLanguage)
+  const isMultiAudio = deliverableMode === 'originalWithMultiAudio'
 
   useEffect(() => {
     const strippedDescription = stripAiDisclosureFooter(uploadSettings.description)
@@ -63,6 +64,12 @@ export function UploadSettingsStep() {
       setUploadSettings({ uploadCaptions: false })
     }
   }, [deliverableMode, uploadSettings.autoUpload, uploadSettings.uploadCaptions, setUploadSettings])
+
+  useEffect(() => {
+    if ((!isMultiAudio || !uploadSettings.uploadCaptions) && uploadSettings.captionGenerationMode !== 'dubbing') {
+      setUploadSettings({ captionGenerationMode: 'dubbing' })
+    }
+  }, [isMultiAudio, uploadSettings.captionGenerationMode, uploadSettings.uploadCaptions, setUploadSettings])
 
   // 영상 정보로 제목/설명을 초기 1회 채워준다. 사용자가 빈 값으로 지웠을 때
   // 다시 채워 넣지 않도록 videoMeta.id 단위로 한 번만 실행. (deps에 입력값을
@@ -100,7 +107,6 @@ export function UploadSettingsStep() {
     setUploadSettings({ tags: parsed })
   }
 
-  const isMultiAudio = deliverableMode === 'originalWithMultiAudio'
   const uploadsVideoToYouTube =
     deliverableMode === 'newDubbedVideos' ||
     (isMultiAudio && videoSource?.type === 'upload')
@@ -289,6 +295,27 @@ export function UploadSettingsStep() {
             />
           )}
 
+          {isMultiAudio && uploadSettings.uploadCaptions && !captionUploadDisabled && (
+            <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-brand-100 bg-brand-50/60 p-3 text-sm text-surface-700 dark:border-brand-900/60 dark:bg-brand-950/20 dark:text-surface-200">
+              <input
+                type="checkbox"
+                className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
+                checked={uploadSettings.captionGenerationMode === 'stt'}
+                onChange={(e) => setUploadSettings({
+                  captionGenerationMode: e.target.checked ? 'stt' : 'dubbing',
+                })}
+              />
+              <span className="min-w-0">
+                <span className="block font-medium">
+                  {t('features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithStt')}
+                </span>
+                <span className="mt-1 block text-xs leading-5 text-surface-500 dark:text-surface-300">
+                  {t('features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithSttDescription')}
+                </span>
+              </span>
+            </label>
+          )}
+
           {originalYouTubeUrl && deliverableMode === 'newDubbedVideos' && (
             <ToggleRow
               icon={<Link2 className="h-4 w-4 text-surface-400" />}
@@ -390,7 +417,7 @@ function ToggleRow({ icon, label, description, active, activeLabel, inactiveLabe
   return (
     <div className={`flex flex-col gap-3 rounded-lg bg-surface-50 p-3 dark:bg-surface-800/50 sm:flex-row sm:items-start sm:justify-between ${disabled ? 'opacity-75' : ''}`}>
       <div className="flex min-w-0 items-start gap-2">
-        <div className="mt-0.5 flex-shrink-0">{icon}</div>
+        <div className="mt-0.5 shrink-0">{icon}</div>
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-1.5">
             <p className="text-sm text-surface-700 dark:text-surface-300">{label}</p>

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -18,6 +18,7 @@ import {
   ytUpdateVideoLocalizations,
   getPersoFileUrl,
   getTranslatedSrt,
+  getGeneratedSttCaptionSrt,
   translateMetadata,
   type MetadataTranslation,
 } from '@/lib/api-client'
@@ -80,6 +81,10 @@ export function UploadStep() {
   const shouldUploadCaptions = autoUpload && uploadCaptionsEnabled
   const shouldApplyAiDisclosure = deliverableMode === 'newDubbedVideos' && containsSyntheticMedia
   const videoMetaTitle = videoMeta?.title
+  const isSttCaptionMode =
+    deliverableMode === 'originalWithMultiAudio' &&
+    uploadCaptionsEnabled &&
+    uploadSettings.captionGenerationMode === 'stt'
 
   const [loadingDownload, setLoadingDownload] = useState<string | null>(null)
   const [captionUploads, setCaptionUploads] = useState<Record<string, UploadStatus>>({})
@@ -290,15 +295,25 @@ export function UploadStep() {
   }, [isAuthenticated, originalVideoUrl, settingsTitle, editableDescription, settingsTags, privacyStatus, selfDeclaredMadeForKids, shouldApplyAiDisclosure, videoMeta, addToast, ensureTranslations, selectedLanguages, metadataLanguage, applyDescriptionFooter, t])
 
   // ─── File download ──────────────────────────────────────────────────
+  const loadCaptionSrt = useCallback(async (langCode: string): Promise<string> => {
+    if (isSttCaptionMode) {
+      if (!dbJobId) return ''
+      return getGeneratedSttCaptionSrt(dbJobId, langCode)
+    }
+
+    const pSeq = projectMap[langCode]
+    if (!pSeq || !spaceSeq) return ''
+    return getTranslatedSrt(pSeq, spaceSeq, 'translated')
+  }, [dbJobId, isSttCaptionMode, projectMap, spaceSeq])
+
   const handleDownload = useCallback(async (langCode: string, type: 'video' | 'voiceAudio' | 'translatedSubtitle') => {
     setLoadingDownload(`${langCode}-${type}`)
     try {
       const lang = getLanguageByCode(langCode)
 
       if (type === 'translatedSubtitle') {
-        const pSeq = projectMap[langCode]
-        if (!pSeq || !spaceSeq) return
-        const srtContent = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+        const srtContent = await loadCaptionSrt(langCode)
+        if (!srtContent) return
         const blob = new Blob([srtContent], { type: 'application/x-subrip;charset=utf-8' })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
@@ -333,7 +348,7 @@ export function UploadStep() {
     } finally {
       setLoadingDownload(null)
     }
-  }, [fetchDownloads, projectMap, spaceSeq])
+  }, [fetchDownloads, loadCaptionSrt])
 
   // ─── Upload dubbed video to YouTube (newDubbedVideos mode) ──────────
   const handleYouTubeUpload = useCallback(async (langCode: string, processNow = true) => {
@@ -431,12 +446,10 @@ export function UploadStep() {
     for (const langCode of langs) {
       const lang = getLanguageByCode(langCode)
       if (!lang) continue
-      const pSeq = projectMap[langCode]
-      if (!pSeq || !spaceSeq) continue
 
       setCaptionUploads((prev) => ({ ...prev, [langCode]: 'uploading' }))
       try {
-        const srtContent = await getTranslatedSrt(pSeq, spaceSeq, 'translated')
+        const srtContent = await loadCaptionSrt(langCode)
         if (srtContent.trim().length === 0) {
           setCaptionUploads((prev) => ({ ...prev, [langCode]: 'error' }))
           continue
@@ -456,7 +469,7 @@ export function UploadStep() {
         addToast({ type: 'error', title: t('features.dubbing.components.steps.uploadStep.valueCaptionUploadFailed', { getDisplayLanguageNameLangCode: getDisplayLanguageName(langCode) }), message: msg })
       }
     }
-  }, [projectMap, spaceSeq, addToast, getDisplayLanguageName, t])
+  }, [addToast, getDisplayLanguageName, loadCaptionSrt, t])
 
   const uploadCaptionsWithMetadata = useCallback(async (targetVideoId: string, langs: string[]) => {
     if (deliverableMode === 'originalWithMultiAudio' && videoSource?.type === 'channel') {
@@ -922,7 +935,9 @@ export function UploadStep() {
                     <div>
                       <p className="text-sm font-medium text-surface-900 dark:text-white">{getDisplayLanguageName(code)}</p>
                       <p className="text-xs text-surface-500 dark:text-surface-300">
-                        {deliverableMode === 'originalWithMultiAudio'
+                        {isSttCaptionMode
+                          ? t('features.dubbing.components.steps.uploadStep.captionsOnlyDownload')
+                          : deliverableMode === 'originalWithMultiAudio'
                           ? t('features.dubbing.components.steps.uploadStep.audioCaptions')
                           : t('features.dubbing.components.steps.uploadStep.videoAudioCaptions')}
                       </p>
@@ -931,7 +946,7 @@ export function UploadStep() {
                   <div
                     className={cn(
                       'grid min-w-0 grid-cols-1 gap-2 sm:ml-auto',
-                      deliverableMode === 'originalWithMultiAudio' ? 'sm:grid-cols-2' : 'sm:grid-cols-3',
+                      isSttCaptionMode ? 'sm:grid-cols-1' : deliverableMode === 'originalWithMultiAudio' ? 'sm:grid-cols-2' : 'sm:grid-cols-3',
                     )}
                   >
                     {deliverableMode !== 'originalWithMultiAudio' && (
@@ -940,10 +955,12 @@ export function UploadStep() {
                         <Download className="h-3.5 w-3.5" /> {t('features.dubbing.components.steps.uploadStep.video')}
                       </Button>
                     )}
-                    <Button variant="outline" size="sm" className="min-w-0 justify-center" onClick={() => handleDownload(code, 'voiceAudio')}
-                      loading={loadingDownload === `${code}-voiceAudio`}>
-                      <Download className="h-3.5 w-3.5" /> {t('features.dubbing.components.steps.uploadStep.audio')}
-                    </Button>
+                    {!isSttCaptionMode && (
+                      <Button variant="outline" size="sm" className="min-w-0 justify-center" onClick={() => handleDownload(code, 'voiceAudio')}
+                        loading={loadingDownload === `${code}-voiceAudio`}>
+                        <Download className="h-3.5 w-3.5" /> {t('features.dubbing.components.steps.uploadStep.audio')}
+                      </Button>
+                    )}
                     <Button variant="outline" size="sm" className="min-w-0 justify-center" onClick={() => handleDownload(code, 'translatedSubtitle')}
                       loading={loadingDownload === `${code}-translatedSubtitle`}>
                       <Download className="h-3.5 w-3.5" /> {t('features.dubbing.components.steps.uploadStep.captions2')}
@@ -1012,6 +1029,7 @@ export function UploadStep() {
                   youtubeVideoId={ytUploads[code]?.videoId ?? null}
                   youtubePreviewVisibility={privacyStatus}
                   previewVideoUrl={previewVideoUrl}
+                  sttCaptionJobId={isSttCaptionMode ? dbJobId : null}
                 />
               )
             })}

--- a/src/features/dubbing/components/steps/VideoInputStep.tsx
+++ b/src/features/dubbing/components/steps/VideoInputStep.tsx
@@ -369,7 +369,7 @@ export function VideoInputStep() {
                 />
               </div>
 
-              <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
+              <div className="max-h-105 space-y-2 overflow-y-auto pr-1">
                 {filteredVideos.length === 0 ? (
                   <p className="py-8 text-center text-sm text-surface-500 dark:text-surface-300">{t('features.dubbing.components.steps.videoInputStep.noMatchingVideos')}</p>
                 ) : (

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -14,6 +14,8 @@ import {
   uploadExternalVideo,
   initializeQueue,
   submitTranslation,
+  submitStt,
+  generateSttCaptions,
   getProjectProgress,
   getDownloadLinks,
   getPersoFileUrl,
@@ -48,6 +50,7 @@ function mapProgressReasonToStatus(reason: string) {
     case 'READY_TARGET_LANGUAGES':
     case 'Transcribing':
     case 'Translating':
+    case 'STT_CAPTION_TRANSLATING':
       return 'translating' as const
     case 'ENQUEUED':
     case 'Uploading':
@@ -70,6 +73,13 @@ function mapProgressReasonToStatus(reason: string) {
 }
 
 const store = useDubbingStore
+
+function isSttCaptionMode() {
+  const state = store.getState()
+  return state.deliverableMode === 'originalWithMultiAudio' &&
+    state.uploadSettings.uploadCaptions &&
+    state.uploadSettings.captionGenerationMode === 'stt'
+}
 
 async function saveJobToDb(
   mediaSeq: number,
@@ -218,6 +228,147 @@ async function pollLanguage(
   return true
 }
 
+async function pollSttCaptionJob(
+  projectSeq: number,
+  spaceSeq: number,
+  pollTimers: Record<string, ReturnType<typeof setTimeout>>,
+  addToast: ReturnType<typeof useNotificationStore.getState>['addToast'],
+  t: LocaleText,
+): Promise<boolean | 'finalizing'> {
+  const progress = await getProjectProgress(projectSeq, spaceSeq)
+  const dbJobId = store.getState().dbJobId
+  const langCodes = store.getState().languageProgress.map((lp) => lp.langCode)
+  const sttProgress = Math.min(70, Math.max(0, Math.round(progress.progress * 0.7)))
+  const status = mapProgressReasonToStatus(progress.progressReason)
+
+  for (const langCode of langCodes) {
+    store.getState().updateLanguageProgress(langCode, {
+      status,
+      progress: sttProgress,
+      progressReason: progress.progressReason,
+    })
+    if (dbJobId) {
+      dbMutation({
+        type: 'updateJobLanguageProgress',
+        payload: {
+          jobId: dbJobId,
+          langCode,
+          status,
+          progress: sttProgress,
+          progressReason: progress.progressReason,
+        },
+      }).catch(() => { /* progress update is best-effort */ })
+    }
+  }
+
+  const reason = progress.progressReason
+  const isTerminal = reason === 'COMPLETED' || reason === 'Completed' || reason === 'FAILED' || reason === 'Failed' || reason === 'CANCELED'
+  if (!isTerminal) {
+    if (progress.progress >= 100) return 'finalizing'
+    return false
+  }
+
+  clearTimeout(pollTimers.stt)
+  delete pollTimers.stt
+
+  if (reason === 'COMPLETED' || reason === 'Completed') {
+    for (const langCode of langCodes) {
+      store.getState().updateLanguageProgress(langCode, {
+        status: 'translating',
+        progress: 72,
+        progressReason: 'STT_CAPTION_TRANSLATING',
+      })
+      if (dbJobId) {
+        dbMutation({
+          type: 'updateJobLanguageProgress',
+          payload: {
+            jobId: dbJobId,
+            langCode,
+            status: 'translating',
+            progress: 72,
+            progressReason: 'STT_CAPTION_TRANSLATING',
+          },
+        }).catch(() => { /* progress update is best-effort */ })
+      }
+    }
+
+    if (!dbJobId) throw new Error(t('features.dubbing.hooks.usePersoFlow.missingVideoInformationPleaseStartAgain'))
+
+    try {
+      const result = await generateSttCaptions({
+        jobId: dbJobId,
+        projectSeq,
+        spaceSeq,
+        targetLanguageCodes: langCodes,
+        sourceLanguageCode: DEFAULT_SOURCE_LANGUAGE,
+      })
+      const byLang = new Map(result.languages.map((item) => [item.langCode, item]))
+      const failedLangs = new Set((result.failedLanguages ?? []).map((item) => item.langCode))
+      for (const langCode of langCodes) {
+        const caption = byLang.get(langCode)
+        if (failedLangs.has(langCode) || !caption) {
+          store.getState().updateLanguageProgress(langCode, {
+            status: 'failed',
+            progressReason: 'FAILED',
+          })
+          continue
+        }
+        store.getState().updateLanguageProgress(langCode, {
+          status: 'completed',
+          progress: 100,
+          progressReason: 'COMPLETED',
+          srtUrl: caption.srtUrl,
+        })
+      }
+    } catch (err) {
+      for (const langCode of langCodes) {
+        store.getState().updateLanguageProgress(langCode, {
+          status: 'failed',
+          progressReason: 'FAILED',
+        })
+        if (dbJobId) {
+          dbMutation({
+            type: 'updateJobLanguageProgress',
+            payload: {
+              jobId: dbJobId,
+              langCode,
+              status: 'failed',
+              progress: 0,
+              progressReason: 'FAILED',
+            },
+          }).catch(() => { /* failure update is best-effort */ })
+        }
+      }
+      addToast({
+        type: 'error',
+        title: t('features.dubbing.hooks.usePersoFlow.captionGenerationFailed'),
+        message: err instanceof Error ? err.message : '',
+      })
+    }
+  }
+
+  const allProgress = store.getState().languageProgress
+  const anyFailed = allProgress.some((lp) => lp.progressReason === 'FAILED' || lp.progressReason === 'Failed' || lp.progressReason === 'CANCELED')
+  const newStatus = anyFailed ? 'failed' : 'completed'
+  const prevJobStatus = store.getState().jobStatus
+  const alreadyFinalized = prevJobStatus === 'completed' || prevJobStatus === 'failed'
+  store.getState().setJobStatus(newStatus)
+
+  if (dbJobId && !alreadyFinalized) {
+    await dbMutationStrict({ type: 'finalizeJobCredits', payload: { jobId: dbJobId } })
+  }
+  if (dbJobId) {
+    await dbMutation({ type: 'updateJobStatus', payload: { jobId: dbJobId, status: newStatus } })
+  }
+  addToast({
+    type: anyFailed ? 'warning' : 'success',
+    title: anyFailed
+      ? t('features.dubbing.hooks.usePersoFlow.captionGenerationFinishedWithSomeErrors')
+      : t('features.dubbing.hooks.usePersoFlow.captionGenerationComplete'),
+  })
+  return true
+}
+
 async function cancelAllProjects(
   addToast: ReturnType<typeof useNotificationStore.getState>['addToast'],
   reason: string,
@@ -231,10 +382,19 @@ async function cancelAllProjects(
             lp.progressReason !== 'CANCELED',
   )
 
+  const canceledProjects = new Set<number>()
   await Promise.allSettled(
     activeLangs.map(async (lp) => {
       const projectSeq = projectMap[lp.langCode]
       if (!projectSeq) return
+      if (canceledProjects.has(projectSeq)) {
+        store.getState().updateLanguageProgress(lp.langCode, {
+          status: 'failed',
+          progressReason: 'CANCELED',
+        })
+        return
+      }
+      canceledProjects.add(projectSeq)
       try {
         await cancelProject(projectSeq, spaceSeq)
       } catch {
@@ -355,10 +515,13 @@ export function usePersoFlow() {
       throw new Error(t('features.dubbing.hooks.usePersoFlow.missingVideoInformationPleaseStartAgain'))
     }
     const targetLanguages = Array.from(new Set(selectedLanguages))
+    const sttCaptionMode = isSttCaptionMode()
 
     addToast({
       type: 'info',
-      title: t('features.dubbing.hooks.usePersoFlow.startingDubbingJob'),
+      title: t(sttCaptionMode
+        ? 'features.dubbing.hooks.usePersoFlow.startingSttCaptionJob'
+        : 'features.dubbing.hooks.usePersoFlow.startingDubbingJob'),
       message: countLocaleMessage(locale, targetLanguages.length, 'features.dubbing.hooks.usePersoFlow.unitLanguages', t),
     })
 
@@ -380,6 +543,45 @@ export function usePersoFlow() {
         t,
       )
       await dbMutationStrict({ type: 'reserveJobCredits', payload: { jobId: dbJobId } })
+
+      if (sttCaptionMode) {
+        const result = await submitStt(spaceSeq, {
+          mediaSeq,
+          isVideoProject: true,
+          title: videoMeta?.title?.trim() || `Dubtube STT project ${mediaSeq}`,
+        })
+        const projectSeq = result.startGenerateProjectIdList?.[0]
+        if (!projectSeq) {
+          throw new Error(t('features.dubbing.hooks.usePersoFlow.failedToStartDubbing'))
+        }
+
+        const projectMap = Object.fromEntries(targetLanguages.map((lang) => [lang, projectSeq]))
+        store.getState().setProjectMap(projectMap)
+        const initialProgress: LanguageProgress[] = targetLanguages.map((code) => ({
+          langCode: code,
+          projectSeq,
+          status: 'transcribing',
+          progress: 0,
+          progressReason: 'PENDING',
+        }))
+        store.getState().setLanguageProgress(initialProgress)
+        store.getState().setJobStatus('transcribing')
+
+        await dbMutationStrict({
+          type: 'updateJobLanguageProjects',
+          payload: {
+            jobId: dbJobId,
+            languages: targetLanguages.map((code) => ({ code, projectSeq })),
+          },
+        })
+
+        addToast({
+          type: 'success',
+          title: t('features.dubbing.hooks.usePersoFlow.sttCaptionJobStarted'),
+          message: countLocaleMessage(locale, targetLanguages.length, 'features.dubbing.hooks.usePersoFlow.unitLanguagesProcessing', t),
+        })
+        return projectMap
+      }
 
       const result = await submitTranslation(spaceSeq, {
         mediaSeq,
@@ -460,6 +662,28 @@ export function usePersoFlow() {
           scheduleNext(langCode, projectSeq, interval)
         }
       }, interval)
+    }
+
+    function scheduleStt(projectSeq: number, interval: number) {
+      pollTimers.current.stt = setTimeout(async () => {
+        try {
+          const done = await pollSttCaptionJob(projectSeq, spaceSeq!, pollTimers.current, addToast, t)
+          if (!done) {
+            const next = Math.min(interval * POLL_BACKOFF, POLL_INTERVAL_MAX)
+            scheduleStt(projectSeq, next)
+          } else if (done === 'finalizing') {
+            scheduleStt(projectSeq, POLL_FINALIZING)
+          }
+        } catch {
+          scheduleStt(projectSeq, interval)
+        }
+      }, interval)
+    }
+
+    if (isSttCaptionMode()) {
+      const projectSeq = Object.values(projectMap).find((value) => value > 0)
+      if (projectSeq) scheduleStt(projectSeq, POLL_INTERVAL_MIN)
+      return
     }
 
     Object.entries(projectMap).forEach(([langCode, projectSeq]) => {

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -59,6 +59,7 @@ const buildDefaultUploadSettings = (): UploadSettings => ({
   selfDeclaredMadeForKids: false,
   containsSyntheticMedia: true,
   uploadReviewConfirmed: false,
+  captionGenerationMode: 'dubbing',
   metadataLanguage: readDefaultLanguage(),
 })
 
@@ -71,6 +72,7 @@ const REVIEW_RESET_FIELDS: Array<keyof UploadSettings> = [
   'privacyStatus',
   'metadataLanguage',
   'uploadCaptions',
+  'captionGenerationMode',
   'selfDeclaredMadeForKids',
   'containsSyntheticMedia',
 ]

--- a/src/features/dubbing/types/dubbing.types.ts
+++ b/src/features/dubbing/types/dubbing.types.ts
@@ -2,6 +2,8 @@ export type DubbingStep = 1 | 2 | 3 | 4 | 5 | 6 | 7
 
 export type DeliverableMode = 'newDubbedVideos' | 'originalWithMultiAudio' | 'downloadOnly'
 
+export type CaptionGenerationMode = 'dubbing' | 'stt'
+
 export type PrivacyStatus = 'public' | 'unlisted' | 'private'
 
 export interface UploadSettings {
@@ -15,6 +17,7 @@ export interface UploadSettings {
   selfDeclaredMadeForKids: boolean
   containsSyntheticMedia: boolean
   uploadReviewConfirmed: boolean
+  captionGenerationMode: CaptionGenerationMode
   /**
    * 사용자가 작성한 제목/설명의 언어. 다른 대상 언어로 자동 번역하는 기준.
    * 마이페이지의 `defaultLanguage`로 초기화되며 더빙별로 override 가능.

--- a/src/features/landing/Hero.tsx
+++ b/src/features/landing/Hero.tsx
@@ -145,7 +145,7 @@ export function Hero() {
                   return (
                     <div key={step.title} className="relative flex gap-3 py-2.5">
                       {index < pipelineSteps.length - 1 ? (
-                        <div className={`absolute left-[17px] top-10 h-[calc(100%-1.5rem)] w-px ${
+                        <div className={`absolute left-4.25 top-10 h-[calc(100%-1.5rem)] w-px ${
                           isDone ? 'bg-brand-200 dark:bg-brand-800' : 'bg-surface-200 dark:bg-surface-800'
                         }`} />
                       ) : null}

--- a/src/lib/api-client/index.ts
+++ b/src/lib/api-client/index.ts
@@ -10,6 +10,8 @@ export {
   validateMedia,
   initializeQueue,
   submitTranslation,
+  submitStt,
+  generateSttCaptions,
   cancelProject,
   getProjectProgress,
   listProjects,
@@ -19,6 +21,7 @@ export {
   regenerateSentenceAudio,
   getDownloadLinks,
   getTranslatedSrt,
+  getGeneratedSttCaptionSrt,
   requestLipSync,
   getPersoFileUrl,
 } from './perso'

--- a/src/lib/api-client/perso.ts
+++ b/src/lib/api-client/perso.ts
@@ -9,6 +9,8 @@ import type {
   ProjectDetail,
   SasTokenResponse,
   ScriptSentence,
+  SttRequest,
+  SttResponse,
   TranslateRequest,
   TranslateResponse,
   UploadVideoResponse,
@@ -130,6 +132,38 @@ export function submitTranslation(
   return sendJson(`${PERSO}/translate?spaceSeq=${spaceSeq}`, 'POST', body)
 }
 
+export function submitStt(
+  spaceSeq: number,
+  body: SttRequest,
+): Promise<SttResponse> {
+  return sendJson(`${PERSO}/stt?spaceSeq=${spaceSeq}`, 'POST', body)
+}
+
+export interface GenerateSttCaptionsRequest {
+  jobId: number
+  projectSeq: number
+  spaceSeq: number
+  targetLanguageCodes: string[]
+  sourceLanguageCode?: string
+}
+
+export interface GeneratedSttCaptionResult {
+  langCode: string
+  srtUrl: string
+  cueCount: number
+}
+
+export interface FailedSttCaptionResult {
+  langCode: string
+  error: string
+}
+
+export function generateSttCaptions(
+  body: GenerateSttCaptionsRequest,
+): Promise<{ languages: GeneratedSttCaptionResult[]; failedLanguages?: FailedSttCaptionResult[] }> {
+  return sendJson(`${PERSO}/stt/captions`, 'POST', body)
+}
+
 // ─── Cancel ──────────────────────────────────────────────────
 
 export function cancelProject(
@@ -236,6 +270,25 @@ export async function getTranslatedSrt(
       if (body?.error?.message) msg = body.error.message
     } catch {
       // raw error response
+    }
+    throw new Error(msg)
+  }
+  return res.text()
+}
+
+export async function getGeneratedSttCaptionSrt(
+  jobId: number,
+  langCode: string,
+): Promise<string> {
+  const qs = new URLSearchParams({ jobId: String(jobId), langCode }).toString()
+  const res = await fetch(`${PERSO}/stt/captions?${qs}`, { cache: 'no-store' })
+  if (!res.ok) {
+    let msg = 'Could not load the generated caption file. Please try again.'
+    try {
+      const body = await res.json()
+      if (body?.error?.message) msg = body.error.message
+    } catch {
+      // Keep fallback message.
     }
     throw new Error(msg)
   }

--- a/src/lib/db/queries/credits.test.ts
+++ b/src/lib/db/queries/credits.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { calculateJobCreditMinutes } from './credits'
+
+describe('calculateJobCreditMinutes', () => {
+  it('charges full rounded video minutes per completed dubbing language', () => {
+    expect(calculateJobCreditMinutes({
+      perLanguageMinutes: 20,
+      languageCount: 5,
+      completedCount: 3,
+      isSttCaptionJob: false,
+    })).toMatchObject({
+      billingMultiplier: 1,
+      billableUnits: 5,
+      completedBillableUnits: 3,
+      billingMode: 'per_language_dubbing',
+      estimatedMinutes: 100,
+      completedMinutes: 60,
+    })
+  })
+
+  it('charges STT caption jobs per language at half price', () => {
+    expect(calculateJobCreditMinutes({
+      perLanguageMinutes: 20,
+      languageCount: 5,
+      completedCount: 3,
+      isSttCaptionJob: true,
+    })).toMatchObject({
+      billingMultiplier: 0.5,
+      billableUnits: 5,
+      completedBillableUnits: 3,
+      billingMode: 'stt_caption_half_per_language',
+      estimatedMinutes: 50,
+      completedMinutes: 30,
+    })
+  })
+
+  it('keeps minimum integer-minute billing for very short STT caption jobs', () => {
+    expect(calculateJobCreditMinutes({
+      perLanguageMinutes: 1,
+      languageCount: 1,
+      completedCount: 1,
+      isSttCaptionJob: true,
+    })).toMatchObject({
+      estimatedMinutes: 1,
+      completedMinutes: 1,
+    })
+  })
+})

--- a/src/lib/db/queries/credits.ts
+++ b/src/lib/db/queries/credits.ts
@@ -2,6 +2,7 @@ import 'server-only'
 
 import type { Client, Transaction } from '@libsql/client'
 import { getDb } from '@/lib/db/client'
+import { parseJobUploadSettings } from '@/lib/dubbing/job-upload-settings'
 import { recordOperationalEventSafe } from '@/lib/ops/observability'
 
 type DbExecutor = Pick<Client | Transaction, 'execute'>
@@ -127,7 +128,7 @@ async function getCreditBalanceWithExecutor(userId: string, db: DbExecutor): Pro
 
 async function getJobCreditEstimate(jobId: number, db: DbExecutor) {
   const result = await db.execute({
-    sql: `SELECT dj.user_id, dj.video_duration_ms,
+    sql: `SELECT dj.user_id, dj.video_duration_ms, dj.deliverable_mode, dj.upload_settings_json,
           COUNT(jl.language_code) as language_count,
           SUM(CASE WHEN jl.status = 'completed' THEN 1 ELSE 0 END) as completed_count
           FROM dubbing_jobs dj
@@ -146,12 +147,23 @@ async function getJobCreditEstimate(jobId: number, db: DbExecutor) {
 
   const perLanguageMinutes = Math.max(1, Math.ceil(asNumber(row.video_duration_ms) / 60_000))
   const languageCount = Math.max(1, asNumber(row.language_count))
+  const settings = parseJobUploadSettings(String(row.upload_settings_json ?? ''))
+  const isSttCaptionJob =
+    row.deliverable_mode === 'originalWithMultiAudio' &&
+    settings.uploadSettings.uploadCaptions &&
+    settings.uploadSettings.captionGenerationMode === 'stt'
+  const creditMinutes = calculateJobCreditMinutes({
+    perLanguageMinutes,
+    languageCount,
+    completedCount: asNumber(row.completed_count),
+    isSttCaptionJob,
+  })
   return {
     userId: String(row.user_id),
     perLanguageMinutes,
     languageCount,
-    completedCount: asNumber(row.completed_count),
-    estimatedMinutes: perLanguageMinutes * languageCount,
+    completedCount: creditMinutes.completedBillableUnits,
+    ...creditMinutes,
   }
 }
 
@@ -183,6 +195,28 @@ function insufficientCredits(available: number, required: number) {
   err.code = 'INSUFFICIENT_CREDITS'
   err.details = { available, required }
   return err
+}
+
+export function calculateJobCreditMinutes(args: {
+  perLanguageMinutes: number
+  languageCount: number
+  completedCount: number
+  isSttCaptionJob: boolean
+}) {
+  const perLanguageMinutes = Math.max(1, Math.ceil(args.perLanguageMinutes))
+  const languageCount = Math.max(1, Math.ceil(args.languageCount))
+  const completedCount = Math.max(0, Math.ceil(args.completedCount))
+  const billingMultiplier = args.isSttCaptionJob ? 0.5 : 1
+  return {
+    billingMultiplier,
+    billableUnits: languageCount,
+    completedBillableUnits: completedCount,
+    billingMode: args.isSttCaptionJob ? 'stt_caption_half_per_language' : 'per_language_dubbing',
+    estimatedMinutes: Math.max(1, Math.ceil(perLanguageMinutes * languageCount * billingMultiplier)),
+    completedMinutes: completedCount > 0
+      ? Math.max(1, Math.ceil(perLanguageMinutes * completedCount * billingMultiplier))
+      : 0,
+  }
 }
 
 export async function createPaymentOrder(order: {
@@ -318,6 +352,9 @@ export async function reserveJobCredits(userId: string, jobId: number) {
         JSON.stringify({
           perLanguageMinutes: estimate.perLanguageMinutes,
           languageCount: estimate.languageCount,
+          billableUnits: estimate.billableUnits,
+          billingMultiplier: estimate.billingMultiplier,
+          billingMode: estimate.billingMode,
         }),
       ],
     })
@@ -382,7 +419,7 @@ export async function finalizeJobCredits(userId: string, jobId: number) {
       return { consumed: 0, released: 0, idempotent: true }
     }
 
-    const consumed = Math.min(reserved, estimate.perLanguageMinutes * estimate.completedCount)
+    const consumed = Math.min(reserved, estimate.completedMinutes)
     await tx.execute({
       sql: `UPDATE users
             SET credits_remaining = MAX(0, credits_remaining - ?), updated_at = datetime('now')
@@ -405,6 +442,10 @@ export async function finalizeJobCredits(userId: string, jobId: number) {
         JSON.stringify({
           completedCount: estimate.completedCount,
           languageCount: estimate.languageCount,
+          billableUnits: estimate.billableUnits,
+          completedBillableUnits: estimate.completedBillableUnits,
+          billingMultiplier: estimate.billingMultiplier,
+          billingMode: estimate.billingMode,
           releasedUnused: reserved - consumed,
         }),
       ],

--- a/src/lib/db/queries/generated-captions.ts
+++ b/src/lib/db/queries/generated-captions.ts
@@ -1,0 +1,113 @@
+import 'server-only'
+
+import { getDb } from '@/lib/db/client'
+
+export interface GeneratedCaption {
+  userId: string
+  jobId: number
+  languageCode: string
+  sourceProjectSeq: number | null
+  sourceType: string
+  srtContent: string
+  cueCount: number
+}
+
+let generatedCaptionTablesReady = false
+
+async function ensureGeneratedCaptionTables() {
+  if (generatedCaptionTablesReady) return
+  const db = getDb()
+  await db.batch([
+    {
+      sql: `CREATE TABLE IF NOT EXISTS generated_captions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        job_id INTEGER NOT NULL,
+        language_code TEXT NOT NULL,
+        source_project_seq INTEGER,
+        source_type TEXT NOT NULL DEFAULT 'stt',
+        srt_content TEXT NOT NULL,
+        cue_count INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (job_id) REFERENCES dubbing_jobs(id) ON DELETE CASCADE,
+        UNIQUE (job_id, language_code)
+      )`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_generated_captions_user_created
+        ON generated_captions (user_id, created_at DESC)`,
+      args: [],
+    },
+    {
+      sql: `CREATE INDEX IF NOT EXISTS idx_generated_captions_job_language
+        ON generated_captions (job_id, language_code)`,
+      args: [],
+    },
+  ])
+  generatedCaptionTablesReady = true
+}
+
+export async function upsertGeneratedCaption(args: {
+  userId: string
+  jobId: number
+  languageCode: string
+  sourceProjectSeq?: number | null
+  sourceType?: string
+  srtContent: string
+  cueCount: number
+}) {
+  await ensureGeneratedCaptionTables()
+  await getDb().execute({
+    sql: `INSERT INTO generated_captions
+          (user_id, job_id, language_code, source_project_seq, source_type, srt_content, cue_count, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+          ON CONFLICT(job_id, language_code) DO UPDATE SET
+            user_id = excluded.user_id,
+            source_project_seq = excluded.source_project_seq,
+            source_type = excluded.source_type,
+            srt_content = excluded.srt_content,
+            cue_count = excluded.cue_count,
+            updated_at = datetime('now')`,
+    args: [
+      args.userId,
+      args.jobId,
+      args.languageCode,
+      args.sourceProjectSeq ?? null,
+      args.sourceType ?? 'stt',
+      args.srtContent,
+      args.cueCount,
+    ],
+  })
+}
+
+export async function getGeneratedCaption(jobId: number, languageCode: string): Promise<GeneratedCaption | null> {
+  await ensureGeneratedCaptionTables()
+  const result = await getDb().execute({
+    sql: `SELECT user_id, job_id, language_code, source_project_seq, source_type, srt_content, cue_count
+          FROM generated_captions
+          WHERE job_id = ? AND language_code = ?
+          LIMIT 1`,
+    args: [jobId, languageCode],
+  })
+  const row = result.rows[0]
+  if (!row) return null
+  return {
+    userId: String(row.user_id),
+    jobId: Number(row.job_id),
+    languageCode: String(row.language_code),
+    sourceProjectSeq: row.source_project_seq == null ? null : Number(row.source_project_seq),
+    sourceType: String(row.source_type),
+    srtContent: String(row.srt_content),
+    cueCount: Number(row.cue_count ?? 0),
+  }
+}
+
+export async function deleteGeneratedCaptionsForJob(jobId: number) {
+  await ensureGeneratedCaptionTables()
+  await getDb().execute({
+    sql: 'DELETE FROM generated_captions WHERE job_id = ?',
+    args: [jobId],
+  })
+}

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -64,3 +64,9 @@ export {
   getUserYouTubeUploads,
   getCompletedJobLanguages,
 } from './dashboard'
+
+export {
+  upsertGeneratedCaption,
+  getGeneratedCaption,
+  deleteGeneratedCaptionsForJob,
+} from './generated-captions'

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -7,6 +7,7 @@ import {
   type PersistedDeliverableMode,
   type PersistedJobUploadSettings,
 } from '@/lib/dubbing/job-upload-settings'
+import { deleteGeneratedCaptionsForJob } from './generated-captions'
 
 export interface DubbingJobUploadSettingsInput {
   deliverableMode?: PersistedDeliverableMode
@@ -299,7 +300,13 @@ export async function getDubbingJobLanguageWorkItems(limit = 50): Promise<Dubbin
           LIMIT ?`,
     args: [limit],
   })
-  return result.rows.map((row) => rowToDubbingJobLanguageWorkItem(row))
+  return result.rows
+    .map((row) => rowToDubbingJobLanguageWorkItem(row))
+    .filter((item) => !(
+      item.deliverableMode === 'originalWithMultiAudio' &&
+      item.uploadSettings.uploadSettings.uploadCaptions &&
+      item.uploadSettings.uploadSettings.captionGenerationMode === 'stt'
+    ))
 }
 
 export async function getDubbingJobLanguageWorkItem(
@@ -365,6 +372,7 @@ export async function getJobLanguageTerminalSummary(jobId: number) {
 
 export async function deleteDubbingJob(jobId: number) {
   const db = getDb()
+  await deleteGeneratedCaptionsForJob(jobId)
   await db.batch([
     { sql: 'DELETE FROM job_languages WHERE job_id = ?', args: [jobId] },
     { sql: 'DELETE FROM dubbing_jobs WHERE id = ?', args: [jobId] },

--- a/src/lib/dubbing/job-upload-settings.ts
+++ b/src/lib/dubbing/job-upload-settings.ts
@@ -1,5 +1,7 @@
 export type PersistedDeliverableMode = 'newDubbedVideos' | 'originalWithMultiAudio' | 'downloadOnly'
 
+export type PersistedCaptionGenerationMode = 'dubbing' | 'stt'
+
 export type PersistedPrivacyStatus = 'public' | 'unlisted' | 'private'
 
 export interface PersistedUploadSettings {
@@ -13,6 +15,7 @@ export interface PersistedUploadSettings {
   selfDeclaredMadeForKids: boolean
   containsSyntheticMedia: boolean
   uploadReviewConfirmed: boolean
+  captionGenerationMode: PersistedCaptionGenerationMode
   metadataLanguage: string
 }
 
@@ -34,6 +37,7 @@ const DEFAULT_UPLOAD_SETTINGS: PersistedUploadSettings = {
   selfDeclaredMadeForKids: false,
   containsSyntheticMedia: true,
   uploadReviewConfirmed: false,
+  captionGenerationMode: 'dubbing',
   metadataLanguage: 'ko',
 }
 
@@ -82,6 +86,10 @@ function asDeliverableMode(value: unknown): PersistedDeliverableMode {
     : DEFAULT_JOB_UPLOAD_SETTINGS.deliverableMode
 }
 
+function asCaptionGenerationMode(value: unknown): PersistedCaptionGenerationMode {
+  return value === 'stt' ? 'stt' : DEFAULT_UPLOAD_SETTINGS.captionGenerationMode
+}
+
 export function normalizeJobUploadSettings(value: unknown): PersistedJobUploadSettings {
   const root = asObject(value)
   const uploadSettings = asObject(root.uploadSettings)
@@ -109,6 +117,7 @@ export function normalizeJobUploadSettings(value: unknown): PersistedJobUploadSe
         uploadSettings.uploadReviewConfirmed,
         DEFAULT_UPLOAD_SETTINGS.uploadReviewConfirmed,
       ),
+      captionGenerationMode: asCaptionGenerationMode(uploadSettings.captionGenerationMode),
       metadataLanguage: asString(uploadSettings.metadataLanguage, DEFAULT_UPLOAD_SETTINGS.metadataLanguage),
     },
   }

--- a/src/lib/dubbing/process.test.ts
+++ b/src/lib/dubbing/process.test.ts
@@ -53,6 +53,7 @@ const uploadSettings = {
     selfDeclaredMadeForKids: false,
     containsSyntheticMedia: true,
     uploadReviewConfirmed: true,
+    captionGenerationMode: 'dubbing' as const,
     metadataLanguage: 'ko',
   },
 }

--- a/src/lib/i18n/client-messages/common.ts
+++ b/src/lib/i18n/client-messages/common.ts
@@ -64,6 +64,10 @@ export const commonMessages = {
   'dubbing.processing.reason.processing': { ko: '더빙 오디오를 만드는 중...', en: 'Creating dubbed audio...' },
   'dubbing.processing.reason.ready': { ko: '전사를 준비하는 중...', en: 'Preparing transcription...' },
   'dubbing.processing.reason.readyTargetLanguages': { ko: '번역하는 중...', en: 'Translating...' },
+  'dubbing.processing.reason.sttCaptionTranslating': {
+    ko: 'STT 기반 자막 번역 중...',
+    en: 'Translating STT captions...',
+  },
   'dubbing.processing.status.completed': { ko: '완료', en: 'Complete' },
   'dubbing.processing.status.failed': { ko: '실패', en: 'Failed' },
   'dubbing.processing.status.idle': { ko: '대기 중', en: 'Waiting' },
@@ -104,21 +108,53 @@ export const commonMessages = {
     ko: '영상 길이(올림)',
     en: 'Video length (rounded up)',
   },
+  'features.dubbing.components.steps.processingStep.creatingCaptionsWithSttAndTranslation': {
+    ko: '원본 영상은 STT로 한 번 전사하고, 선택한 언어별 YouTube 자막을 생성합니다.',
+    en: 'Transcribing the source video once with STT, then generating YouTube captions for each selected language.',
+  },
+  'features.dubbing.components.steps.translationEditStep.captionProcessing': {
+    ko: '자막 처리',
+    en: 'Caption processing',
+  },
   'features.dubbing.components.steps.translationEditStep.channelWithSubscriberCount': {
     ko: '{title} · 구독자 {count}',
     en: '{title} · {count} subscribers',
+  },
+  'features.dubbing.components.steps.translationEditStep.dubbingCaptionGeneration': {
+    ko: '기존 더빙 처리',
+    en: 'Existing dubbing flow',
   },
   'features.dubbing.components.steps.translationEditStep.metadataBasedOn': {
     ko: '{language} 기준',
     en: 'Based on {language}',
   },
+  'features.dubbing.components.steps.translationEditStep.startCaptionProcessing': {
+    ko: '자막 처리 시작',
+    en: 'Start caption processing',
+  },
+  'features.dubbing.components.steps.translationEditStep.sttCaptionGeneration': {
+    ko: 'STT 기반 생성',
+    en: 'STT-based generation',
+  },
   'features.dubbing.components.steps.uploadSettingsStep.defaultDescription': {
     ko: '{title} - Dubtube AI 더빙',
     en: '{title} - Dubtube AI dubbing',
   },
+  'features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithStt': {
+    ko: 'STT로 자막 생성',
+    en: 'Generate captions with STT',
+  },
+  'features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithSttDescription': {
+    ko: '원본 영상은 STT 한 번만 실행하고, Gemini가 선택한 언어별 YouTube 자막으로 변환합니다.',
+    en: 'Run STT once on the source video, then let Gemini create YouTube captions for each selected language.',
+  },
   'features.dubbing.components.steps.uploadStep.captionOnlyEditsApplyToCaptionFiles': {
     ko: '이 모드에서는 자막 텍스트와 시간만 편집합니다. 대사 수정과 오디오 재생성은 숨겨집니다.',
     en: 'In this mode, edit only caption text and timing. Dialogue editing and audio regeneration are hidden.',
+  },
+  'features.dubbing.components.steps.uploadStep.captionsOnlyDownload': {
+    ko: '자막',
+    en: 'Captions',
   },
   'features.dubbing.components.steps.uploadStep.completedLanguageProgress': {
     ko: '{completed} / {total}개 언어 완료. ',
@@ -199,6 +235,26 @@ export const commonMessages = {
   'features.dubbing.components.subtitleScriptEditor.valueCaptionsOnly': {
     ko: '{languageName} 자막',
     en: '{languageName} captions',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationComplete': {
+    ko: '자막 생성 완료',
+    en: 'Caption generation complete',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationFailed': {
+    ko: '자막 생성 실패',
+    en: 'Caption generation failed',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationFinishedWithSomeErrors': {
+    ko: '자막 생성이 일부 실패했습니다',
+    en: 'Caption generation finished with some errors',
+  },
+  'features.dubbing.hooks.usePersoFlow.startingSttCaptionJob': {
+    ko: 'STT 자막 작업 시작',
+    en: 'Starting STT caption job',
+  },
+  'features.dubbing.hooks.usePersoFlow.sttCaptionJobStarted': {
+    ko: 'STT 자막 작업이 시작되었습니다',
+    en: 'STT caption job started',
   },
   'features.landing.pricingSection.included1080pOutput': { ko: '1080p 출력', en: '1080p output' },
   'features.landing.pricingSection.includedLanguageCount': {

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -172,6 +172,62 @@ const baseMessages = {
   'dubbing.processing.reason.completed': { ko: '완료', en: 'Complete' },
   'dubbing.processing.reason.failed': { ko: '처리 실패', en: 'Processing failed' },
   'dubbing.processing.reason.canceled': { ko: '취소됨', en: 'Canceled' },
+  'dubbing.processing.reason.sttCaptionTranslating': {
+    ko: 'STT 기반 자막 번역 중...',
+    en: 'Translating STT captions...',
+  },
+  'features.dubbing.components.steps.processingStep.creatingCaptionsWithSttAndTranslation': {
+    ko: '원본 영상은 STT로 한 번 전사하고, 선택한 언어별 YouTube 자막을 생성합니다.',
+    en: 'Transcribing the source video once with STT, then generating YouTube captions for each selected language.',
+  },
+  'features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithStt': {
+    ko: 'STT로 자막 생성',
+    en: 'Generate captions with STT',
+  },
+  'features.dubbing.components.steps.uploadSettingsStep.generateCaptionsWithSttDescription': {
+    ko: '원본 영상은 STT 한 번만 실행하고, Gemini가 선택한 언어별 YouTube 자막으로 변환합니다.',
+    en: 'Run STT once on the source video, then let Gemini create YouTube captions for each selected language.',
+  },
+  'features.dubbing.components.steps.translationEditStep.captionProcessing': {
+    ko: '자막 처리',
+    en: 'Caption processing',
+  },
+  'features.dubbing.components.steps.translationEditStep.sttCaptionGeneration': {
+    ko: 'STT 기반 생성',
+    en: 'STT-based generation',
+  },
+  'features.dubbing.components.steps.translationEditStep.dubbingCaptionGeneration': {
+    ko: '기존 더빙 처리',
+    en: 'Existing dubbing flow',
+  },
+  'features.dubbing.components.steps.translationEditStep.startCaptionProcessing': {
+    ko: '자막 처리 시작',
+    en: 'Start caption processing',
+  },
+  'features.dubbing.components.steps.uploadStep.captionsOnlyDownload': {
+    ko: '자막',
+    en: 'Captions',
+  },
+  'features.dubbing.hooks.usePersoFlow.startingSttCaptionJob': {
+    ko: 'STT 자막 작업 시작',
+    en: 'Starting STT caption job',
+  },
+  'features.dubbing.hooks.usePersoFlow.sttCaptionJobStarted': {
+    ko: 'STT 자막 작업이 시작되었습니다',
+    en: 'STT caption job started',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationFailed': {
+    ko: '자막 생성 실패',
+    en: 'Caption generation failed',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationFinishedWithSomeErrors': {
+    ko: '자막 생성이 일부 실패했습니다',
+    en: 'Caption generation finished with some errors',
+  },
+  'features.dubbing.hooks.usePersoFlow.captionGenerationComplete': {
+    ko: '자막 생성 완료',
+    en: 'Caption generation complete',
+  },
   'features.landing.pricingSection.includedLanguageCount': {
     ko: '{SUPPORTED_LANGUAGE_COUNT}개 언어 지원',
     en: '{SUPPORTED_LANGUAGE_COUNT} supported languages',

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -72,6 +72,16 @@ export interface TranslateResponse {
   startGenerateProjectIdList: number[]
 }
 
+export interface SttRequest {
+  mediaSeq: number
+  isVideoProject: boolean
+  title?: string
+}
+
+export interface SttResponse {
+  startGenerateProjectIdList: number[]
+}
+
 /**
  * Progress reason values from Perso API.
  * Internal values (PENDING, PROCESSING, etc.) are used by our polling logic.
@@ -167,6 +177,26 @@ export interface ScriptSentence {
   originalText: string
   translatedText: string
   speakerLabel: string
+}
+
+export interface SttScriptSentence {
+  seq: number
+  externalScriptSeq?: string
+  speakerOrderIndex?: number
+  offsetMs: number
+  durationMs: number
+  originalDraftText?: string
+  originalText: string
+}
+
+export interface SttScriptResponse {
+  hasNext?: boolean
+  nextCursorId?: number | null
+  sentences?: SttScriptSentence[]
+  speakers?: Array<{
+    speakerOrderIndex: number
+    externalSpeakerSeq?: string
+  }>
 }
 
 export interface ProjectDetail {

--- a/src/lib/translate/gemini.ts
+++ b/src/lib/translate/gemini.ts
@@ -2,6 +2,7 @@ import 'server-only'
 
 import { GoogleAuth } from 'google-auth-library'
 import { getServerEnv } from '@/lib/env'
+import type { SrtCue } from '@/utils/srt'
 
 // 모델 ID는 AI Studio / Vertex 양쪽에서 동일하게 'gemini-2.5-flash' 사용.
 const MODEL_ID = 'gemini-2.5-flash'
@@ -242,5 +243,155 @@ function buildPrompt(args: {
     `INPUT_TITLE: ${args.title}`,
     'INPUT_DESCRIPTION:',
     args.description,
+  ].join('\n')
+}
+
+export interface TimedTranscriptSegment {
+  id: number
+  startMs: number
+  endMs: number
+  text: string
+  speakerLabel?: string
+}
+
+export interface TranslateTimedSubtitlesInput {
+  sourceLanguageCode: string
+  targetLanguageCode: string
+  segments: TimedTranscriptSegment[]
+}
+
+const SUBTITLE_CHUNK_SEGMENT_LIMIT = 180
+const SUBTITLE_CHUNK_DURATION_MS = 5 * 60 * 1000
+
+export async function translateTimedSubtitles(input: TranslateTimedSubtitlesInput): Promise<SrtCue[]> {
+  const chunks = chunkTimedSegments(input.segments)
+  const cues: SrtCue[] = []
+
+  for (const chunk of chunks) {
+    const translated = await translateTimedSubtitleChunk({
+      ...input,
+      segments: chunk,
+    })
+    cues.push(...translated)
+  }
+
+  return cues
+    .filter((cue) => cue.text.trim().length > 0 && cue.endMs > cue.startMs)
+    .sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs)
+}
+
+function chunkTimedSegments(segments: TimedTranscriptSegment[]): TimedTranscriptSegment[][] {
+  const chunks: TimedTranscriptSegment[][] = []
+  let current: TimedTranscriptSegment[] = []
+  let chunkStart = 0
+
+  for (const segment of segments) {
+    if (current.length === 0) {
+      chunkStart = segment.startMs
+    }
+
+    const wouldExceedCount = current.length >= SUBTITLE_CHUNK_SEGMENT_LIMIT
+    const wouldExceedDuration = segment.endMs - chunkStart > SUBTITLE_CHUNK_DURATION_MS
+    if (current.length > 0 && (wouldExceedCount || wouldExceedDuration)) {
+      chunks.push(current)
+      current = []
+      chunkStart = segment.startMs
+    }
+
+    current.push(segment)
+  }
+
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+async function translateTimedSubtitleChunk(input: TranslateTimedSubtitlesInput): Promise<SrtCue[]> {
+  const prompt = buildTimedSubtitlePrompt(input)
+  const text = await callGemini(prompt)
+  const parsed = parseGeminiJson(text)
+  const rawCues = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as { cues?: unknown }).cues)
+      ? (parsed as { cues: unknown[] }).cues
+      : null
+
+  if (!rawCues) {
+    throw new TranslateError('GEMINI_INVALID_SUBTITLE_SHAPE', 'Timed subtitle response must contain a cues array')
+  }
+
+  const chunkStart = Math.min(...input.segments.map((segment) => segment.startMs))
+  const chunkEnd = Math.max(...input.segments.map((segment) => segment.endMs))
+  const cues: SrtCue[] = []
+
+  for (const raw of rawCues) {
+    if (!raw || typeof raw !== 'object') continue
+    const item = raw as Record<string, unknown>
+    const startMs = asFiniteNumber(item.startMs)
+    const endMs = asFiniteNumber(item.endMs)
+    const text = typeof item.text === 'string' ? item.text.trim() : ''
+    if (startMs === null || endMs === null || !text) continue
+    const safeStart = clamp(Math.floor(startMs), chunkStart, chunkEnd)
+    const safeEnd = clamp(Math.floor(endMs), safeStart + 250, chunkEnd)
+    if (safeEnd <= safeStart) continue
+    cues.push({ startMs: safeStart, endMs: safeEnd, text: normalizeCaptionText(text) })
+  }
+
+  if (cues.length === 0 && input.segments.length > 0) {
+    throw new TranslateError('GEMINI_EMPTY_SUBTITLES', 'Gemini returned no usable subtitle cues')
+  }
+
+  return cues
+}
+
+function parseGeminiJson(text: string): unknown {
+  const trimmed = text.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)
+  const jsonText = fenced ? fenced[1] : trimmed
+  try {
+    return JSON.parse(jsonText)
+  } catch {
+    throw new TranslateError('GEMINI_INVALID_JSON', `Could not parse: ${text.slice(0, 300)}`)
+  }
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  const number = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isFinite(number) ? number : null
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function normalizeCaptionText(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('\n')
+}
+
+function buildTimedSubtitlePrompt(input: TranslateTimedSubtitlesInput): string {
+  const sourceHint =
+    input.sourceLanguageCode === 'auto'
+      ? 'Detect the source language from the text.'
+      : `The source language is "${input.sourceLanguageCode}".`
+
+  return [
+    'You are a senior subtitle localizer for YouTube videos.',
+    sourceHint,
+    `Create publication-ready subtitles for target language "${input.targetLanguageCode}".`,
+    'Use natural, native phrasing. Preserve meaning, tone, names, numbers, product terms, and speaker intent.',
+    'Return subtitles, not a literal word-by-word transcript. Split or merge nearby lines only when it improves readability.',
+    'Keep every cue inside the timing range of the provided source segments. Do not invent timestamps outside the input.',
+    'Respect speech timing: each cue must appear while that speech is happening. Avoid text that is too long for the visible duration.',
+    'Use one or two short lines per cue. Prefer concise phrasing suitable for YouTube captions.',
+    'Output strict JSON only with this shape: {"cues":[{"startMs":0,"endMs":1200,"text":"..."}]}',
+    'Do not include markdown, comments, SRT numbering, or explanations.',
+    '',
+    'SOURCE_SEGMENTS:',
+    JSON.stringify(input.segments),
   ].join('\n')
 }

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -43,6 +43,7 @@ const createDubbingJobSchema = z.object({
       selfDeclaredMadeForKids: z.boolean(),
       containsSyntheticMedia: z.boolean(),
       uploadReviewConfirmed: z.boolean(),
+      captionGenerationMode: z.enum(['dubbing', 'stt']).optional(),
       metadataLanguage: z.string(),
     }).optional(),
   }),

--- a/src/lib/validators/perso.ts
+++ b/src/lib/validators/perso.ts
@@ -63,6 +63,20 @@ export const translateBodySchema = z.object({
   title: trimmedNonEmptyString.optional(),
 })
 
+export const sttBodySchema = z.object({
+  mediaSeq: z.number().int().positive(),
+  isVideoProject: z.boolean(),
+  title: trimmedNonEmptyString.optional(),
+})
+
+export const generateSttCaptionsBodySchema = z.object({
+  jobId: z.number().int().positive(),
+  projectSeq: z.number().int().positive(),
+  spaceSeq: z.number().int().positive(),
+  targetLanguageCodes: z.array(trimmedNonEmptyString).min(1),
+  sourceLanguageCode: trimmedNonEmptyString.optional(),
+})
+
 export const scriptPatchBodySchema = z.object({
   translatedText: z.string().min(1),
 })


### PR DESCRIPTION
﻿## 변경 내용
- 원본+자막 업로드 모드에 STT 기반 자막 생성 옵션을 추가했습니다.
- Perso STT 프로젝트 생성, STT 스크립트 조회, Gemini 기반 YouTube SRT 생성 API를 추가했습니다.
- 생성된 자막을 DB에 저장하고 다운로드, YouTube 자막 업로드, 자막 편집기에서 재사용하도록 연결했습니다.
- STT 자막 모드는 언어 수 기준 반값 크레딧 예약/정산을 적용했습니다.
- Tailwind 유틸리티 클래스 경고를 정리했습니다.

## 검증
- npm run typecheck
- npm run lint
- npm test
- npm run build
- localhost:3000 /ko/dubbing 로드 확인

Refs #307
