### PR TITLE
fix: 로그인 후 YouTube 권한 복구 흐름 정리

### DIFF
--- a/src/app/api/auth/auth-callback.test.ts
+++ b/src/app/api/auth/auth-callback.test.ts
@@ -113,19 +113,69 @@ describe('POST /api/auth/callback', () => {
           access_token: 'at-123',
           refresh_token: 'rt-456',
           expires_in: 3600,
+          scope: [
+            'openid',
+            'email',
+            'profile',
+            'https://www.googleapis.com/auth/youtube.upload',
+            'https://www.googleapis.com/auth/youtube.force-ssl',
+            'https://www.googleapis.com/auth/youtube.readonly',
+          ].join(' '),
           token_type: 'Bearer',
         }),
       })
       .mockResolvedValueOnce({
         ok: false,
       })
-    const res = await POST(makeReq({ code: 'good-code', redirectUri: CALLBACK_REDIRECT_URI }))
+    const res = await POST(makeReq({
+      code: 'good-code',
+      redirectUri: CALLBACK_REDIRECT_URI,
+      scopeMode: 'youtube-write',
+    }))
     expect(res.status).toBe(401)
     const body = await res.json()
     expect(body.error.code).toBe('USERINFO_FAILED')
   })
 
+  it('rejects YouTube reconnect when Google did not grant YouTube scopes', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'login-only-token',
+        refresh_token: 'rt-456',
+        expires_in: 3600,
+        scope: 'openid email profile',
+        token_type: 'Bearer',
+      }),
+    })
+
+    const res = await POST(makeReq({
+      code: 'missing-youtube-scope',
+      redirectUri: CALLBACK_REDIRECT_URI,
+      scopeMode: 'youtube-write',
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toMatchObject({
+      code: 'YOUTUBE_SCOPE_DENIED',
+      message: expect.stringContaining('YouTube 권한이 허용되지 않았습니다'),
+    })
+    expect(upsertUser).not.toHaveBeenCalled()
+    expect(createUserSession).not.toHaveBeenCalled()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('exchanges code and returns user + sets cookies on success', async () => {
+    const grantedYouTubeScopes = [
+      'openid',
+      'email',
+      'profile',
+      'https://www.googleapis.com/auth/youtube.upload',
+      'https://www.googleapis.com/auth/youtube.force-ssl',
+      'https://www.googleapis.com/auth/youtube.readonly',
+    ].join(' ')
+
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -133,6 +183,7 @@ describe('POST /api/auth/callback', () => {
           access_token: 'at-123',
           refresh_token: 'rt-456',
           expires_in: 3600,
+          scope: grantedYouTubeScopes,
           token_type: 'Bearer',
         }),
       })
@@ -146,7 +197,11 @@ describe('POST /api/auth/callback', () => {
         }),
       })
 
-    const res = await POST(makeReq({ code: 'good-code', redirectUri: CALLBACK_REDIRECT_URI }))
+    const res = await POST(makeReq({
+      code: 'good-code',
+      redirectUri: CALLBACK_REDIRECT_URI,
+      scopeMode: 'youtube-write',
+    }))
     expect(res.status).toBe(200)
 
     const body = await res.json()
@@ -176,6 +231,37 @@ describe('POST /api/auth/callback', () => {
     expect(setCookies.find((c: string) => c.startsWith('google_access_token='))).toBeUndefined()
   })
 
+  it('does not overwrite stored YouTube tokens on login-only callback', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'login-at-123',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: 'user-login',
+          email: 'login@example.com',
+        }),
+      })
+
+    const res = await POST(makeReq({ code: 'login-code', redirectUri: CALLBACK_REDIRECT_URI }))
+    expect(res.status).toBe(200)
+
+    expect(upsertUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'user-login',
+        accessToken: null,
+        refreshToken: null,
+        tokenExpiresAt: null,
+      }),
+    )
+  })
+
   it('handles missing refresh_token gracefully', async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -194,7 +280,11 @@ describe('POST /api/auth/callback', () => {
         }),
       })
 
-    const res = await POST(makeReq({ code: 'code-no-refresh', redirectUri: CALLBACK_REDIRECT_URI }))
+    const res = await POST(makeReq({
+      code: 'code-no-refresh',
+      redirectUri: CALLBACK_REDIRECT_URI,
+      scopeMode: 'youtube-write',
+    }))
     expect(res.status).toBe(200)
 
     expect(upsertUser).toHaveBeenCalledWith(

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -11,6 +11,30 @@ export const dynamic = 'force-dynamic'
 
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
+const YOUTUBE_WRITE_REQUIRED_SCOPES = [
+  'https://www.googleapis.com/auth/youtube.upload',
+  'https://www.googleapis.com/auth/youtube.force-ssl',
+  'https://www.googleapis.com/auth/youtube.readonly',
+] as const
+const YOUTUBE_READONLY_REQUIRED_SCOPES = [
+  'https://www.googleapis.com/auth/youtube.readonly',
+] as const
+
+function hasGrantedScopes(scopeValue: string | undefined, requiredScopes: readonly string[]) {
+  if (!scopeValue) return true
+  const grantedScopes = new Set(scopeValue.split(/\s+/).filter(Boolean))
+  return requiredScopes.every((scope) => grantedScopes.has(scope))
+}
+
+function hasRequiredYouTubeScopes(scopeMode: string, scopeValue: string | undefined) {
+  if (scopeMode === 'youtube-write') {
+    return hasGrantedScopes(scopeValue, YOUTUBE_WRITE_REQUIRED_SCOPES)
+  }
+  if (scopeMode === 'youtube-readonly') {
+    return hasGrantedScopes(scopeValue, YOUTUBE_READONLY_REQUIRED_SCOPES)
+  }
+  return true
+}
 
 function getAllowedRedirectOrigins(req: NextRequest) {
   const origins = new Set<string>([req.nextUrl.origin])
@@ -47,7 +71,7 @@ export async function POST(req: NextRequest) {
       return apiFail('BAD_REQUEST', 'code and redirectUri required', 400)
     }
 
-    const { code, redirectUri } = parsed.data
+    const { code, redirectUri, scopeMode } = parsed.data
     const serverEnv = getServerEnv()
     const clientEnv = getClientEnv()
     const verifiedRedirectUri = getVerifiedRedirectUri(req, redirectUri)
@@ -79,7 +103,16 @@ export async function POST(req: NextRequest) {
       access_token: string
       refresh_token?: string
       expires_in: number
+      scope?: string
       token_type: string
+    }
+
+    if (!hasRequiredYouTubeScopes(scopeMode, tokens.scope)) {
+      return apiFail(
+        'YOUTUBE_SCOPE_DENIED',
+        'YouTube 권한이 허용되지 않았습니다. Google 동의 화면에서 YouTube 권한을 모두 허용해 주세요.',
+        403,
+      )
     }
 
     const userRes = await fetch(GOOGLE_USERINFO_URL, {
@@ -103,9 +136,9 @@ export async function POST(req: NextRequest) {
       email: info.email,
       displayName: info.name ?? null,
       photoURL: info.picture ?? null,
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token ?? null,
-      tokenExpiresAt: expiresAt,
+      accessToken: scopeMode === 'login' ? null : tokens.access_token,
+      refreshToken: scopeMode === 'login' ? null : tokens.refresh_token ?? null,
+      tokenExpiresAt: scopeMode === 'login' ? null : expiresAt,
     })
 
     const session = await createSessionCookie(info.sub)

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -18,16 +18,6 @@ import {
   type AppLocale,
 } from '@/lib/i18n/config'
 
-async function hasConnectedYouTubeChannel(): Promise<boolean> {
-  try {
-    const res = await fetch('/api/youtube/stats?channel=true', { cache: 'no-store' })
-    const body = (await res.json().catch(() => null)) as { ok?: boolean; data?: unknown } | null
-    return res.ok && body?.ok === true && !!body.data
-  } catch {
-    return false
-  }
-}
-
 function getRedirectLocale(returnTo: string, fallback: AppLocale): AppLocale {
   return getPathLocale(returnTo) ??
     getPathLocale(window.location.pathname) ??
@@ -67,20 +57,6 @@ export default function AuthCallbackPage() {
         // YouTube reconnect flow: just go back wherever the user came from.
         if (scopeMode === 'youtube-write' || scopeMode === 'youtube-readonly') {
           window.location.replace(withSafeLocalePath(returnTo, redirectLocale, '/settings?section=youtube'))
-          return
-        }
-
-        // Initial login: nudge user to connect YouTube if they haven't yet.
-        const connected = await hasConnectedYouTubeChannel()
-        if (cancelled) return
-
-        if (!connected) {
-          addToast({
-            type: 'info',
-            title: t('app.auth.callback.page.connectYouTubeChannel'),
-            message: t('app.auth.callback.page.connectYouTubeChannelInSettings'),
-          })
-          window.location.replace(withLocalePath('/settings?section=youtube', redirectLocale))
           return
         }
 

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -77,8 +77,8 @@ export default function AuthCallbackPage() {
         if (!connected) {
           addToast({
             type: 'info',
-            title: t('components.layout.landingNavBar.connectYouTubeChannel'),
-            message: t('components.layout.landingNavBar.connectYouTubeChannelInSettings'),
+            title: t('app.auth.callback.page.connectYouTubeChannel'),
+            message: t('app.auth.callback.page.connectYouTubeChannelInSettings'),
           })
           window.location.replace(withLocalePath('/settings?section=youtube', redirectLocale))
           return
@@ -88,11 +88,11 @@ export default function AuthCallbackPage() {
         window.location.replace(isLandingPath(normalizedReturnTo) ? withLocalePath('/dashboard', redirectLocale) : normalizedReturnTo)
       } catch (err) {
         if (cancelled) return
-        const message = err instanceof Error ? err.message : t('components.layout.landingNavBar.pleaseTryAgainShortlyContactUsIfThe')
+        const message = err instanceof Error ? err.message : t('app.auth.callback.page.tryAgainShortly')
         setErrorMessage(message)
         addToast({
           type: 'error',
-          title: t('components.layout.landingNavBar.couldNotSignIn'),
+          title: t('app.auth.callback.page.couldNotSignIn'),
           message,
         })
         window.setTimeout(() => {

--- a/src/features/settings/components/SettingsClient.tsx
+++ b/src/features/settings/components/SettingsClient.tsx
@@ -22,7 +22,7 @@ import { useYouTubeSettingsStore } from '@/stores/youtubeSettingsStore'
 import { SUPPORTED_LANGUAGES, getLanguageByCode } from '@/utils/languages'
 import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
 import { useLocaleRouter } from '@/hooks/useLocalePath'
-import { useChannelStats } from '@/hooks/useYouTubeData'
+import { isYouTubeConnectionError, useChannelStats } from '@/hooks/useYouTubeData'
 import { formatNumber } from '@/utils/formatters'
 import { signInWithGoogle, signOut as clearStoredGoogleUser } from '@/lib/google-auth'
 import { useAuthStore } from '@/stores/authStore'
@@ -108,10 +108,7 @@ export function SettingsClient() {
   const youtubeSectionRef = useRef<HTMLDivElement>(null)
 
   const { data: channel, error: channelError } = useChannelStats()
-  const isYouTubeConnected = !!channel && !(
-    channelError instanceof Error &&
-    (channelError.message.includes(t('internal.keyword.youtubeConnection')) || channelError.message.includes('Google access token'))
-  )
+  const isYouTubeConnected = !!channel && !isYouTubeConnectionError(channelError)
 
   const draftTags = useMemo(() => parseTagsInput(defaultTagsInput), [defaultTagsInput])
   const targetLanguageCodes = useMemo(
@@ -542,10 +539,11 @@ function YouTubeConnectionCard() {
   const [connecting, setConnecting] = useState(false)
   const addToast = useNotificationStore((state) => state.addToast)
   const { data: channel, isLoading: channelLoading, error: channelError } = useChannelStats()
-  const missingYouTubeConnection =
-    channelError instanceof Error &&
-    (channelError.message.includes(t('internal.keyword.youtubeConnection')) || channelError.message.includes('Google access token'))
+  const missingYouTubeConnection = isYouTubeConnectionError(channelError)
   const isConnected = !!channel && !missingYouTubeConnection
+  const connectionMessage = missingYouTubeConnection && channelError instanceof Error
+    ? channelError.message
+    : t('app.app.youtube.page.noYouTubeChannelConnected')
 
   const handleReconnect = async () => {
     setConnecting(true)
@@ -637,7 +635,7 @@ function YouTubeConnectionCard() {
       ) : (
         <div className="mt-4 flex flex-col items-center gap-4 py-8">
           <Video className="h-12 w-12 text-surface-300" />
-          <p className="text-surface-500 dark:text-surface-300">{t('app.app.youtube.page.noYouTubeChannelConnected')}</p>
+          <p className="max-w-md text-center text-sm leading-6 text-surface-600 dark:text-surface-300">{connectionMessage}</p>
           <p className="max-w-md text-center text-xs leading-5 text-surface-600 dark:text-surface-300">
             {t('app.app.youtube.page.dubtubeRequestsYouTubePermissionsForChannelReadsUploads')}
           </p>

--- a/src/hooks/useYouTubeData.ts
+++ b/src/hooks/useYouTubeData.ts
@@ -24,14 +24,18 @@ interface ApiResponse<T> {
   }
 }
 
+const YOUTUBE_RECONNECT_ERROR_CODES = new Set([
+  'MISSING_ACCESS_TOKEN',
+  'UNAUTHORIZED',
+  'YOUTUBE_RECONNECT_REQUIRED',
+  'YOUTUBE_CHANNEL_REQUIRED',
+  'YOUTUBE_CHANNEL_FORBIDDEN',
+  'YOUTUBE_CHANNEL_UNAVAILABLE',
+])
+
 export function isYouTubeConnectionError(error: unknown): boolean {
   if (error instanceof YouTubeDataError) {
-    return (
-      error.code === 'MISSING_ACCESS_TOKEN' ||
-      error.code === 'UNAUTHORIZED' ||
-      error.status === 401 ||
-      error.status === 403
-    )
+    return YOUTUBE_RECONNECT_ERROR_CODES.has(error.code ?? '') || error.status === 401
   }
   return error instanceof Error && (
     error.message.includes('Google access token') ||

--- a/src/lib/google-auth.ts
+++ b/src/lib/google-auth.ts
@@ -143,7 +143,7 @@ export async function completeGoogleSignIn(): Promise<{
   const res = await fetch('/api/auth/callback', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code, redirectUri }),
+    body: JSON.stringify({ code, redirectUri, scopeMode }),
   })
 
   if (!res.ok) {

--- a/src/lib/i18n/client-messages/common.ts
+++ b/src/lib/i18n/client-messages/common.ts
@@ -27,7 +27,23 @@ export const commonMessages = {
     ko: '업로드할 영상을 불러오지 못했습니다.',
     en: 'Could not load videos to upload.',
   },
+  'app.auth.callback.page.connectYouTubeChannel': {
+    ko: 'YouTube 채널을 연결해 주세요',
+    en: 'Connect your YouTube channel',
+  },
+  'app.auth.callback.page.connectYouTubeChannelInSettings': {
+    ko: '더빙과 업로드를 시작하려면 설정에서 YouTube 채널을 먼저 연결해야 합니다.',
+    en: 'Connect your YouTube channel in Settings before starting dubbing and uploads.',
+  },
+  'app.auth.callback.page.couldNotSignIn': {
+    ko: '로그인할 수 없습니다',
+    en: 'Could not sign in',
+  },
   'app.auth.callback.page.processingLogin': { ko: '로그인 처리 중입니다...', en: 'Signing you in...' },
+  'app.auth.callback.page.tryAgainShortly': {
+    ko: '잠시 후 다시 시도해 주세요. 문제가 계속되면 문의해 주세요.',
+    en: 'Please try again shortly. Contact us if the problem continues.',
+  },
   "app.globalError.anUnexpectedErrorOccurred": { ko: "예상치 못한 오류가 발생했습니다", en: "An unexpected error occurred" },
   "app.globalError.errorCodeForSupportValue": { ko: "문의 시 전달할 오류 코드: {errorDigest}", en: "Error code for support: {errorDigest}" },
   "app.globalError.pleaseTryAgainInAMomentContactSupport": { ko: "잠시 후 다시 시도해 주세요. 문제가 계속되면 문의해 주세요.", en: "Please try again in a moment. Contact support if the problem continues." },

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -255,7 +255,23 @@ const baseMessages = {
     en: 'Payment confirmation failed.',
   },
   'app.app.loading.label': { ko: '로딩 중...', en: 'Loading...' },
+  'app.auth.callback.page.connectYouTubeChannel': {
+    ko: 'YouTube 채널을 연결해 주세요',
+    en: 'Connect your YouTube channel',
+  },
+  'app.auth.callback.page.connectYouTubeChannelInSettings': {
+    ko: '더빙과 업로드를 시작하려면 설정에서 YouTube 채널을 먼저 연결해야 합니다.',
+    en: 'Connect your YouTube channel in Settings before starting dubbing and uploads.',
+  },
+  'app.auth.callback.page.couldNotSignIn': {
+    ko: '로그인할 수 없습니다',
+    en: 'Could not sign in',
+  },
   'app.auth.callback.page.processingLogin': { ko: '로그인 처리 중입니다...', en: 'Signing you in...' },
+  'app.auth.callback.page.tryAgainShortly': {
+    ko: '잠시 후 다시 시도해 주세요. 문제가 계속되면 문의해 주세요.',
+    en: 'Please try again shortly. Contact us if the problem continues.',
+  },
   'app.app.uploads.page.couldNotLoadVideosToUpload': {
     ko: '업로드할 영상을 불러오지 못했습니다.',
     en: 'Could not load videos to upload.',

--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -10,4 +10,5 @@ export const syncBodySchema = z.object({
 export const callbackBodySchema = z.object({
   code: z.string().min(1),
   redirectUri: z.string().url(),
+  scopeMode: z.enum(['login', 'youtube-write', 'youtube-readonly']).default('login'),
 })

--- a/src/lib/youtube/error.ts
+++ b/src/lib/youtube/error.ts
@@ -5,6 +5,7 @@ export class YouTubeError extends Error {
     public status: number,
     message: string,
     public code = 'YOUTUBE_ERROR',
+    public reason?: string,
   ) {
     super(message)
     this.name = 'YouTubeError'

--- a/src/lib/youtube/route-helpers.test.ts
+++ b/src/lib/youtube/route-helpers.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { z } from 'zod'
 import { cookies } from 'next/headers'
-import { ytOk, ytFail, ytHandle, requireAccessToken, parseQuery, parseYtBody } from './route-helpers'
+import { ytOk, ytFail, ytHandle, requireAccessToken, parseQuery, parseYtBody, withTokenRetry } from './route-helpers'
 import { YouTubeError } from './server'
 import { verifySessionCookie } from '@/lib/auth/session-cookie'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
@@ -17,6 +17,10 @@ vi.mock('@/lib/auth/session-cookie', () => ({
 vi.mock('@/lib/auth/token-refresh', () => ({
   getOrRefreshAccessToken: vi.fn(),
 }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('ytOk', () => {
   it('returns JSON with ok: true envelope', async () => {
@@ -54,6 +58,17 @@ describe('ytFail', () => {
     const err = new YouTubeError(0, 'No status', 'NO_STATUS')
     const res = ytFail(err)
     expect(res.status).toBe(500)
+  })
+
+  it('maps missing YouTube scope to a reconnect action', async () => {
+    const err = new YouTubeError(403, 'missing scope', 'YOUTUBE_RECONNECT_REQUIRED', 'insufficientPermissions')
+    const res = ytFail(err)
+    const body = await res.json()
+    expect(res.status).toBe(403)
+    expect(body.error).toMatchObject({
+      code: 'YOUTUBE_RECONNECT_REQUIRED',
+      message: expect.stringContaining('YouTube 연결을 다시 진행'),
+    })
   })
 
   it('handles generic Error', async () => {
@@ -238,5 +253,58 @@ describe('requireAccessToken', () => {
       expect((e as YouTubeError).status).toBe(401)
       expect((e as YouTubeError).code).toBe('MISSING_ACCESS_TOKEN')
     }
+  })
+})
+
+describe('withTokenRetry', () => {
+  it('refreshes once and retries when YouTube scopes are missing from the access token', async () => {
+    vi.mocked(cookies)
+      .mockResolvedValueOnce({
+        get: vi.fn((name: string) =>
+          name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+        ),
+      } as never)
+      .mockResolvedValueOnce({
+        get: vi.fn((name: string) =>
+          name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+        ),
+      } as never)
+    vi.mocked(verifySessionCookie).mockResolvedValue('user-1')
+    vi.mocked(getOrRefreshAccessToken)
+      .mockResolvedValueOnce('login-only-token')
+      .mockResolvedValueOnce('youtube-token')
+
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new YouTubeError(
+        403,
+        'missing scope',
+        'YOUTUBE_RECONNECT_REQUIRED',
+        'insufficientPermissions',
+      ))
+      .mockResolvedValueOnce({ ok: true })
+
+    await expect(withTokenRetry(new Request('http://localhost'), fn)).resolves.toEqual({ ok: true })
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenNthCalledWith(1, 'login-only-token')
+    expect(fn).toHaveBeenNthCalledWith(2, 'youtube-token')
+    expect(getOrRefreshAccessToken).toHaveBeenNthCalledWith(1, 'user-1', { force: undefined })
+    expect(getOrRefreshAccessToken).toHaveBeenNthCalledWith(2, 'user-1', { force: true })
+  })
+
+  it('does not retry quota errors as auth problems', async () => {
+    vi.mocked(cookies).mockResolvedValueOnce({
+      get: vi.fn((name: string) =>
+        name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+      ),
+    } as never)
+    vi.mocked(verifySessionCookie).mockResolvedValueOnce('user-1')
+    vi.mocked(getOrRefreshAccessToken).mockResolvedValueOnce('youtube-token')
+
+    const err = new YouTubeError(403, 'quota', 'QUOTA_EXCEEDED', 'quotaExceeded')
+    const fn = vi.fn().mockRejectedValueOnce(err)
+
+    await expect(withTokenRetry(new Request('http://localhost'), fn)).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(getOrRefreshAccessToken).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/lib/youtube/route-helpers.ts
+++ b/src/lib/youtube/route-helpers.ts
@@ -9,7 +9,7 @@ export { apiOk as ytOk }
 export function ytFail(err: unknown) {
   if (err instanceof YouTubeError) {
     const status = err.status || 500
-    const logPayload = { status, code: err.code, message: err.message }
+    const logPayload = { status, code: err.code, reason: err.reason, message: err.message }
     if (status >= 500) logger.error('youtube api error', logPayload)
     else logger.warn('youtube api error', logPayload)
     return apiFail(err.code, toUserMessage(err.code, status), status)
@@ -19,7 +19,19 @@ export function ytFail(err: unknown) {
 
 function toUserMessage(code: string, status: number) {
   if (code === 'MISSING_ACCESS_TOKEN') {
-    return 'YouTube 연결이 필요합니다. Google 계정으로 다시 연결해 주세요.'
+    return 'YouTube 연결이 필요합니다. 설정에서 Google 계정으로 YouTube 연결을 눌러 권한을 허용해 주세요.'
+  }
+  if (code === 'YOUTUBE_RECONNECT_REQUIRED') {
+    return 'YouTube 권한이 빠져 있습니다. 설정에서 Google 계정으로 YouTube 연결을 다시 진행하고, 권한 동의 화면에서 YouTube 권한을 허용해 주세요.'
+  }
+  if (code === 'YOUTUBE_CHANNEL_REQUIRED') {
+    return '현재 Google 계정에 YouTube 채널이 없습니다. YouTube에서 채널을 만든 뒤 다시 연결해 주세요.'
+  }
+  if (code === 'YOUTUBE_CHANNEL_FORBIDDEN') {
+    return '이 Google 계정으로는 해당 YouTube 채널을 사용할 수 없습니다. 채널 소유자 또는 관리자 계정으로 다시 연결해 주세요.'
+  }
+  if (code === 'YOUTUBE_CHANNEL_UNAVAILABLE') {
+    return 'YouTube 채널이 닫혔거나 정지되어 정보를 불러올 수 없습니다. YouTube Studio에서 채널 상태를 확인해 주세요.'
   }
   if (code === 'VIDEO_NOT_FOUND') {
     return 'YouTube 영상을 찾을 수 없습니다.'
@@ -46,7 +58,7 @@ function toUserMessage(code: string, status: number) {
     return 'YouTube 연결이 만료되었습니다. 다시 연결해 주세요.'
   }
   if (status === 403) {
-    return 'YouTube 권한이 부족합니다. Google 계정 권한을 확인해 주세요.'
+    return 'YouTube 요청 권한을 확인하지 못했습니다. 설정에서 YouTube 연결을 다시 진행한 뒤 계속 실패하면 다른 Google 계정 또는 채널 권한을 확인해 주세요.'
   }
   return 'YouTube 요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.'
 }
@@ -60,8 +72,8 @@ export async function ytHandle<T>(fn: () => Promise<T>): Promise<Response> {
 }
 
 /**
- * YouTube API 호출 함수를 401 자동 재시도로 감싼다.
- * 401(인증 거부)이 떨어지면 DB의 refresh_token으로 강제 리프레시 후 1회 재시도한다.
+ * YouTube API 호출 함수를 인증/권한 오류 자동 재시도로 감싼다.
+ * 401 또는 YouTube 권한 누락 403이 떨어지면 DB의 refresh_token으로 강제 리프레시 후 1회 재시도한다.
  * 사용 예:
  *   await withTokenRetry(req, (token) => uploadCaptionToYouTube({ accessToken: token, ... }))
  */
@@ -73,9 +85,12 @@ export async function withTokenRetry<T>(
   try {
     return await fn(token)
   } catch (err) {
-    const status = err instanceof YouTubeError ? err.status : 0
-    if (status !== 401) throw err
-    // 401: 토큰이 stale일 가능성 → 강제 리프레시 후 1회 재시도
+    const shouldRefresh = err instanceof YouTubeError && (
+      err.status === 401 ||
+      err.code === 'YOUTUBE_RECONNECT_REQUIRED'
+    )
+    if (!shouldRefresh) throw err
+    // 401 또는 권한 누락 403은 DB의 refresh_token으로 새 access token을 받아 1회만 재시도한다.
     const fresh = await requireAccessToken(req, { forceRefresh: true })
     if (fresh === token) throw err
     return await fn(fresh)

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -41,6 +41,11 @@ describe('YouTubeError', () => {
     const err = new YouTubeError(500, 'fail')
     expect(err.code).toBe('YOUTUBE_ERROR')
   })
+
+  it('stores YouTube error reason when provided', () => {
+    const err = new YouTubeError(403, 'Forbidden', 'YOUTUBE_RECONNECT_REQUIRED', 'insufficientPermissions')
+    expect(err.reason).toBe('insufficientPermissions')
+  })
 })
 
 describe('fetchVideoStatistics', () => {
@@ -112,6 +117,40 @@ describe('fetchChannelStatistics', () => {
     await expect(fetchChannelStatistics('tok')).rejects.toMatchObject({
       status: 401,
       code: 'CHANNEL_FETCH_FAILED',
+    })
+  })
+
+  it('maps insufficient YouTube scopes to reconnect-required errors', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        error: {
+          message: 'Request had insufficient authentication scopes.',
+          errors: [{ reason: 'insufficientPermissions' }],
+        },
+      }, 403),
+    )
+
+    await expect(fetchChannelStatistics('tok')).rejects.toMatchObject({
+      status: 403,
+      code: 'YOUTUBE_RECONNECT_REQUIRED',
+      reason: 'insufficientPermissions',
+    })
+  })
+
+  it('maps Google accounts without a YouTube channel to channel-required errors', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        error: {
+          message: 'The authenticated user must have a channel.',
+          errors: [{ reason: 'authenticatedUserNotChannel' }],
+        },
+      }, 403),
+    )
+
+    await expect(fetchChannelStatistics('tok')).rejects.toMatchObject({
+      status: 403,
+      code: 'YOUTUBE_CHANNEL_REQUIRED',
+      reason: 'authenticatedUserNotChannel',
     })
   })
 
@@ -239,9 +278,10 @@ describe('fetchMyVideos', () => {
     const promise = fetchMyVideos('tok')
     await expect(promise).rejects.toMatchObject({
       status: 403,
-      code: 'MY_VIDEOS_FAILED',
+      code: 'QUOTA_EXCEEDED',
+      reason: 'quotaExceeded',
     })
-    await expect(promise).rejects.toThrow(/quota/)
+    await expect(promise).rejects.toThrow(/사용량 한도/)
   })
 
   it('falls back to search when uploads playlist request fails for non-quota errors', async () => {

--- a/src/lib/youtube/stats.ts
+++ b/src/lib/youtube/stats.ts
@@ -43,16 +43,54 @@ function youtubeErrorFromBody(
   code: string,
 ): YouTubeError {
   const parsed = parseYouTubeErrorBody(body)
-  let message = fallbackMessage
+  const reason = parsed.reason
 
-  if (parsed.reason === 'quotaExceeded') {
-    message =
-      'YouTube API quota가 초과되어 내 영상을 불러올 수 없습니다. quota가 리셋된 뒤 다시 시도해주세요.'
-  } else if (parsed.message) {
-    message = fallbackMessage
+  if (reason === 'quotaExceeded' || reason === 'dailyLimitExceeded') {
+    return new YouTubeError(
+      status,
+      'YouTube API 사용량 한도를 초과했습니다. 잠시 후 다시 시도해 주세요.',
+      'QUOTA_EXCEEDED',
+      reason,
+    )
   }
 
-  return new YouTubeError(status, message, code)
+  if (reason === 'insufficientPermissions') {
+    return new YouTubeError(
+      status,
+      'YouTube 권한이 빠진 Google 토큰입니다. 설정에서 Google 계정으로 YouTube 연결을 다시 진행하고, 권한 동의 화면에서 YouTube 권한을 허용해 주세요.',
+      'YOUTUBE_RECONNECT_REQUIRED',
+      reason,
+    )
+  }
+
+  if (reason === 'authenticatedUserNotChannel') {
+    return new YouTubeError(
+      status,
+      '현재 Google 계정에 YouTube 채널이 없습니다. YouTube에서 채널을 만든 뒤 다시 연결해 주세요.',
+      'YOUTUBE_CHANNEL_REQUIRED',
+      reason,
+    )
+  }
+
+  if (reason === 'channelForbidden' || reason === 'forbidden') {
+    return new YouTubeError(
+      status,
+      '이 Google 계정으로는 해당 YouTube 채널을 사용할 수 없습니다. 채널 소유자 또는 관리자 계정으로 다시 연결해 주세요.',
+      'YOUTUBE_CHANNEL_FORBIDDEN',
+      reason,
+    )
+  }
+
+  if (reason === 'channelClosed' || reason === 'channelSuspended') {
+    return new YouTubeError(
+      status,
+      'YouTube 채널이 닫혔거나 정지되어 정보를 불러올 수 없습니다. YouTube Studio에서 채널 상태를 확인해 주세요.',
+      'YOUTUBE_CHANNEL_UNAVAILABLE',
+      reason,
+    )
+  }
+
+  return new YouTubeError(status, fallbackMessage, code, reason)
 }
 
 export async function fetchVideoStatistics(


### PR DESCRIPTION
Closes #328

## 원인
- 일반 로그인 콜백이 base scope 토큰을 YouTube 토큰 저장 칸에 저장해 기존 YouTube 권한 토큰을 일시적으로 밀어내던 흐름 정리
- `/auth/callback`에서 일반 로그인 직후 YouTube 채널 조회를 실행해 login-only 토큰으로 403을 만들던 흐름 제거
- YouTube API 403을 모두 같은 권한 부족 문구로 보여 주던 오류 매핑을 reason 기준으로 세분화

## 변경
- OAuth 콜백에 `scopeMode` 전달 및 서버 검증 추가
- Google 토큰 응답의 실제 `scope`를 확인해 YouTube 권한이 빠진 토큰은 저장하지 않도록 처리
- `insufficientPermissions`는 강제 refresh 후 1회 재시도하고, 실패하면 설정 화면에서 바로 재연결 안내 표시
- 채널 없음, 채널 권한 없음, 채널 정지/닫힘, quota 초과를 각각 다른 사용자 메시지로 분리

## 검증
- `npm test -- src/app/api/auth/auth-callback.test.ts src/lib/youtube/server.test.ts src/lib/youtube/route-helpers.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`