### PR TITLE
refactor: 설정 페이지 YouTube 박스 분리 — 채널 연결 시에만 노출

### DIFF
--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -106,6 +106,12 @@ export function SettingsClient() {
   )
   const youtubeSectionRef = useRef<HTMLDivElement>(null)
 
+  const { data: channel, error: channelError } = useChannelStats()
+  const isYouTubeConnected = !!channel && !(
+    channelError instanceof Error &&
+    (channelError.message.includes(t('internal.keyword.youtubeConnection')) || channelError.message.includes('Google access token'))
+  )
+
   const draftTags = useMemo(() => parseTagsInput(defaultTagsInput), [defaultTagsInput])
   const targetLanguageCodes = useMemo(
     () => getMetadataTargetLanguageCodes(draftMetadataTargetPreset, draftMetadataTargetLanguages),
@@ -220,6 +226,75 @@ export function SettingsClient() {
         <YouTubeConnectionCard />
       </div>
 
+      {isYouTubeConnected && (
+        <Card>
+          <div className="mb-5 flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-50 text-brand-600 dark:bg-brand-900/20 dark:text-brand-300">
+              <Video className="h-5 w-5" />
+            </div>
+            <div>
+              <CardTitle>{t('settings.youtubeDefaults.title')}</CardTitle>
+              <p className="mt-1 text-sm text-surface-500 dark:text-surface-400">
+                {t('settings.youtubeDefaults.description')}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <Select
+              label={t('app.app.youtube.page.defaultVisibility')}
+              value={draftDefaultPrivacy}
+              onChange={(event) => setDraftDefaultPrivacy(event.target.value as PrivacyStatus)}
+              options={[
+                { value: 'public', label: t('app.app.youtube.page.public') },
+                { value: 'unlisted', label: t('app.app.youtube.page.unlisted') },
+                { value: 'private', label: t('app.app.youtube.page.private') },
+              ]}
+            />
+            <Input
+              label={t('app.app.youtube.page.defaultTags')}
+              value={defaultTagsInput}
+              onChange={(event) => setDefaultTagsInput(event.target.value)}
+              placeholder={t('app.app.youtube.page.commaSeparatedEGDubtubeAIDubbingVlog')}
+            />
+            <div className="md:col-span-2">
+              <div className="mb-1.5 flex items-center justify-between gap-3">
+                <label className="block text-sm font-medium text-surface-700 dark:text-surface-300">
+                  {t('settings.launchLanguageSelection')}
+                </label>
+                <Button type="button" variant="outline" size="sm" onClick={openLaunchLanguageModal}>
+                  <Languages className="h-4 w-4" />
+                  {t('settings.launchLanguageSelection.edit')}
+                </Button>
+              </div>
+              <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-850">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-surface-900 dark:text-surface-100">
+                      {t(selectedPreset.labelKey)}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-surface-600 dark:text-surface-300">
+                      {t('settings.launchLanguageSelection.selectedCount', { count: targetLanguageCodes.length })}
+                    </p>
+                  </div>
+                  <Badge variant="brand">{t(selectedPreset.labelKey)}</Badge>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {presetLanguages.map((language) => language && (
+                    <span
+                      key={language.code}
+                      className="max-w-full rounded-full bg-white px-2.5 py-1 text-xs font-medium text-surface-700 ring-1 ring-surface-200 dark:bg-surface-900 dark:text-surface-200 dark:ring-surface-700"
+                    >
+                      {language.flag} {isEnglish ? language.name : language.nativeName}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </Card>
+      )}
+
       <Card>
         <div className="mb-5 flex items-center gap-3">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-50 text-brand-600 dark:bg-brand-900/20 dark:text-brand-300">
@@ -259,70 +334,20 @@ export function SettingsClient() {
             onChange={(event) => setDraftDefaultLanguage(event.target.value)}
             options={languageOptions}
           />
-          <Select
-            label={t('app.app.youtube.page.defaultVisibility')}
-            value={draftDefaultPrivacy}
-            onChange={(event) => setDraftDefaultPrivacy(event.target.value as PrivacyStatus)}
-            options={[
-              { value: 'public', label: t('app.app.youtube.page.public') },
-              { value: 'unlisted', label: t('app.app.youtube.page.unlisted') },
-              { value: 'private', label: t('app.app.youtube.page.private') },
-            ]}
-          />
-          <Input
-            label={t('app.app.youtube.page.defaultTags')}
-            value={defaultTagsInput}
-            onChange={(event) => setDefaultTagsInput(event.target.value)}
-            placeholder={t('app.app.youtube.page.commaSeparatedEGDubtubeAIDubbingVlog')}
-          />
-          <div className="md:col-span-2">
-            <div className="mb-1.5 flex items-center justify-between gap-3">
-              <label className="block text-sm font-medium text-surface-700 dark:text-surface-300">
-                {t('settings.launchLanguageSelection')}
-              </label>
-              <Button type="button" variant="outline" size="sm" onClick={openLaunchLanguageModal}>
-                <Languages className="h-4 w-4" />
-                {t('settings.launchLanguageSelection.edit')}
-              </Button>
-            </div>
-            <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-850">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <p className="text-sm font-medium text-surface-900 dark:text-surface-100">
-                    {t(selectedPreset.labelKey)}
-                  </p>
-                  <p className="mt-1 text-xs leading-5 text-surface-600 dark:text-surface-300">
-                    {t('settings.launchLanguageSelection.selectedCount', { count: targetLanguageCodes.length })}
-                  </p>
-                </div>
-                <Badge variant="brand">{t(selectedPreset.labelKey)}</Badge>
-              </div>
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                {presetLanguages.map((language) => language && (
-                  <span
-                    key={language.code}
-                    className="max-w-full rounded-full bg-white px-2.5 py-1 text-xs font-medium text-surface-700 ring-1 ring-surface-200 dark:bg-surface-900 dark:text-surface-200 dark:ring-surface-700"
-                  >
-                    {language.flag} {isEnglish ? language.name : language.nativeName}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
         </div>
-
-        {hasPendingPreferenceChanges && (
-          <div className="mt-4 flex flex-col gap-3 rounded-lg border border-brand-200 bg-brand-50 p-3 dark:border-brand-500/60 dark:bg-surface-850 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm font-medium text-brand-800 dark:text-surface-100">
-              {t('settings.preferences.unsavedChanges')}
-            </p>
-            <Button onClick={savePreferences} loading={saveMutation.isPending} className="w-full sm:w-auto">
-              <Save className="h-4 w-4" />
-              {t('settings.preferences.saveChanges')}
-            </Button>
-          </div>
-        )}
       </Card>
+
+      {hasPendingPreferenceChanges && (
+        <div className="flex flex-col gap-3 rounded-lg border border-brand-200 bg-brand-50 p-3 dark:border-brand-500/60 dark:bg-surface-850 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm font-medium text-brand-800 dark:text-surface-100">
+            {t('settings.preferences.unsavedChanges')}
+          </p>
+          <Button onClick={savePreferences} loading={saveMutation.isPending} className="w-full sm:w-auto">
+            <Save className="h-4 w-4" />
+            {t('settings.preferences.saveChanges')}
+          </Button>
+        </div>
+      )}
 
       <Modal
         open={languageModalOpen}

--- a/src/lib/i18n/client-messages/common.ts
+++ b/src/lib/i18n/client-messages/common.ts
@@ -287,12 +287,20 @@ export const commonMessages = {
   'privacyStatus.unlisted': { ko: '일부 공개', en: 'Unlisted' },
   'settings.appLocale': { ko: '앱 언어', en: 'App locale' },
   'settings.languageDefaults.description': {
-    ko: '화면 언어, 표시 테마, 제목·설명 번역 기본값을 정합니다.',
-    en: 'Set display language, theme, and title/description translation defaults.',
+    ko: '화면 언어와 테마, 제목·설명 기본 언어를 정합니다.',
+    en: 'Set display language, theme, and default metadata language.',
   },
   'settings.languageDefaults.title': {
-    ko: '언어, 테마 및 YouTube 기본값',
-    en: 'Language, theme, and YouTube defaults',
+    ko: '기본 설정',
+    en: 'Preferences',
+  },
+  'settings.youtubeDefaults.description': {
+    ko: '새 작업에 적용할 공개 범위, 태그, 출시 언어를 정합니다. (실제 작업 시 수정 가능합니다.)',
+    en: 'Set the visibility, tags, and launch languages applied to new jobs. (You can change these per job.)',
+  },
+  'settings.youtubeDefaults.title': {
+    ko: 'YouTube 업로드 기본값',
+    en: 'YouTube upload defaults',
   },
   'settings.launchLanguages.allLanguages': {
     ko: '언어 직접 선택',

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -24,12 +24,20 @@ const baseMessages = {
   'status.complete': { ko: '완료', en: 'Complete' },
   'status.failed': { ko: '실패', en: 'Failed' },
   'settings.languageDefaults.title': {
-    ko: '언어, 테마 및 YouTube 기본값',
-    en: 'Language, theme, and YouTube defaults',
+    ko: '기본 설정',
+    en: 'Preferences',
   },
   'settings.languageDefaults.description': {
-    ko: '화면 언어, 표시 테마, 제목·설명 번역 기본값을 정합니다.',
-    en: 'Set display language, theme, and title/description translation defaults.',
+    ko: '화면 언어와 테마, 제목·설명 기본 언어를 정합니다.',
+    en: 'Set display language, theme, and default metadata language.',
+  },
+  'settings.youtubeDefaults.title': {
+    ko: 'YouTube 업로드 기본값',
+    en: 'YouTube upload defaults',
+  },
+  'settings.youtubeDefaults.description': {
+    ko: '새 작업에 적용할 공개 범위, 태그, 출시 언어를 정합니다. (실제 작업 시 수정 가능합니다.)',
+    en: 'Set the visibility, tags, and launch languages applied to new jobs. (You can change these per job.)',
   },
   'settings.appLocale': { ko: '앱 언어', en: 'App locale' },
   'settings.themeMode': { ko: '화면 테마', en: 'Theme' },


### PR DESCRIPTION
## 요약
설정 페이지의 단일 카드를 두 카드로 분리합니다. 사용자 피드백 반영: YouTube 관련 설정과 일반 환경 설정을 따로 묶어 가독성·맥락 명료성 향상.

**카드 구성:**
- **YouTube 업로드 기본값** (NEW, 채널 연결 시에만 노출) — 기본 공개 범위, 기본 태그, 출시 언어
- **기본 설정 / Preferences** — 앱 언어, 화면 테마, 제목·설명 기본 작성 언어

저장 배너는 두 카드 변경을 통합 감지해 페이지 하단에 표시.

## 변경 파일
- `src/features/settings/components/SettingsClient.tsx` — Card 분리, `useChannelStats`로 연결 여부 체크, 저장 배너 페이지 레벨로 이동
- `src/lib/i18n/messages.ts` + `src/lib/i18n/client-messages/common.ts` — `settings.languageDefaults` 텍스트 갱신, `settings.youtubeDefaults` 키 신규

## 노트
이 커밋(`4aa103d`)은 PR #312/#313 머지 직후 chore 브랜치에 추가했지만 양쪽 PR이 이미 머지된 뒤라 합류 못한 상태였어요. 본 PR로 develop 동기화.

## 테스트 플랜
- [ ] 설정 페이지 — YouTube 미연결 상태: YouTube 박스 미노출, "기본 설정"만 노출
- [ ] 설정 페이지 — YouTube 연결 상태: "YouTube 업로드 기본값" + "기본 설정" 모두 노출
- [ ] 두 카드 중 어느 쪽이든 값을 바꾸면 페이지 하단에 저장 배너 표시
- [ ] 저장 후 토스트 + 양 카드 상태 반영 확인