### PR TITLE
fix: Google OAuth 팝업 차단 회피 — 리다이렉트 기반 흐름으로 전환

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -2,32 +2,86 @@
 
 export const dynamic = 'force-dynamic'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { completeGoogleSignIn } from '@/lib/google-auth'
+import { useAuthStore } from '@/stores/authStore'
+import { useNotificationStore } from '@/stores/notificationStore'
 import { useLocaleText } from '@/hooks/useLocaleText'
 
-// Google OAuth popup callback.
-// Google redirects here with ?code=... — pass to opener via postMessage then close.
+async function hasConnectedYouTubeChannel(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/youtube/stats?channel=true', { cache: 'no-store' })
+    const body = (await res.json().catch(() => null)) as { ok?: boolean; data?: unknown } | null
+    return res.ok && body?.ok === true && !!body.data
+  } catch {
+    return false
+  }
+}
+
 export default function AuthCallbackPage() {
   const t = useLocaleText()
+  const addToast = useNotificationStore((s) => s.addToast)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const finishedRef = useRef(false)
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const code = params.get('code')
-    const error = params.get('error')
-    const state = params.get('state')
+    if (finishedRef.current) return
+    finishedRef.current = true
 
-    if (window.opener) {
-      window.opener.postMessage(
-        { type: 'google_oauth_callback', code, error, state },
-        window.location.origin,
-      )
+    let cancelled = false
+
+    ;(async () => {
+      try {
+        const { user, scopeMode, returnTo } = await completeGoogleSignIn()
+        if (cancelled) return
+
+        useAuthStore.getState().setUser(user)
+
+        // YouTube reconnect flow: just go back wherever the user came from.
+        if (scopeMode === 'youtube-write' || scopeMode === 'youtube-readonly') {
+          window.location.replace(returnTo)
+          return
+        }
+
+        // Initial login: nudge user to connect YouTube if they haven't yet.
+        const connected = await hasConnectedYouTubeChannel()
+        if (cancelled) return
+
+        if (!connected) {
+          addToast({
+            type: 'info',
+            title: t('components.layout.landingNavBar.connectYouTubeChannel'),
+            message: t('components.layout.landingNavBar.connectYouTubeChannelInSettings'),
+          })
+          window.location.replace('/settings?section=youtube')
+          return
+        }
+
+        const isLandingReturn = returnTo === '/' || returnTo === '' || returnTo.startsWith('/?')
+        window.location.replace(isLandingReturn ? '/dashboard' : returnTo)
+      } catch (err) {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : t('components.layout.landingNavBar.pleaseTryAgainShortlyContactUsIfThe')
+        setErrorMessage(message)
+        addToast({
+          type: 'error',
+          title: t('components.layout.landingNavBar.couldNotSignIn'),
+          message,
+        })
+        window.setTimeout(() => {
+          if (!cancelled) window.location.replace('/')
+        }, 2000)
+      }
+    })()
+
+    return () => {
+      cancelled = true
     }
-    window.close()
-  }, [])
+  }, [addToast, t])
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-surface-50 px-6 text-center text-sm text-surface-600 dark:bg-surface-950 dark:text-surface-300">
-      {t('app.auth.callback.page.processingLogin')}
+      {errorMessage ?? t('app.auth.callback.page.processingLogin')}
     </main>
   )
 }

--- a/src/components/layout/LandingNavBar.tsx
+++ b/src/components/layout/LandingNavBar.tsx
@@ -9,47 +9,23 @@ import { useNotificationStore } from '@/stores/notificationStore'
 import { Button } from '@/components/ui'
 import { AppLocaleSelect } from '@/components/layout/AppLocaleSelect'
 import { useLocaleText } from '@/hooks/useLocaleText'
-import { useLocaleRouter } from '@/hooks/useLocalePath'
-
-async function hasConnectedYouTubeChannel(): Promise<boolean> {
-  try {
-    const res = await fetch('/api/youtube/stats?channel=true', { cache: 'no-store' })
-    const body = (await res.json().catch(() => null)) as { ok?: boolean; data?: unknown } | null
-    return res.ok && body?.ok === true && !!body.data
-  } catch {
-    return false
-  }
-}
 
 export function LandingNavBar() {
   const { isAuthenticated } = useAuthStore()
   const addToast = useNotificationStore((s) => s.addToast)
-  const router = useLocaleRouter()
   const [loading, setLoading] = useState(false)
   const t = useLocaleText()
 
   const handleGoogleLogin = async () => {
     setLoading(true)
     try {
-      const { user } = await signInWithGoogle()
-      useAuthStore.getState().setUser(user)
-      const connected = await hasConnectedYouTubeChannel()
-      if (!connected) {
-        addToast({
-          type: 'info',
-          title: t('components.layout.landingNavBar.connectYouTubeChannel'),
-          message: t('components.layout.landingNavBar.connectYouTubeChannelInSettings'),
-        })
-        router.push('/settings?section=youtube')
-        return
-      }
-      router.push('/dashboard')
+      await signInWithGoogle({ returnTo: '/dashboard' })
+      // Page navigates to Google; control never returns here on success.
     } catch (err) {
-      const message = err instanceof Error && err.message.includes(t('internal.keyword.popup'))
-        ? t('components.layout.landingNavBar.allowPopUpsThenSignInAgain')
+      const message = err instanceof Error
+        ? err.message
         : t('components.layout.landingNavBar.pleaseTryAgainShortlyContactUsIfThe')
       addToast({ type: 'error', title: t('components.layout.landingNavBar.couldNotSignIn'), message })
-    } finally {
       setLoading(false)
     }
   }

--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -424,16 +424,18 @@ function YouTubeConnectionCard() {
   const handleReconnect = async () => {
     setConnecting(true)
     try {
-      const { user } = await signInWithGoogle({ forceConsent: true, scopeMode: 'youtube-write' })
-      useAuthStore.getState().setUser(user)
-      window.location.reload()
+      await signInWithGoogle({
+        forceConsent: true,
+        scopeMode: 'youtube-write',
+        returnTo: '/settings?section=youtube',
+      })
+      // Page navigates to Google; control never returns here on success.
     } catch {
       addToast({
         type: 'error',
         title: t('app.app.youtube.page.couldNotConnectYouTube'),
-        message: t('app.app.youtube.page.pleaseAllowPopUpsAndTryAgain'),
+        message: t('app.app.youtube.page.pleaseTryAgainShortly'),
       })
-    } finally {
       setConnecting(false)
     }
   }

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -1,6 +1,6 @@
 /**
  * Google OAuth direct sign-in (no Firebase SDK).
- * Client-only; uses popup + postMessage + window.localStorage.
+ * Redirect-based flow: navigates main window to Google, returns via /auth/callback.
  */
 'use client'
 
@@ -14,7 +14,10 @@ export interface GoogleUser {
 export type GoogleAuthScopeMode = 'login' | 'youtube-write' | 'youtube-readonly'
 
 const STORAGE_KEY_USER = 'google_user'
-const AUTH_TIMEOUT_MS = 2 * 60 * 1000
+const STORAGE_KEY_OAUTH_STATE = 'oauth_state'
+const STORAGE_KEY_OAUTH_SCOPE_MODE = 'oauth_scope_mode'
+const STORAGE_KEY_OAUTH_RETURN = 'oauth_return_to'
+
 const BASE_SCOPES = ['openid', 'email', 'profile'] as const
 const YOUTUBE_WRITE_SCOPES = [
   'https://www.googleapis.com/auth/youtube.upload',
@@ -48,113 +51,101 @@ function storeUser(user: GoogleUser) {
   localStorage.setItem(STORAGE_KEY_USER, JSON.stringify(user))
 }
 
-export async function signInWithGoogle(
-  options: { forceConsent?: boolean; scopeMode?: GoogleAuthScopeMode } = {}
-): Promise<{
-  user: GoogleUser
-}> {
+/**
+ * Navigates the current window to Google's OAuth consent screen.
+ * Returns a Promise that never resolves on the calling side (page is leaving).
+ * The flow completes in /auth/callback via completeGoogleSignIn().
+ */
+export function signInWithGoogle(
+  options: { forceConsent?: boolean; scopeMode?: GoogleAuthScopeMode; returnTo?: string } = {}
+): Promise<never> {
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
   if (!clientId) {
-    throw new Error('Google 로그인을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요.')
+    return Promise.reject(new Error('Google 로그인을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요.'))
   }
 
-  return new Promise((resolve, reject) => {
-    const redirectUri = `${window.location.origin}/auth/callback`
-    const scope = getGoogleScopes(options.scopeMode ?? 'login').join(' ')
+  const scopeMode: GoogleAuthScopeMode = options.scopeMode ?? 'login'
+  const redirectUri = `${window.location.origin}/auth/callback`
+  const scope = getGoogleScopes(scopeMode).join(' ')
+  const stateNonce = crypto.randomUUID()
+  const returnTo = options.returnTo ?? (window.location.pathname + window.location.search)
 
-    const stateNonce = crypto.randomUUID()
-    sessionStorage.setItem('oauth_state', stateNonce)
+  sessionStorage.setItem(STORAGE_KEY_OAUTH_STATE, stateNonce)
+  sessionStorage.setItem(STORAGE_KEY_OAUTH_SCOPE_MODE, scopeMode)
+  sessionStorage.setItem(STORAGE_KEY_OAUTH_RETURN, returnTo)
 
-    const authUrl =
-      `https://accounts.google.com/o/oauth2/v2/auth?` +
-      `client_id=${encodeURIComponent(clientId)}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&response_type=code` +
-      `&scope=${encodeURIComponent(scope)}` +
-      `&access_type=offline` +
-      `&include_granted_scopes=true` +
-      `&prompt=${options.forceConsent ? 'consent' : 'select_account'}` +
-      `&state=${encodeURIComponent(stateNonce)}`
+  const authUrl =
+    `https://accounts.google.com/o/oauth2/v2/auth?` +
+    `client_id=${encodeURIComponent(clientId)}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&response_type=code` +
+    `&scope=${encodeURIComponent(scope)}` +
+    `&access_type=offline` +
+    `&include_granted_scopes=true` +
+    `&prompt=${options.forceConsent ? 'consent' : 'select_account'}` +
+    `&state=${encodeURIComponent(stateNonce)}`
 
-    const popup = window.open(authUrl, 'google_auth', 'width=500,height=600')
-    if (!popup) {
-      sessionStorage.removeItem('oauth_state')
-      reject(new Error('팝업이 차단되었습니다. 팝업 차단을 해제해 주세요.'))
-      return
-    }
+  window.location.href = authUrl
+  return new Promise<never>(() => {})
+}
 
-    let timeoutTimer: number | null = null
+/**
+ * Completes the OAuth flow inside /auth/callback after Google redirects back.
+ * Validates state, exchanges code via the server, stores user locally, and
+ * returns the user along with the original scopeMode and returnTo destination.
+ */
+export async function completeGoogleSignIn(): Promise<{
+  user: GoogleUser
+  scopeMode: GoogleAuthScopeMode
+  returnTo: string
+}> {
+  const params = new URLSearchParams(window.location.search)
+  const code = params.get('code')
+  const state = params.get('state')
+  const errorParam = params.get('error')
 
-    const cleanup = () => {
-      window.removeEventListener('message', onMessage)
-      if (timeoutTimer !== null) {
-        window.clearTimeout(timeoutTimer)
-        timeoutTimer = null
-      }
-    }
+  const expectedState = sessionStorage.getItem(STORAGE_KEY_OAUTH_STATE)
+  const scopeMode = (sessionStorage.getItem(STORAGE_KEY_OAUTH_SCOPE_MODE) as GoogleAuthScopeMode) || 'login'
+  const returnTo = sessionStorage.getItem(STORAGE_KEY_OAUTH_RETURN) || '/dashboard'
 
-    // Use postMessage only. Reading cross-origin popup state can trigger COOP warnings
-    // while the popup is on accounts.google.com.
-    async function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return
-      if (event.data?.type !== 'google_oauth_callback') return
+  sessionStorage.removeItem(STORAGE_KEY_OAUTH_STATE)
+  sessionStorage.removeItem(STORAGE_KEY_OAUTH_SCOPE_MODE)
+  sessionStorage.removeItem(STORAGE_KEY_OAUTH_RETURN)
 
-      cleanup()
+  if (errorParam) {
+    throw new Error('Google 인증을 완료하지 못했습니다. 다시 시도해 주세요.')
+  }
+  if (!code) {
+    throw new Error('인증 코드를 받지 못했습니다.')
+  }
+  if (!expectedState || state !== expectedState) {
+    throw new Error('로그인 요청을 확인할 수 없습니다. 다시 시도해 주세요.')
+  }
 
-      const { code, error, state: returnedState } = event.data
-
-      if (error) {
-        reject(new Error('Google 인증을 완료하지 못했습니다. 다시 시도해 주세요.'))
-        return
-      }
-      if (!code) {
-        reject(new Error('인증 코드를 받지 못했습니다.'))
-        return
-      }
-
-      const expectedState = sessionStorage.getItem('oauth_state')
-      sessionStorage.removeItem('oauth_state')
-      if (!expectedState || returnedState !== expectedState) {
-        reject(new Error('로그인 요청을 확인할 수 없습니다. 다시 시도해 주세요.'))
-        return
-      }
-
-      try {
-        const res = await fetch('/api/auth/callback', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ code, redirectUri }),
-        })
-
-        if (!res.ok) {
-          const body = await res.json().catch(() => null)
-          throw new Error(body?.error?.message || '인증에 실패했습니다.')
-        }
-
-        const body = await res.json()
-        const data = body.data
-
-        const user: GoogleUser = {
-          uid: data.id,
-          email: data.email,
-          displayName: data.displayName || null,
-          photoURL: data.photoURL || null,
-        }
-
-        storeUser(user)
-        resolve({ user })
-      } catch (err) {
-        reject(err)
-      }
-    }
-
-    window.addEventListener('message', onMessage)
-    timeoutTimer = window.setTimeout(() => {
-      cleanup()
-      sessionStorage.removeItem('oauth_state')
-      reject(new Error('로그인이 제한 시간 안에 완료되지 않았습니다. 다시 시도해 주세요.'))
-    }, AUTH_TIMEOUT_MS)
+  const redirectUri = `${window.location.origin}/auth/callback`
+  const res = await fetch('/api/auth/callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code, redirectUri }),
   })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+    throw new Error(body?.error?.message || '인증에 실패했습니다.')
+  }
+
+  const body = await res.json()
+  const data = body.data
+
+  const user: GoogleUser = {
+    uid: data.id,
+    email: data.email,
+    displayName: data.displayName || null,
+    photoURL: data.photoURL || null,
+  }
+
+  storeUser(user)
+  return { user, scopeMode, returnTo }
 }
 
 export function signOut(): void {


### PR DESCRIPTION
## 요약
macOS Safari/Chrome 등에서 팝업 기반 OAuth가 차단되어 로그인이 막히는 문제를 해결합니다. 팝업 + `postMessage` 의존을 제거하고, 메인 창을 Google OAuth로 직접 리다이렉트하는 표준 흐름으로 전환했습니다.

## 변경 파일
- `src/lib/google-auth.ts` — `signInWithGoogle()`은 `window.location.href`로 Google로 이동. 신규 `completeGoogleSignIn()`이 `/auth/callback`에서 state 검증·코드 교환·user 저장을 담당. 옵션에 `returnTo` 추가.
- `src/app/auth/callback/page.tsx` — 팝업 종료자가 아니라 본 흐름의 종착 페이지로 동작. user 저장 → YouTube 채널 연결 여부에 따라 `/dashboard` 또는 `/settings?section=youtube`로 `window.location.replace`.
- `src/components/layout/LandingNavBar.tsx` — `handleGoogleLogin` 단순화. 분기 로직은 콜백 페이지로 이전.
- `src/features/settings/components/SettingsClient.tsx` — `handleReconnect` 단순화.

## 효과
- 팝업 차단(특히 macOS Safari)으로 인한 로그인 실패 영구 해결
- COOP/postMessage 의존성 제거 → 환경별 회귀 없음
- 모바일·iframe·in-app browser 환경에서도 안정적
- 사용자 제스처 끊김 (silent fail) 이슈 해소

## 테스트 플랜
- [ ] macOS Safari에서 랜딩 → "Google로 시작" → 동의 → 자동 리다이렉트 → `/dashboard` 진입
- [ ] 미연결 계정으로 로그인 → `/settings?section=youtube`로 보내짐 (안내 토스트 1회 표시)
- [ ] 설정 페이지 "재연결" → 구글 동의(forceConsent) → 설정 페이지로 복귀
- [ ] OAuth 취소/에러 → 토스트 + 2초 뒤 `/`로 복귀
- [ ] 뒤로가기 시 `/auth/callback` 재진입되지 않음 (`replace` 사용)

> 본 PR이 develop에 머지되면 PR #314 (develop → main)에도 자동 포함됩니다.