### PR TITLE
feat: 7일 복구 가능한 회원탈퇴 플로우 도입

### DIFF
--- a/migrations/0006_account_deletion_recovery.sql
+++ b/migrations/0006_account_deletion_recovery.sql
@@ -1,0 +1,16 @@
+ALTER TABLE users ADD COLUMN account_status TEXT NOT NULL DEFAULT 'active';
+ALTER TABLE users ADD COLUMN deletion_requested_at TEXT;
+ALTER TABLE users ADD COLUMN deletion_restore_expires_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_users_account_status
+  ON users (account_status, deletion_restore_expires_at);
+
+ALTER TABLE dubbing_jobs ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE job_languages ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE youtube_uploads ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE analytics_cache ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE perso_media_resources ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE upload_queue ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE payment_orders ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE credit_transactions ADD COLUMN account_deletion_requested_at TEXT;
+ALTER TABLE operational_events ADD COLUMN account_deletion_requested_at TEXT;

--- a/src/app/api/user/account/account-route.test.ts
+++ b/src/app/api/user/account/account-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth/session', () => ({
+  requireSession: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries', () => ({
+  requestUserAccountDeletion: vi.fn(),
+}))
+
+import { requireSession } from '@/lib/auth/session'
+import { requestUserAccountDeletion } from '@/lib/db/queries'
+import { DELETE } from './route'
+
+const mockRequireSession = vi.mocked(requireSession)
+const mockRequestUserAccountDeletion = vi.mocked(requestUserAccountDeletion)
+
+function req(cookie?: string) {
+  return new NextRequest('http://localhost/api/user/account', {
+    method: 'DELETE',
+    headers: cookie ? { cookie } : undefined,
+  })
+}
+
+describe('DELETE /api/user/account', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 without a valid session', async () => {
+    mockRequireSession.mockResolvedValueOnce({
+      ok: false,
+      response: Response.json(
+        { ok: false, error: { code: 'UNAUTHORIZED', message: 'Missing token' } },
+        { status: 401 },
+      ),
+    })
+
+    const res = await DELETE(req())
+    expect(res.status).toBe(401)
+    expect(mockRequestUserAccountDeletion).not.toHaveBeenCalled()
+  })
+
+  it('requests deletion for the authenticated account and clears auth cookies', async () => {
+    mockRequireSession.mockResolvedValueOnce({
+      ok: true,
+      session: { uid: 'user-1', email: 'user@example.com' },
+    })
+
+    const res = await DELETE(req('dubtube_session=signed'))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ ok: true, data: null })
+    expect(mockRequestUserAccountDeletion).toHaveBeenCalledWith('user-1')
+
+    const setCookies = res.headers.getSetCookie()
+    expect(setCookies.some((cookie) => cookie.startsWith('dubtube_session=') && cookie.includes('Max-Age=0'))).toBe(true)
+    expect(setCookies.some((cookie) => cookie.startsWith('google_access_token=') && cookie.includes('Max-Age=0'))).toBe(true)
+  })
+
+  it('returns a server error when deletion fails', async () => {
+    mockRequireSession.mockResolvedValueOnce({
+      ok: true,
+      session: { uid: 'user-1', email: 'user@example.com' },
+    })
+    mockRequestUserAccountDeletion.mockRejectedValueOnce(new Error('DB failed'))
+
+    const res = await DELETE(req('dubtube_session=signed'))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+  })
+})

--- a/src/app/api/user/account/route.ts
+++ b/src/app/api/user/account/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server'
+import { requireSession } from '@/lib/auth/session'
+import { apiFailFromError, apiOk } from '@/lib/api/response'
+import { requestUserAccountDeletion } from '@/lib/db/queries'
+import { SESSION_COOKIE } from '@/lib/auth/session-cookie'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const COOKIES_TO_CLEAR = [SESSION_COOKIE, 'google_access_token']
+
+export async function DELETE(req: NextRequest) {
+  const auth = await requireSession(req)
+  if (!auth.ok) return auth.response
+
+  try {
+    await requestUserAccountDeletion(auth.session.uid)
+    const res = apiOk(null)
+    for (const name of COOKIES_TO_CLEAR) {
+      res.cookies.set(name, '', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 0,
+      })
+    }
+    return res
+  } catch (err) {
+    return apiFailFromError(err)
+  }
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -6,7 +6,17 @@ import { useEffect, useRef, useState } from 'react'
 import { completeGoogleSignIn } from '@/lib/google-auth'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
-import { useLocaleText } from '@/hooks/useLocaleText'
+import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
+import {
+  DEFAULT_APP_LOCALE,
+  getLocaleFromCookieString,
+  getPathLocale,
+  isSafeLocalPath,
+  stripLocalePrefix,
+  withLocalePath,
+  withSafeLocalePath,
+  type AppLocale,
+} from '@/lib/i18n/config'
 
 async function hasConnectedYouTubeChannel(): Promise<boolean> {
   try {
@@ -18,8 +28,24 @@ async function hasConnectedYouTubeChannel(): Promise<boolean> {
   }
 }
 
+function getRedirectLocale(returnTo: string, fallback: AppLocale): AppLocale {
+  return getPathLocale(returnTo) ??
+    getPathLocale(window.location.pathname) ??
+    getLocaleFromCookieString(document.cookie) ??
+    fallback ??
+    DEFAULT_APP_LOCALE
+}
+
+function isLandingPath(path: string): boolean {
+  if (!isSafeLocalPath(path)) return false
+  const [pathWithoutHash] = path.split('#')
+  const [pathname] = pathWithoutHash.split('?')
+  return stripLocalePrefix(pathname || '/') === '/'
+}
+
 export default function AuthCallbackPage() {
   const t = useLocaleText()
+  const appLocale = useAppLocale()
   const addToast = useNotificationStore((s) => s.addToast)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const finishedRef = useRef(false)
@@ -36,10 +62,11 @@ export default function AuthCallbackPage() {
         if (cancelled) return
 
         useAuthStore.getState().setUser(user)
+        const redirectLocale = getRedirectLocale(returnTo, appLocale)
 
         // YouTube reconnect flow: just go back wherever the user came from.
         if (scopeMode === 'youtube-write' || scopeMode === 'youtube-readonly') {
-          window.location.replace(returnTo)
+          window.location.replace(withSafeLocalePath(returnTo, redirectLocale, '/settings?section=youtube'))
           return
         }
 
@@ -53,12 +80,12 @@ export default function AuthCallbackPage() {
             title: t('components.layout.landingNavBar.connectYouTubeChannel'),
             message: t('components.layout.landingNavBar.connectYouTubeChannelInSettings'),
           })
-          window.location.replace('/settings?section=youtube')
+          window.location.replace(withLocalePath('/settings?section=youtube', redirectLocale))
           return
         }
 
-        const isLandingReturn = returnTo === '/' || returnTo === '' || returnTo.startsWith('/?')
-        window.location.replace(isLandingReturn ? '/dashboard' : returnTo)
+        const normalizedReturnTo = withSafeLocalePath(returnTo, redirectLocale, '/dashboard')
+        window.location.replace(isLandingPath(normalizedReturnTo) ? withLocalePath('/dashboard', redirectLocale) : normalizedReturnTo)
       } catch (err) {
         if (cancelled) return
         const message = err instanceof Error ? err.message : t('components.layout.landingNavBar.pleaseTryAgainShortlyContactUsIfThe')
@@ -69,7 +96,7 @@ export default function AuthCallbackPage() {
           message,
         })
         window.setTimeout(() => {
-          if (!cancelled) window.location.replace('/')
+          if (!cancelled) window.location.replace(withLocalePath('/', appLocale))
         }, 2000)
       }
     })()
@@ -77,7 +104,7 @@ export default function AuthCallbackPage() {
     return () => {
       cancelled = true
     }
-  }, [addToast, t])
+  }, [addToast, appLocale, t])
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-surface-50 px-6 text-center text-sm text-surface-600 dark:bg-surface-950 dark:text-surface-300">

--- a/src/components/feedback/Toast.tsx
+++ b/src/components/feedback/Toast.tsx
@@ -13,10 +13,24 @@ const icons: Record<ToastType, typeof CheckCircle2> = {
 }
 
 const styles: Record<ToastType, string> = {
-  success: 'border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-900/20',
-  error: 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20',
-  info: 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-900/20',
-  warning: 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20',
+  success: 'border-emerald-200 bg-white dark:border-emerald-700 dark:bg-surface-900',
+  error: 'border-red-200 bg-white dark:border-red-700 dark:bg-surface-900',
+  info: 'border-blue-200 bg-white dark:border-blue-700 dark:bg-surface-900',
+  warning: 'border-amber-200 bg-white dark:border-amber-700 dark:bg-surface-900',
+}
+
+const accentStyles: Record<ToastType, string> = {
+  success: 'bg-emerald-500',
+  error: 'bg-red-500',
+  info: 'bg-blue-500',
+  warning: 'bg-amber-500',
+}
+
+const iconBgStyles: Record<ToastType, string> = {
+  success: 'bg-emerald-50 ring-emerald-100 dark:bg-emerald-950/40 dark:ring-emerald-800',
+  error: 'bg-red-50 ring-red-100 dark:bg-red-950/40 dark:ring-red-800',
+  info: 'bg-blue-50 ring-blue-100 dark:bg-blue-950/40 dark:ring-blue-800',
+  warning: 'bg-amber-50 ring-amber-100 dark:bg-amber-950/40 dark:ring-amber-800',
 }
 
 const iconColors: Record<ToastType, string> = {
@@ -33,28 +47,36 @@ export function ToastContainer() {
   if (toasts.length === 0) return null
 
   return (
-    <div role="status" aria-live="polite" aria-atomic="false" className="fixed bottom-4 right-4 z-[100] flex max-w-[calc(100vw-2rem)] flex-col gap-2">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="pointer-events-none fixed inset-x-3 top-3 z-[120] flex flex-col items-center gap-3 sm:top-5"
+    >
       {toasts.map((toast) => {
         const Icon = icons[toast.type]
         return (
           <div
             key={toast.id}
             className={cn(
-              'flex w-[calc(100vw-2rem)] max-w-[420px] items-start gap-3 rounded-lg border p-4 shadow-lg animate-slide-up sm:w-[420px]',
+              'pointer-events-auto relative flex w-full max-w-[560px] items-start gap-3 overflow-hidden rounded-lg border p-4 pl-5 shadow-2xl ring-1 ring-black/5 animate-slide-down dark:ring-white/10 sm:p-5 sm:pl-6',
               styles[toast.type],
             )}
           >
-            <Icon className={cn('h-5 w-5 shrink-0 mt-0.5', iconColors[toast.type])} aria-hidden="true" />
+            <div className={cn('absolute inset-y-0 left-0 w-1.5', accentStyles[toast.type])} aria-hidden="true" />
+            <div className={cn('mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full ring-1', iconBgStyles[toast.type])}>
+              <Icon className={cn('h-5 w-5', iconColors[toast.type])} aria-hidden="true" />
+            </div>
             <div className="flex-1 min-w-0">
-              <p className="break-words text-sm font-medium text-surface-900 dark:text-surface-100">{toast.title}</p>
+              <p className="break-words text-base font-semibold leading-6 text-surface-950 dark:text-surface-50">{toast.title}</p>
               {toast.message && (
-                <p className="mt-0.5 break-words text-sm text-surface-600 dark:text-surface-400">{toast.message}</p>
+                <p className="mt-1 break-words text-sm leading-6 text-surface-700 dark:text-surface-300">{toast.message}</p>
               )}
             </div>
             <button
               onClick={() => removeToast(toast.id)}
               aria-label={t('components.feedback.toast.closeNotification')}
-              className="shrink-0 rounded p-0.5 text-surface-500 hover:text-surface-700 dark:text-surface-400 dark:hover:text-surface-200"
+              className="shrink-0 rounded-md p-1 text-surface-500 hover:bg-surface-100 hover:text-surface-800 dark:text-surface-400 dark:hover:bg-surface-800 dark:hover:text-surface-100"
             >
               <X className="h-4 w-4" aria-hidden="true" />
             </button>

--- a/src/components/layout/AppLocaleSelect.tsx
+++ b/src/components/layout/AppLocaleSelect.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { useCallback, useEffect, useRef, type FormEvent } from 'react'
+import { useCallback, useRef, type ChangeEvent, type FormEvent } from 'react'
 import { ChevronDown, Globe2 } from 'lucide-react'
 import {
   APP_LOCALE_LABELS,
   APP_LOCALES,
+  LOCALE_COOKIE,
+  LOCALE_COOKIE_MAX_AGE,
+  withLocalePath,
   type AppLocale,
 } from '@/lib/i18n/config'
-import { useI18nStore } from '@/stores/i18nStore'
 import { useAppLocale } from '@/hooks/useLocaleText'
-import { useLocaleRouter } from '@/hooks/useLocalePath'
 import { cn } from '@/utils/cn'
 
 type AppLocaleSelectProps = {
@@ -18,36 +19,21 @@ type AppLocaleSelectProps = {
 
 export function AppLocaleSelect({ className }: AppLocaleSelectProps) {
   const appLocale = useAppLocale()
-  const setAppLocale = useI18nStore((state) => state.setAppLocale)
-  const localeRouter = useLocaleRouter()
-  const selectRef = useRef<HTMLSelectElement>(null)
-  const requestedLocaleRef = useRef(appLocale)
-
-  useEffect(() => {
-    requestedLocaleRef.current = appLocale
-  }, [appLocale])
+  const navigatingRef = useRef(false)
 
   const applyLocale = useCallback((nextLocale: AppLocale) => {
-    if (nextLocale === requestedLocaleRef.current) return
-    requestedLocaleRef.current = nextLocale
-    setAppLocale(nextLocale)
-    localeRouter.replaceLocale(nextLocale)
-  }, [localeRouter, setAppLocale])
+    if (navigatingRef.current || nextLocale === appLocale) return
+    navigatingRef.current = true
+    document.cookie = `${LOCALE_COOKIE}=${nextLocale}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE}; SameSite=Lax`
+    const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
+    window.location.replace(withLocalePath(current || '/', nextLocale))
+  }, [appLocale])
 
-  useEffect(() => {
-    const select = selectRef.current
-    if (!select) return
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    applyLocale(event.currentTarget.value as AppLocale)
+  }
 
-    const handleNativeChange = () => applyLocale(select.value as AppLocale)
-    select.addEventListener('change', handleNativeChange)
-    select.addEventListener('input', handleNativeChange)
-    return () => {
-      select.removeEventListener('change', handleNativeChange)
-      select.removeEventListener('input', handleNativeChange)
-    }
-  }, [applyLocale])
-
-  const handleChange = (event: FormEvent<HTMLSelectElement>) => {
+  const handleInput = (event: FormEvent<HTMLSelectElement>) => {
     applyLocale(event.currentTarget.value as AppLocale)
   }
 
@@ -55,11 +41,11 @@ export function AppLocaleSelect({ className }: AppLocaleSelectProps) {
     <div className={cn('relative', className)}>
       <Globe2 className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-500 dark:text-surface-300" />
       <select
-        ref={selectRef}
+        key={appLocale}
         aria-label="Language / 언어"
-        value={appLocale}
+        defaultValue={appLocale}
         onChange={handleChange}
-        onInput={handleChange}
+        onInput={handleInput}
         className="h-9 w-full appearance-none rounded-md border border-surface-300 bg-white pl-8 pr-8 text-sm font-medium text-surface-800 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-850 dark:text-surface-100"
       >
         {APP_LOCALES.map((locale) => (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -77,14 +77,17 @@ export function Sidebar({ isOpsAdmin = false }: { isOpsAdmin?: boolean }) {
   return (
     <>
       <aside className="fixed left-0 top-0 z-40 hidden h-screen w-64 flex-col border-r border-surface-200 bg-white dark:border-surface-800 dark:bg-surface-900 lg:flex">
-        <div className="flex h-16 items-center gap-2.5 border-b border-surface-200 px-6 dark:border-surface-800">
+        <LocaleLink
+          href="/dashboard"
+          className="flex h-16 items-center gap-2.5 border-b border-surface-200 px-6 transition-colors hover:bg-surface-50 focus-ring dark:border-surface-800 dark:hover:bg-surface-850"
+        >
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-600">
             <Languages className="h-4.5 w-4.5 text-white" />
           </div>
           <span className="text-lg font-bold text-surface-900 dark:text-surface-100">
             Dub<span className="text-brand-600 dark:text-brand-400">tube</span>
           </span>
-        </div>
+        </LocaleLink>
 
         <nav className="flex-1 space-y-1 p-3">
           {visibleItems.map(renderNavItem)}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -9,8 +9,8 @@ import { OpsAlertButton } from '@/features/ops/components/OpsAlertButton'
 import { useChannelStats } from '@/hooks/useYouTubeData'
 import { AppLocaleSelect } from '@/components/layout/AppLocaleSelect'
 import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
-import { useLocaleRouter } from '@/hooks/useLocalePath'
 import { useOperationsAccess } from '@/features/ops/hooks/useOperationsAccess'
+import { withLocalePath } from '@/lib/i18n/config'
 
 interface TopbarProps {
   isOpsAdmin?: boolean
@@ -18,7 +18,6 @@ interface TopbarProps {
 
 export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
   const { user, clear } = useAuthStore()
-  const router = useLocaleRouter()
   const { data: channel } = useChannelStats()
   const opsAccess = useOperationsAccess({ enabled: isOpsAdmin })
   const locale = useAppLocale()
@@ -35,7 +34,7 @@ export function Topbar({ isOpsAdmin = false }: TopbarProps = {}) {
     signOut()
     clear()
     await fetch('/api/auth/signout', { method: 'POST' }).catch(() => {})
-    router.push('/')
+    window.location.replace(withLocalePath('/', locale))
   }
 
   return (

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Suspense, useEffect, useRef, useState } from 'react'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/services/queryClient'
 import { ToastContainer } from '@/components/feedback/Toast'
@@ -14,8 +14,6 @@ import {
   getPathLocale,
   LOCALE_COOKIE,
   LOCALE_COOKIE_MAX_AGE,
-  stripLocalePrefix,
-  withLocalePath,
   type AppLocale,
 } from '@/lib/i18n/config'
 
@@ -73,7 +71,6 @@ function AuthHydrator() {
 
 function I18nHydrator() {
   const pathname = usePathname()
-  const router = useRouter()
   const initializedRef = useRef(false)
 
   useEffect(() => {
@@ -81,13 +78,9 @@ function I18nHydrator() {
     let canceled = false
 
     const applyDocumentLang = (state = useI18nStore.getState()) => {
-      document.documentElement.lang = state.appLocale
-      writeLocaleCookie(state.appLocale)
-    }
-
-    const currentLocalizedPath = () => {
-      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
-      return stripLocalePrefix(current || '/')
+      const effectiveLocale = getPathLocale(window.location.pathname) ?? state.appLocale
+      document.documentElement.lang = effectiveLocale
+      writeLocaleCookie(effectiveLocale)
     }
 
     Promise.resolve(useI18nStore.persist.rehydrate()).finally(() => {
@@ -103,11 +96,6 @@ function I18nHydrator() {
 
       unsubscribe = useI18nStore.subscribe((state) => {
         applyDocumentLang(state)
-
-        const routeLocale = getPathLocale(window.location.pathname)
-        if (routeLocale && routeLocale !== state.appLocale) {
-          router.replace(withLocalePath(currentLocalizedPath(), state.appLocale))
-        }
       })
     })
 
@@ -116,7 +104,7 @@ function I18nHydrator() {
       initializedRef.current = false
       unsubscribe?.()
     }
-  }, [router])
+  }, [])
 
   useEffect(() => {
     if (!initializedRef.current) return

--- a/src/features/landing/HeroUrlInput.tsx
+++ b/src/features/landing/HeroUrlInput.tsx
@@ -6,17 +6,48 @@ import { Button, Input } from '@/components/ui'
 import { isValidYouTubeUrl } from '@/utils/validators'
 import { useLocaleText } from '@/hooks/useLocaleText'
 import { useLocaleRouter } from '@/hooks/useLocalePath'
+import { useAuthStore } from '@/stores/authStore'
+import { useNotificationStore } from '@/stores/notificationStore'
+import { signInWithGoogle } from '@/lib/google-auth'
+
+const SIGN_IN_REDIRECT_DELAY_MS = 900
 
 export function HeroUrlInput() {
   const [url, setUrl] = useState('')
+  const [signingIn, setSigningIn] = useState(false)
   const router = useLocaleRouter()
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const authLoading = useAuthStore((state) => state.isLoading)
+  const addToast = useNotificationStore((state) => state.addToast)
   const isValid = url.length > 0 && isValidYouTubeUrl(url)
   const t = useLocaleText()
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!isValid) return
-    router.push(`/dubbing?url=${encodeURIComponent(url)}`)
+    if (!isValid || authLoading || signingIn) return
+
+    const returnTo = `/dubbing?url=${encodeURIComponent(url)}`
+    if (isAuthenticated) {
+      router.push(returnTo)
+      return
+    }
+
+    addToast({
+      type: 'info',
+      title: t('features.landing.heroUrlInput.signInRequired'),
+      message: t('features.landing.heroUrlInput.signInWithGoogleToContinue'),
+    })
+    setSigningIn(true)
+    try {
+      await new Promise((resolve) => window.setTimeout(resolve, SIGN_IN_REDIRECT_DELAY_MS))
+      await signInWithGoogle({ returnTo })
+    } catch (err) {
+      const message = err instanceof Error
+        ? err.message
+        : t('components.layout.landingNavBar.pleaseTryAgainShortlyContactUsIfThe')
+      addToast({ type: 'error', title: t('components.layout.landingNavBar.couldNotSignIn'), message })
+      setSigningIn(false)
+    }
   }
 
   return (
@@ -29,7 +60,7 @@ export function HeroUrlInput() {
           className="border-0 shadow-none focus-visible:ring-0"
           icon={<Play className="h-4 w-4" />}
         />
-        <Button type="submit" className="shrink-0" disabled={!isValid}>
+        <Button type="submit" className="shrink-0" disabled={!isValid || authLoading} loading={signingIn}>
           {t('features.landing.heroUrlInput.startDubbing')}
           <ArrowRight className="h-4 w-4" />
         </Button>

--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Check, Globe, Globe2, Languages, Loader2, Save, Settings, Unlink, Video } from 'lucide-react'
+import { AlertTriangle, Check, Globe, Globe2, Languages, Loader2, Save, Settings, Trash2, Unlink, Video } from 'lucide-react'
 import { Card, CardTitle, Select, Button, Badge, Input, Modal } from '@/components/ui'
 import {
   APP_LOCALE_LABELS,
@@ -13,6 +13,7 @@ import {
   getMetadataTargetLanguageCodes,
   MARKET_LANGUAGE_PRESETS,
   normalizeMetadataTargetLanguages,
+  withLocalePath,
   type AppLocale,
 } from '@/lib/i18n/config'
 import { useI18nStore } from '@/stores/i18nStore'
@@ -23,7 +24,7 @@ import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
 import { useLocaleRouter } from '@/hooks/useLocalePath'
 import { useChannelStats } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
-import { signInWithGoogle } from '@/lib/google-auth'
+import { signInWithGoogle, signOut as clearStoredGoogleUser } from '@/lib/google-auth'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
 import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
@@ -349,6 +350,8 @@ export function SettingsClient() {
         </div>
       )}
 
+      <AccountDangerZone />
+
       <Modal
         open={languageModalOpen}
         onClose={() => setLanguageModalOpen(false)}
@@ -432,6 +435,107 @@ export function SettingsClient() {
         </div>
       </Modal>
     </div>
+  )
+}
+
+const ACCOUNT_DELETE_CONFIRMATION = 'DELETE'
+
+function AccountDangerZone() {
+  const t = useLocaleText()
+  const appLocale = useAppLocale()
+  const queryClient = useQueryClient()
+  const clearAuth = useAuthStore((s) => s.clear)
+  const addToast = useNotificationStore((state) => state.addToast)
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [confirmation, setConfirmation] = useState('')
+  const [deleting, setDeleting] = useState(false)
+  const confirmationMatches = confirmation.trim() === ACCOUNT_DELETE_CONFIRMATION
+
+  const closeDeleteModal = () => {
+    if (deleting) return
+    setDeleteModalOpen(false)
+    setConfirmation('')
+  }
+
+  const handleDeleteAccount = async () => {
+    if (!confirmationMatches) return
+    setDeleting(true)
+    try {
+      const res = await fetch('/api/user/account', { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => null) as { error?: { message?: string } } | null
+        throw new Error(body?.error?.message || t('settings.accountDeletion.failedMessage'))
+      }
+      clearStoredGoogleUser()
+      clearAuth()
+      queryClient.clear()
+      window.location.replace(withLocalePath('/', appLocale))
+    } catch (error) {
+      addToast({
+        type: 'error',
+        title: t('settings.accountDeletion.failed'),
+        message: error instanceof Error ? error.message : t('settings.accountDeletion.failedMessage'),
+      })
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <Card className="border-red-200 dark:border-red-900/70">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-300">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <CardTitle>{t('settings.dangerZone.title')}</CardTitle>
+              <p className="mt-1 text-sm leading-6 text-surface-600 dark:text-surface-300 xl:whitespace-nowrap">
+                {t('settings.dangerZone.description')}
+              </p>
+            </div>
+          </div>
+          <Button type="button" variant="destructive" onClick={() => setDeleteModalOpen(true)} className="w-full sm:w-auto">
+            <Trash2 className="h-4 w-4" />
+            {t('settings.accountDeletion.button')}
+          </Button>
+        </div>
+      </Card>
+
+      <Modal
+        open={deleteModalOpen}
+        onClose={closeDeleteModal}
+        title={t('settings.accountDeletion.modalTitle')}
+      >
+        <div className="space-y-5">
+          <p className="text-sm leading-6 text-surface-700 dark:text-surface-300">
+            {t('settings.accountDeletion.modalDescription')}
+          </p>
+          <Input
+            label={t('settings.accountDeletion.confirmLabel', { confirmation: ACCOUNT_DELETE_CONFIRMATION })}
+            value={confirmation}
+            onChange={(event) => setConfirmation(event.target.value)}
+            placeholder={ACCOUNT_DELETE_CONFIRMATION}
+            autoComplete="off"
+          />
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={closeDeleteModal} disabled={deleting}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDeleteAccount}
+              loading={deleting}
+              disabled={!confirmationMatches}
+            >
+              <Trash2 className="h-4 w-4" />
+              {t('settings.accountDeletion.confirmButton')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
   )
 }
 

--- a/src/hooks/useLocalePath.ts
+++ b/src/hooks/useLocalePath.ts
@@ -5,6 +5,8 @@ import { usePathname, useRouter } from 'next/navigation'
 import {
   getPathLocale,
   stripLocalePrefix,
+  LOCALE_COOKIE,
+  LOCALE_COOKIE_MAX_AGE,
   withLocalePath,
   type AppLocale,
 } from '@/lib/i18n/config'
@@ -34,7 +36,12 @@ export function useLocaleRouter() {
       ? pathname
       : `${window.location.pathname}${window.location.search}${window.location.hash}`
     const path = stripLocalePrefix(current || '/')
-    router.replace(withLocalePath(path, locale))
+    if (typeof window === 'undefined') {
+      router.replace(withLocalePath(path, locale))
+      return
+    }
+    document.cookie = `${LOCALE_COOKIE}=${locale}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE}; SameSite=Lax`
+    window.location.replace(withLocalePath(path, locale))
   }, [pathname, router])
 
   return { push, replace, replaceLocale, localize, locale }

--- a/src/hooks/useUserPreferencesSync.ts
+++ b/src/hooks/useUserPreferencesSync.ts
@@ -1,11 +1,13 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useI18nStore } from '@/stores/i18nStore'
 import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
 import { fetchUserPreferences } from '@/lib/api-client/user-preferences'
+import { getPathLocale } from '@/lib/i18n/config'
 
 /**
  * youtubeSettingsStore와 i18nStore에 서버(/api/user/preferences) 설정을 주입한다.
@@ -20,6 +22,8 @@ export function useUserPreferencesSync() {
   const user = useAuthStore((s) => s.user)
   const uid = user?.uid ?? null
   const queryClient = useQueryClient()
+  const pathname = usePathname()
+  const routeLocale = getPathLocale(pathname)
 
   const previousUidRef = useRef<string | null>(uid)
 
@@ -50,8 +54,8 @@ export function useUserPreferencesSync() {
     store.setDefaultLanguage(serverPrefs.defaultLanguage)
     store.setDefaultTags(serverPrefs.defaultTags)
     const i18nStore = useI18nStore.getState()
-    i18nStore.setAppLocale(serverPrefs.appLocale)
+    i18nStore.setAppLocale(routeLocale ?? serverPrefs.appLocale)
     i18nStore.setMetadataTargetPreset(serverPrefs.metadataTargetPreset)
     i18nStore.setMetadataTargetLanguages(serverPrefs.metadataTargetLanguages)
-  }, [serverPrefs])
+  }, [routeLocale, serverPrefs])
 }

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -5,6 +5,7 @@ export {
   updateUserTokens,
   clearUserGoogleTokens,
   deductUserMinutes,
+  requestUserAccountDeletion,
   getUserPreferencesRaw,
   setUserPreferencesRaw,
 } from './users'

--- a/src/lib/db/queries/users-account-deletion.test.ts
+++ b/src/lib/db/queries/users-account-deletion.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    execute: vi.fn(),
+    commit: vi.fn(),
+    rollback: vi.fn(),
+    close: vi.fn(),
+  }
+  return {
+    tx,
+    transaction: vi.fn(async () => tx),
+    execute: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({
+    execute: mocks.execute,
+    transaction: mocks.transaction,
+  })),
+}))
+
+vi.mock('@/lib/auth/token-crypto', () => ({
+  encryptToken: vi.fn(async (value: string | null | undefined) => value ? `encrypted:${value}` : null),
+  decryptToken: vi.fn(async (value: string | null | undefined) => value ? value.replace(/^encrypted:/, '') : null),
+}))
+
+import { requestUserAccountDeletion, upsertUser } from './users'
+
+function resetTx() {
+  mocks.tx.execute.mockReset()
+  mocks.tx.commit.mockReset()
+  mocks.tx.rollback.mockReset()
+  mocks.tx.close.mockReset()
+  mocks.transaction.mockClear()
+  mocks.execute.mockReset()
+}
+
+describe('user account deletion recovery queries', () => {
+  beforeEach(() => {
+    resetTx()
+    mocks.tx.execute.mockResolvedValue({ rows: [] })
+    mocks.tx.commit.mockResolvedValue(undefined)
+    mocks.tx.rollback.mockResolvedValue(undefined)
+  })
+
+  it('marks the account and related records as pending deletion instead of deleting them', async () => {
+    await requestUserAccountDeletion('user-1')
+
+    const sql = mocks.tx.execute.mock.calls.map(([query]) => query.sql).join('\n')
+    expect(sql).toContain('UPDATE users')
+    expect(sql).toContain('account_status = ?')
+    expect(sql).toContain('email = ?')
+    expect(sql).toContain('UPDATE app_sessions SET revoked_at')
+    expect(sql).toContain('UPDATE upload_queue SET account_deletion_requested_at')
+    expect(sql).toContain('UPDATE dubbing_jobs SET account_deletion_requested_at')
+    expect(sql).toContain('UPDATE job_languages')
+    expect(sql).toContain('UPDATE youtube_uploads')
+    expect(sql).toContain('UPDATE analytics_cache SET account_deletion_requested_at')
+    expect(sql).toContain('UPDATE payment_orders SET account_deletion_requested_at')
+    expect(sql).not.toContain('DELETE FROM users')
+    expect(sql).not.toContain('DELETE FROM dubbing_jobs')
+    expect(mocks.tx.execute.mock.calls[0][0].args[0]).toBe('pending_deletion')
+    expect(mocks.tx.execute.mock.calls[0][0].args[3]).toMatch(/^withdrawal-requested\+[a-f0-9]{32}@withdrawal\.dubtube\.local$/)
+    expect(mocks.tx.commit).toHaveBeenCalled()
+  })
+
+  it('restores pending deletion markers when the user signs in within the recovery window', async () => {
+    mocks.tx.execute.mockResolvedValueOnce({
+      rows: [{ account_status: 'pending_deletion', deletion_restore_expires_at: new Date(Date.now() + 60_000).toISOString() }],
+    })
+
+    await upsertUser({
+      id: 'user-1',
+      email: 'user@example.com',
+      displayName: 'User',
+      photoURL: null,
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      tokenExpiresAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    const sql = mocks.tx.execute.mock.calls.map(([query]) => query.sql).join('\n')
+    expect(sql).toContain('SELECT account_status, deletion_restore_expires_at FROM users')
+    expect(sql).toContain('UPDATE dubbing_jobs SET account_deletion_requested_at = NULL')
+    expect(sql).toContain('UPDATE payment_orders SET account_deletion_requested_at = NULL')
+    expect(sql).toContain('account_status = excluded.account_status')
+    expect(sql).not.toContain('DELETE FROM users')
+    expect(mocks.tx.commit).toHaveBeenCalled()
+  })
+
+  it('purges expired pending deletion data before creating a fresh account on sign-in', async () => {
+    mocks.tx.execute.mockResolvedValueOnce({
+      rows: [{ account_status: 'pending_deletion', deletion_restore_expires_at: new Date(Date.now() - 60_000).toISOString() }],
+    })
+
+    await upsertUser({
+      id: 'user-1',
+      email: 'user@example.com',
+      displayName: 'User',
+      photoURL: null,
+      accessToken: 'access',
+      refreshToken: null,
+      tokenExpiresAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    const sql = mocks.tx.execute.mock.calls.map(([query]) => query.sql).join('\n')
+    expect(sql).toContain('UPDATE payment_orders SET user_id = ?')
+    expect(sql).toContain('DELETE FROM upload_queue')
+    expect(sql).toContain('DELETE FROM job_languages')
+    expect(sql).toContain('DELETE FROM users')
+    expect(sql).toContain('INSERT INTO users')
+    expect(mocks.tx.commit).toHaveBeenCalled()
+  })
+})

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -1,7 +1,187 @@
 import 'server-only'
 
+import { createHash } from 'node:crypto'
+import type { Transaction } from '@libsql/client'
 import { getDb } from '@/lib/db/client'
 import { decryptToken, encryptToken } from '@/lib/auth/token-crypto'
+
+const ACCOUNT_STATUS_ACTIVE = 'active'
+const ACCOUNT_STATUS_PENDING_DELETION = 'pending_deletion'
+const ACCOUNT_DELETION_DISPLAY_NAME = '회원탈퇴 요청'
+const ACCOUNT_DELETION_EMAIL_DOMAIN = 'withdrawal.dubtube.local'
+const ACCOUNT_DELETION_RECOVERY_DAYS = 7
+
+function getDeletionRequestDigest(userId: string) {
+  return createHash('sha256').update(userId).digest('hex').slice(0, 32)
+}
+
+function getDeletedUserId(userId: string) {
+  return `deleted:${getDeletionRequestDigest(userId)}`
+}
+
+function getDeletionRequestEmail(userId: string) {
+  return `withdrawal-requested+${getDeletionRequestDigest(userId)}@${ACCOUNT_DELETION_EMAIL_DOMAIN}`
+}
+
+function getDeletionRestoreExpiresAt(now = new Date()) {
+  return new Date(now.getTime() + ACCOUNT_DELETION_RECOVERY_DAYS * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function canRestorePendingDeletion(expiresAt: unknown): boolean {
+  if (!expiresAt) return true
+  const raw = String(expiresAt)
+  const timestamp = Date.parse(raw.includes('T') ? raw : `${raw.replace(' ', 'T')}Z`)
+  return Number.isNaN(timestamp) || timestamp >= Date.now()
+}
+
+async function clearAccountDeletionMarkers(tx: Transaction, userId: string) {
+  await tx.execute({
+    sql: 'UPDATE dubbing_jobs SET account_deletion_requested_at = NULL, updated_at = datetime(\'now\') WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: `UPDATE job_languages
+          SET account_deletion_requested_at = NULL, updated_at = datetime('now')
+          WHERE job_id IN (SELECT id FROM dubbing_jobs WHERE user_id = ?)`,
+    args: [userId],
+  })
+  await tx.execute({
+    sql: `UPDATE youtube_uploads
+          SET account_deletion_requested_at = NULL, updated_at = datetime('now')
+          WHERE user_id = ?
+             OR job_language_id IN (
+               SELECT jl.id
+               FROM job_languages jl
+               JOIN dubbing_jobs dj ON dj.id = jl.job_id
+               WHERE dj.user_id = ?
+             )`,
+    args: [userId, userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE analytics_cache SET account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE perso_media_resources SET account_deletion_requested_at = NULL, updated_at = datetime(\'now\') WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE upload_queue SET account_deletion_requested_at = NULL, updated_at = datetime(\'now\') WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE payment_orders SET account_deletion_requested_at = NULL, updated_at = datetime(\'now\') WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE credit_transactions SET account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE operational_events SET account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [userId],
+  })
+}
+
+async function purgeExpiredDeletedAccount(tx: Transaction, userId: string) {
+  const deletedUserId = getDeletedUserId(userId)
+  await tx.execute({
+    sql: 'UPDATE payment_orders SET user_id = ?, account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [deletedUserId, userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE credit_transactions SET user_id = ?, account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [deletedUserId, userId],
+  })
+  await tx.execute({
+    sql: 'UPDATE operational_events SET user_id = NULL, account_deletion_requested_at = NULL WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM app_sessions WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM upload_queue WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: `DELETE FROM youtube_uploads
+          WHERE user_id = ?
+             OR job_language_id IN (
+               SELECT jl.id
+               FROM job_languages jl
+               JOIN dubbing_jobs dj ON dj.id = jl.job_id
+               WHERE dj.user_id = ?
+             )`,
+    args: [userId, userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM analytics_cache WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM job_languages WHERE job_id IN (SELECT id FROM dubbing_jobs WHERE user_id = ?)',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM dubbing_jobs WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM perso_media_resources WHERE user_id = ?',
+    args: [userId],
+  })
+  await tx.execute({
+    sql: 'DELETE FROM users WHERE id = ?',
+    args: [userId],
+  })
+}
+
+async function writeUser(
+  tx: Transaction,
+  user: {
+    id: string
+    email: string
+    displayName: string | null
+    photoURL: string | null
+    accessToken: string | null
+    refreshToken?: string | null
+    tokenExpiresAt?: string | null
+  },
+  accessToken: string | null,
+  refreshToken: string | null,
+) {
+  await tx.execute({
+    sql: `INSERT INTO users (
+            id, email, display_name, photo_url, google_access_token,
+            google_refresh_token, token_expires_at, account_status,
+            deletion_requested_at, deletion_restore_expires_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, datetime('now'))
+          ON CONFLICT(id) DO UPDATE SET
+            email = excluded.email,
+            display_name = excluded.display_name,
+            photo_url = excluded.photo_url,
+            google_access_token = COALESCE(excluded.google_access_token, users.google_access_token),
+            google_refresh_token = COALESCE(excluded.google_refresh_token, users.google_refresh_token),
+            token_expires_at = COALESCE(excluded.token_expires_at, users.token_expires_at),
+            account_status = excluded.account_status,
+            deletion_requested_at = NULL,
+            deletion_restore_expires_at = NULL,
+            updated_at = datetime('now')`,
+    args: [
+      user.id,
+      user.email,
+      user.displayName,
+      user.photoURL,
+      accessToken,
+      refreshToken,
+      user.tokenExpiresAt ?? null,
+      ACCOUNT_STATUS_ACTIVE,
+    ],
+  })
+}
 
 export async function upsertUser(user: {
   id: string
@@ -12,30 +192,31 @@ export async function upsertUser(user: {
   refreshToken?: string | null
   tokenExpiresAt?: string | null
 }) {
-  const db = getDb()
   const accessToken = await encryptToken(user.accessToken)
   const refreshToken = await encryptToken(user.refreshToken)
-  await db.execute({
-    sql: `INSERT INTO users (id, email, display_name, photo_url, google_access_token, google_refresh_token, token_expires_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
-          ON CONFLICT(id) DO UPDATE SET
-            email = excluded.email,
-            display_name = excluded.display_name,
-            photo_url = excluded.photo_url,
-            google_access_token = COALESCE(excluded.google_access_token, users.google_access_token),
-            google_refresh_token = COALESCE(excluded.google_refresh_token, users.google_refresh_token),
-            token_expires_at = COALESCE(excluded.token_expires_at, users.token_expires_at),
-            updated_at = datetime('now')`,
-    args: [
-      user.id,
-      user.email,
-      user.displayName,
-      user.photoURL,
-      accessToken,
-      refreshToken,
-      user.tokenExpiresAt ?? null,
-    ],
-  })
+  const tx = await getDb().transaction('write')
+  try {
+    const existing = await tx.execute({
+      sql: 'SELECT account_status, deletion_restore_expires_at FROM users WHERE id = ?',
+      args: [user.id],
+    })
+    const row = existing.rows[0]
+    if (row?.account_status === ACCOUNT_STATUS_PENDING_DELETION) {
+      if (canRestorePendingDeletion(row.deletion_restore_expires_at)) {
+        await clearAccountDeletionMarkers(tx, user.id)
+      } else {
+        await purgeExpiredDeletedAccount(tx, user.id)
+      }
+    }
+
+    await writeUser(tx, user, accessToken, refreshToken)
+    await tx.commit()
+  } catch (err) {
+    await tx.rollback().catch(() => {})
+    throw err
+  } finally {
+    tx.close()
+  }
 }
 
 export async function getUserTokens(userId: string) {
@@ -113,4 +294,90 @@ export async function setUserPreferencesRaw(userId: string, preferences: string)
     sql: `UPDATE users SET preferences = ?, updated_at = datetime('now') WHERE id = ?`,
     args: [preferences, userId],
   })
+}
+
+export async function requestUserAccountDeletion(userId: string): Promise<void> {
+  const requestedAt = new Date().toISOString()
+  const restoreExpiresAt = getDeletionRestoreExpiresAt(new Date(requestedAt))
+  const tx = await getDb().transaction('write')
+  try {
+    await tx.execute({
+      sql: `UPDATE users
+            SET account_status = ?,
+                deletion_requested_at = ?,
+                deletion_restore_expires_at = ?,
+                email = ?,
+                display_name = ?,
+                photo_url = NULL,
+                google_access_token = NULL,
+                google_refresh_token = NULL,
+                token_expires_at = NULL,
+                updated_at = datetime('now')
+            WHERE id = ?`,
+      args: [
+        ACCOUNT_STATUS_PENDING_DELETION,
+        requestedAt,
+        restoreExpiresAt,
+        getDeletionRequestEmail(userId),
+        ACCOUNT_DELETION_DISPLAY_NAME,
+        userId,
+      ],
+    })
+    await tx.execute({
+      sql: 'UPDATE app_sessions SET revoked_at = datetime(\'now\'), updated_at = datetime(\'now\') WHERE user_id = ?',
+      args: [userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE upload_queue SET account_deletion_requested_at = ?, updated_at = datetime(\'now\') WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE dubbing_jobs SET account_deletion_requested_at = ?, updated_at = datetime(\'now\') WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: `UPDATE job_languages
+            SET account_deletion_requested_at = ?, updated_at = datetime('now')
+            WHERE job_id IN (SELECT id FROM dubbing_jobs WHERE user_id = ?)`,
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: `UPDATE youtube_uploads
+            SET account_deletion_requested_at = ?, updated_at = datetime('now')
+            WHERE user_id = ?
+               OR job_language_id IN (
+                 SELECT jl.id
+                 FROM job_languages jl
+                 JOIN dubbing_jobs dj ON dj.id = jl.job_id
+                 WHERE dj.user_id = ?
+               )`,
+      args: [requestedAt, userId, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE analytics_cache SET account_deletion_requested_at = ? WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE perso_media_resources SET account_deletion_requested_at = ?, updated_at = datetime(\'now\') WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE payment_orders SET account_deletion_requested_at = ?, updated_at = datetime(\'now\') WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE credit_transactions SET account_deletion_requested_at = ? WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.execute({
+      sql: 'UPDATE operational_events SET account_deletion_requested_at = ? WHERE user_id = ?',
+      args: [requestedAt, userId],
+    })
+    await tx.commit()
+  } catch (err) {
+    await tx.rollback().catch(() => {})
+    throw err
+  } finally {
+    tx.close()
+  }
 }

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -4,6 +4,13 @@
  */
 'use client'
 
+import {
+  DEFAULT_APP_LOCALE,
+  getLocaleFromCookieString,
+  getPathLocale,
+  withSafeLocalePath,
+} from '@/lib/i18n/config'
+
 export interface GoogleUser {
   uid: string
   email: string
@@ -51,6 +58,16 @@ function storeUser(user: GoogleUser) {
   localStorage.setItem(STORAGE_KEY_USER, JSON.stringify(user))
 }
 
+function getCurrentLocale() {
+  return getPathLocale(window.location.pathname) ??
+    getLocaleFromCookieString(document.cookie) ??
+    DEFAULT_APP_LOCALE
+}
+
+function getCurrentReturnPath() {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
 /**
  * Navigates the current window to Google's OAuth consent screen.
  * Returns a Promise that never resolves on the calling side (page is leaving).
@@ -68,7 +85,7 @@ export function signInWithGoogle(
   const redirectUri = `${window.location.origin}/auth/callback`
   const scope = getGoogleScopes(scopeMode).join(' ')
   const stateNonce = crypto.randomUUID()
-  const returnTo = options.returnTo ?? (window.location.pathname + window.location.search)
+  const returnTo = withSafeLocalePath(options.returnTo ?? getCurrentReturnPath(), getCurrentLocale(), '/dashboard')
 
   sessionStorage.setItem(STORAGE_KEY_OAUTH_STATE, stateNonce)
   sessionStorage.setItem(STORAGE_KEY_OAUTH_SCOPE_MODE, scopeMode)

--- a/src/lib/i18n/client-messages/common.ts
+++ b/src/lib/i18n/client-messages/common.ts
@@ -200,6 +200,14 @@ export const commonMessages = {
     ko: '{languageName} 자막',
     en: '{languageName} captions',
   },
+  'features.landing.heroUrlInput.signInRequired': {
+    ko: '로그인이 필요합니다',
+    en: 'Sign-in required',
+  },
+  'features.landing.heroUrlInput.signInWithGoogleToContinue': {
+    ko: 'Google로 로그인하면 입력한 영상으로 더빙을 이어서 시작합니다.',
+    en: 'Sign in with Google to continue dubbing with the video you entered.',
+  },
   'features.landing.pricingSection.included1080pOutput': { ko: '1080p 출력', en: '1080p output' },
   'features.landing.pricingSection.includedLanguageCount': {
     ko: '{SUPPORTED_LANGUAGE_COUNT}개 언어 지원',
@@ -285,7 +293,43 @@ export const commonMessages = {
   'privacyStatus.private': { ko: '비공개', en: 'Private' },
   'privacyStatus.public': { ko: '공개', en: 'Public' },
   'privacyStatus.unlisted': { ko: '일부 공개', en: 'Unlisted' },
+  'settings.accountDeletion.button': {
+    ko: '회원탈퇴',
+    en: 'Delete account',
+  },
+  'settings.accountDeletion.confirmButton': {
+    ko: '계정 삭제',
+    en: 'Delete account',
+  },
+  'settings.accountDeletion.confirmLabel': {
+    ko: '계속하려면 {confirmation}를 입력하세요',
+    en: 'Type {confirmation} to continue',
+  },
+  'settings.accountDeletion.failed': {
+    ko: '계정을 삭제하지 못했습니다',
+    en: 'Could not delete account',
+  },
+  'settings.accountDeletion.failedMessage': {
+    ko: '잠시 후 다시 시도해 주세요.',
+    en: 'Please try again shortly.',
+  },
+  'settings.accountDeletion.modalDescription': {
+    ko: '회원탈퇴를 요청하면 즉시 로그아웃되고 계정, YouTube 연결, 업로드 큐, 더빙 작업 기록이 복구 대기 상태가 됩니다. 1주일 내 같은 Google 계정으로 다시 로그인하면 정상 계정으로 복구됩니다.',
+    en: 'After requesting withdrawal, you will be signed out and your account, YouTube connection, upload queue, and dubbing job history will be held for recovery. Sign in with the same Google account within 7 days to restore everything.',
+  },
+  'settings.accountDeletion.modalTitle': {
+    ko: '계정 삭제',
+    en: 'Delete account',
+  },
   'settings.appLocale': { ko: '앱 언어', en: 'App locale' },
+  'settings.dangerZone.description': {
+    ko: '더빙 작업 기록이 모두 삭제 요청 상태로 전환됩니다. 1주일 내 다시 로그인하면 계정을 복구할 수 있습니다.',
+    en: 'Your dubbing job history is moved into deletion-request status. Sign in again within 7 days to restore your account.',
+  },
+  'settings.dangerZone.title': {
+    ko: '회원탈퇴',
+    en: 'Account withdrawal',
+  },
   'settings.languageDefaults.description': {
     ko: '화면 언어와 테마, 제목·설명 기본 언어를 정합니다.',
     en: 'Set display language, theme, and default metadata language.',
@@ -293,14 +337,6 @@ export const commonMessages = {
   'settings.languageDefaults.title': {
     ko: '기본 설정',
     en: 'Preferences',
-  },
-  'settings.youtubeDefaults.description': {
-    ko: '새 작업에 적용할 공개 범위, 태그, 출시 언어를 정합니다. (실제 작업 시 수정 가능합니다.)',
-    en: 'Set the visibility, tags, and launch languages applied to new jobs. (You can change these per job.)',
-  },
-  'settings.youtubeDefaults.title': {
-    ko: 'YouTube 업로드 기본값',
-    en: 'YouTube upload defaults',
   },
   'settings.launchLanguages.allLanguages': {
     ko: '언어 직접 선택',
@@ -358,6 +394,14 @@ export const commonMessages = {
   'settings.themeMode.dark': { ko: '다크 모드', en: 'Dark mode' },
   'settings.themeMode.light': { ko: '라이트 모드', en: 'Light mode' },
   'settings.themeMode.system': { ko: '시스템 설정 사용', en: 'Use system setting' },
+  'settings.youtubeDefaults.description': {
+    ko: '새 작업에 적용할 공개 범위, 태그, 출시 언어를 정합니다. (실제 작업 시 수정 가능합니다.)',
+    en: 'Set the visibility, tags, and launch languages applied to new jobs. (You can change these per job.)',
+  },
+  'settings.youtubeDefaults.title': {
+    ko: 'YouTube 업로드 기본값',
+    en: 'YouTube upload defaults',
+  },
   'status.complete': { ko: '완료', en: 'Complete' },
   'status.failed': { ko: '실패', en: 'Failed' },
   'status.processing': { ko: '처리 중', en: 'Processing' },

--- a/src/lib/i18n/config.test.ts
+++ b/src/lib/i18n/config.test.ts
@@ -4,12 +4,15 @@ import {
   CUSTOM_METADATA_TARGET_PRESET,
   DEFAULT_APP_LOCALE,
   DEFAULT_METADATA_TARGET_PRESET,
+  getLocaleFromCookieString,
   getMetadataTargetLanguageCodes,
   getMarketLanguagePreset,
   isAppLocale,
+  isSafeLocalPath,
   MARKET_LANGUAGE_PRESETS,
   normalizeMetadataTargetLanguages,
   resolveAppLocale,
+  withSafeLocalePath,
 } from './config'
 
 describe('i18n config', () => {
@@ -25,6 +28,26 @@ describe('i18n config', () => {
     expect(resolveAppLocale('en')).toBe('en')
     expect(resolveAppLocale('fr')).toBe('ko')
     expect(resolveAppLocale(null)).toBe('ko')
+  })
+
+  it('normalizes local paths with a locale prefix', () => {
+    expect(withSafeLocalePath('/dashboard', 'en')).toBe('/en/dashboard')
+    expect(withSafeLocalePath('/ko/settings?section=youtube#top', 'en')).toBe('/en/settings?section=youtube#top')
+    expect(withSafeLocalePath('https://example.com', 'ko', '/dashboard')).toBe('/ko/dashboard')
+    expect(withSafeLocalePath('https://example.com', 'ko', 'https://fallback.example.com')).toBe('/ko')
+  })
+
+  it('only treats root-relative URLs as safe local paths', () => {
+    expect(isSafeLocalPath('/dashboard')).toBe(true)
+    expect(isSafeLocalPath('//example.com')).toBe(false)
+    expect(isSafeLocalPath('https://example.com')).toBe(false)
+    expect(isSafeLocalPath('dashboard')).toBe(false)
+  })
+
+  it('reads the app locale cookie from a cookie header string', () => {
+    expect(getLocaleFromCookieString('x=1; dubtube_locale=en; y=2')).toBe('en')
+    expect(getLocaleFromCookieString('dubtube_locale=ja')).toBeNull()
+    expect(getLocaleFromCookieString(null)).toBeNull()
   })
 
   it('defines metadata target presets for launch and international growth', () => {

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -73,6 +73,10 @@ export function stripLocalePrefix(pathname: string): string {
   return stripped === '/' ? '/' : stripped.replace(/\/$/, '') || '/'
 }
 
+export function isSafeLocalPath(path: string | null | undefined): path is string {
+  return !!path && path.startsWith('/') && !path.startsWith('//') && !/^[a-z][a-z0-9+.-]*:/i.test(path)
+}
+
 export function withLocalePath(path: string, locale: AppLocale): string {
   if (!path || path === '/') return `/${locale}`
   if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith('#')) return path
@@ -82,6 +86,39 @@ export function withLocalePath(path: string, locale: AppLocale): string {
   const normalizedPath = stripLocalePrefix(pathname.startsWith('/') ? pathname : `/${pathname}`)
   const localized = normalizedPath === '/' ? `/${locale}` : `/${locale}${normalizedPath}`
   return `${localized}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`
+}
+
+export function withSafeLocalePath(
+  path: string | null | undefined,
+  locale: AppLocale,
+  fallbackPath = '/',
+): string {
+  const safePath = isSafeLocalPath(path)
+    ? path
+    : isSafeLocalPath(fallbackPath)
+      ? fallbackPath
+      : '/'
+  return withLocalePath(safePath, locale)
+}
+
+export function getLocaleFromCookieString(cookieString: string | null | undefined): AppLocale | null {
+  if (!cookieString) return null
+
+  const prefix = `${LOCALE_COOKIE}=`
+  const match = cookieString
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix))
+
+  if (!match) return null
+
+  const raw = match.slice(prefix.length)
+  try {
+    const decoded = decodeURIComponent(raw)
+    return isAppLocale(decoded) ? decoded : null
+  } catch {
+    return isAppLocale(raw) ? raw : null
+  }
 }
 
 export interface MarketLanguagePreset {

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -96,6 +96,50 @@ const baseMessages = {
     ko: '설정 저장 실패',
     en: 'Could not save settings',
   },
+  'settings.dangerZone.title': {
+    ko: '회원탈퇴',
+    en: 'Account withdrawal',
+  },
+  'settings.dangerZone.description': {
+    ko: '더빙 작업 기록이 모두 삭제 요청 상태로 전환됩니다. 1주일 내 다시 로그인하면 계정을 복구할 수 있습니다.',
+    en: 'Your dubbing job history is moved into deletion-request status. Sign in again within 7 days to restore your account.',
+  },
+  'settings.accountDeletion.button': {
+    ko: '회원탈퇴',
+    en: 'Delete account',
+  },
+  'settings.accountDeletion.modalTitle': {
+    ko: '계정 삭제',
+    en: 'Delete account',
+  },
+  'settings.accountDeletion.modalDescription': {
+    ko: '회원탈퇴를 요청하면 즉시 로그아웃되고 계정, YouTube 연결, 업로드 큐, 더빙 작업 기록이 복구 대기 상태가 됩니다. 1주일 내 같은 Google 계정으로 다시 로그인하면 정상 계정으로 복구됩니다.',
+    en: 'After requesting withdrawal, you will be signed out and your account, YouTube connection, upload queue, and dubbing job history will be held for recovery. Sign in with the same Google account within 7 days to restore everything.',
+  },
+  'settings.accountDeletion.confirmLabel': {
+    ko: '계속하려면 {confirmation}를 입력하세요',
+    en: 'Type {confirmation} to continue',
+  },
+  'settings.accountDeletion.confirmButton': {
+    ko: '계정 삭제',
+    en: 'Delete account',
+  },
+  'settings.accountDeletion.failed': {
+    ko: '계정을 삭제하지 못했습니다',
+    en: 'Could not delete account',
+  },
+  'settings.accountDeletion.failedMessage': {
+    ko: '잠시 후 다시 시도해 주세요.',
+    en: 'Please try again shortly.',
+  },
+  'features.landing.heroUrlInput.signInRequired': {
+    ko: '로그인이 필요합니다',
+    en: 'Sign-in required',
+  },
+  'features.landing.heroUrlInput.signInWithGoogleToContinue': {
+    ko: 'Google로 로그인하면 입력한 영상으로 더빙을 이어서 시작합니다.',
+    en: 'Sign in with Google to continue dubbing with the video you entered.',
+  },
   'components.layout.sidebar.labelSettings': { ko: '설정', en: 'Settings' },
   'components.layout.sidebar.appNavigation': { ko: '앱 메뉴', en: 'App navigation' },
   'components.layout.topbar.subscriberCount': { ko: '구독자 {count}', en: '{count} subscribers' },

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -22,12 +22,16 @@ interface NotificationState {
 let toastId = 0
 const timers = new Map<string, ReturnType<typeof setTimeout>>()
 
+function getDefaultDuration(type: ToastType) {
+  return type === 'success' ? 5000 : 7000
+}
+
 export const useNotificationStore = create<NotificationState>((set) => ({
   toasts: [],
   addToast: (toast) => {
     const id = `toast-${++toastId}`
     set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }))
-    const duration = toast.duration ?? 4000
+    const duration = toast.duration ?? getDefaultDuration(toast.type)
     if (duration > 0) {
       timers.set(
         id,


### PR DESCRIPTION
## 변경 사항
- 언어 변경, 로그인/로그아웃 리다이렉트를 locale-aware 경로로 정리했습니다.
- 메인 화면 더빙 시작 시 비로그인 사용자는 눈에 띄는 토스트 후 Google 로그인으로 이동합니다.
- 설정의 회원탈퇴 UI를 추가하고, 탈퇴 요청 후 7일 내 재로그인 시 계정과 관련 DB 마커를 복구하도록 구현했습니다.
- 7일이 지난 뒤 같은 계정으로 로그인하면 기존 작업 데이터는 삭제하고 결제/크레딧 기록은 익명 사용자 ID로 보존합니다.
- 토스트 알림 위치와 크기를 개선하고, Dubtube 로고 클릭 시 대시보드로 이동하게 했습니다.

## 검증
- npm test -- src/lib/db/queries/users-account-deletion.test.ts src/app/api/user/account/account-route.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #318