### PR TITLE
feat: 더빙 언어 선택을 설정의 희망 시장 기본값으로 사전 선택

### DIFF
--- a/src/features/dubbing/components/steps/LanguageSelectStep.tsx
+++ b/src/features/dubbing/components/steps/LanguageSelectStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft, ArrowRight, Check, Search, X } from 'lucide-react'
 import { Button, Card } from '@/components/ui'
 import { cn } from '@/utils/cn'
@@ -14,6 +14,8 @@ import {
 } from '@/utils/languages'
 import { useDubbingStore } from '../../store/dubbingStore'
 import { useDashboardSummary } from '@/hooks/useDashboardData'
+import { useI18nStore } from '@/stores/i18nStore'
+import { getMetadataTargetLanguageCodes } from '@/lib/i18n/config'
 
 type RegionFilter = 'all' | LanguageRegion
 type LocaleText = ReturnType<typeof useLocaleText>
@@ -31,14 +33,34 @@ function countLocaleMessage(
 export function LanguageSelectStep() {
   const {
     selectedLanguages,
+    sourceLanguage,
     videoMeta,
     toggleLanguage,
+    setSelectedLanguages,
     deliverableMode,
     prevStep,
     nextStep,
   } = useDubbingStore()
+  const metadataTargetPreset = useI18nStore((s) => s.metadataTargetPreset)
+  const metadataTargetLanguages = useI18nStore((s) => s.metadataTargetLanguages)
   const locale = useAppLocale()
   const t = useLocaleText()
+
+  // Settings에서 고른 희망 언어를 첫 진입 시 기본값으로 채운다.
+  // 사용자가 명시적으로 비웠을 때 다시 채우지 않도록 단 한 번만 적용.
+  const didInitializeRef = useRef(false)
+  useEffect(() => {
+    if (didInitializeRef.current) return
+    if (selectedLanguages.length > 0) {
+      didInitializeRef.current = true
+      return
+    }
+    const defaults = getMetadataTargetLanguageCodes(metadataTargetPreset, metadataTargetLanguages)
+      .filter((code) => code !== sourceLanguage)
+    if (defaults.length === 0) return
+    setSelectedLanguages(defaults)
+    didInitializeRef.current = true
+  }, [metadataTargetPreset, metadataTargetLanguages, selectedLanguages.length, sourceLanguage, setSelectedLanguages])
 
   const [region, setRegion] = useState<RegionFilter>('popular')
   const [query, setQuery] = useState('')

--- a/src/features/dubbing/store/dubbingStore.ts
+++ b/src/features/dubbing/store/dubbingStore.ts
@@ -107,6 +107,7 @@ interface DubbingState {
   numberOfSpeakers: number
   setSourceLanguage: (code: string) => void
   toggleLanguage: (code: string) => void
+  setSelectedLanguages: (codes: string[]) => void
   setLipSync: (enabled: boolean) => void
   setNumberOfSpeakers: (n: number) => void
 
@@ -229,6 +230,10 @@ export const useDubbingStore = create<DubbingState>((set) => ({
       selectedLanguages: s.selectedLanguages.includes(code)
         ? s.selectedLanguages.filter((l) => l !== code)
         : [...s.selectedLanguages, code],
+    })),
+  setSelectedLanguages: (codes) =>
+    set((s) => ({
+      selectedLanguages: Array.from(new Set(codes)).filter((c) => c !== s.sourceLanguage),
     })),
   setLipSync: (enabled) => set({ lipSyncEnabled: enabled }),
   setNumberOfSpeakers: (n) =>


### PR DESCRIPTION
## 요약
- 설정 페이지에서 사용자가 고른 희망 시장(언어 프리셋/언어 목록)을 더빙 마법사 3단계(언어 선택)에 진입할 때 기본 선택값으로 자동 채워준다.
- `selectedLanguages`가 비어 있을 때 한 번만 적용되며, 사용자가 명시적으로 모두 비웠을 경우 다시 채워 넣지 않는다 (`didInitializeRef`).
- 소스 언어와 동일한 코드는 기본 선택에서 제외한다.

> 참고: 동일 커밋이 PR #310 으로 먼저 main 에 머지되었습니다. 본 PR 은 develop 동기화를 위한 PR 입니다.

## 변경 파일
- `src/features/dubbing/store/dubbingStore.ts` — 다중 선택을 한 번에 세팅할 수 있는 `setSelectedLanguages` 액션 추가 (중복 제거 + 소스 언어 제외)
- `src/features/dubbing/components/steps/LanguageSelectStep.tsx` — `useI18nStore`에서 `metadataTargetPreset`/`metadataTargetLanguages`를 읽어 첫 진입 시 1회 기본값 주입

## 테스트 플랜
- [ ] 설정에서 희망 시장 프리셋 변경 → 더빙 마법사 진입 시 해당 언어들이 기본 선택되어 있는지 확인
- [ ] 사용자 정의(custom) 언어 목록을 설정한 경우에도 동일하게 반영되는지 확인
- [ ] 더빙 마법사에서 칩을 모두 비우고 다음 단계 ↔ 이전 단계 이동 시 다시 자동 채움이 발생하지 않는지 확인
- [ ] 소스 언어가 희망 시장에 포함되어 있을 때 대상 목록에서 제외되는지 확인