### PR TITLE
feat: 더빙 미리보기와 알림 정리

### DIFF
--- a/src/features/dubbing/components/SubtitleScriptEditor.tsx
+++ b/src/features/dubbing/components/SubtitleScriptEditor.tsx
@@ -19,6 +19,8 @@ import { getLanguageByCode, toBcp47 } from '@/utils/languages'
 import { useNotificationStore } from '@/stores/notificationStore'
 import {
   getProjectScript,
+  getDownloadLinks,
+  getPersoFileUrl,
   getTranslatedSrt,
   regenerateSentenceAudio,
   updateSentenceTranslation,
@@ -34,7 +36,6 @@ import {
 import type { ScriptSentence } from '@/lib/perso/types'
 import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
 import { cn } from '@/utils/cn'
-import type { PrivacyStatus } from '@/features/dubbing/types/dubbing.types'
 
 const ENABLE_SENTENCE_LEVEL_AUDIO_REGENERATION = false
 
@@ -82,11 +83,6 @@ function ScriptRow({
         sentence.editedTranslatedText,
       )
       onPatch(sentence.sentenceSeq, { savedTranslatedText: sentence.editedTranslatedText })
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.subtitleScriptEditor.saved'),
-        message: t('features.dubbing.components.subtitleScriptEditor.yourTranslationEditHasBeenSaved'),
-      })
       return true
     } catch {
       addToast({ type: 'error', title: t('features.dubbing.components.subtitleScriptEditor.saveFailed') })
@@ -105,11 +101,6 @@ function ScriptRow({
     setRegenerating(true)
     try {
       await regenerateSentenceAudio(projectSeq, sentence.audioSentenceSeq, sentence.editedTranslatedText)
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.subtitleScriptEditor.audioRegenerationStarted'),
-        message: t('features.dubbing.components.subtitleScriptEditor.theDubbedVideoWillUpdateWhenItFinishes'),
-      })
     } catch {
       addToast({ type: 'error', title: t('features.dubbing.components.subtitleScriptEditor.audioRegenerationFailed') })
     } finally {
@@ -171,6 +162,8 @@ function ScriptRow({
 interface EditableCue extends SrtCue {
   id: number
 }
+
+type PreviewVideoTarget = 'dubbingVideo' | 'originalVideo'
 
 function SrtRow({
   cue,
@@ -254,7 +247,7 @@ interface SubtitleScriptEditorProps {
   spaceSeq: number
   allowDialogueEditing?: boolean
   youtubeVideoId?: string | null
-  youtubePreviewVisibility?: PrivacyStatus
+  previewVideoTarget?: PreviewVideoTarget
   /** 자막 편집 시 화면에 노출할 영상의 직접 재생 URL.
    * - 원본+자막 모드: 원본 영상 URL (모든 언어 공유)
    * - 새 더빙 영상 모드: 해당 언어의 더빙 영상 URL */
@@ -267,7 +260,7 @@ export function SubtitleScriptEditor({
   spaceSeq,
   allowDialogueEditing = true,
   youtubeVideoId,
-  youtubePreviewVisibility,
+  previewVideoTarget = 'dubbingVideo',
   previewVideoUrl,
 }: SubtitleScriptEditorProps) {
   const locale = useAppLocale()
@@ -288,12 +281,43 @@ export function SubtitleScriptEditor({
   const [invalidCueIds, setInvalidCueIds] = useState<Set<number>>(() => new Set())
   const [srtLoading, setSrtLoading] = useState(false)
   const [showPreview, setShowPreview] = useState(false)
-  const [showYouTubePreview, setShowYouTubePreview] = useState(false)
+  const [resolvedPreviewVideoUrl, setResolvedPreviewVideoUrl] = useState<string | null>(null)
+  const [previewVideoLoading, setPreviewVideoLoading] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [pushingToYT, setPushingToYT] = useState(false)
   const [resetting, setResetting] = useState(false)
   const youtubeWatchUrl = youtubeVideoId ? `https://www.youtube.com/watch?v=${youtubeVideoId}` : null
-  const youtubeEmbedUrl = youtubeVideoId ? `https://www.youtube.com/embed/${youtubeVideoId}` : null
+  const effectivePreviewVideoUrl =
+    previewVideoUrl ?? (previewVideoTarget === 'dubbingVideo' ? resolvedPreviewVideoUrl : null)
+  const showPreviewVideoLoading =
+    previewVideoTarget === 'dubbingVideo' && !previewVideoUrl && previewVideoLoading
+
+  const loadPreviewVideo = useCallback(async () => {
+    if (previewVideoUrl || previewVideoTarget !== 'dubbingVideo') return
+
+    setResolvedPreviewVideoUrl(null)
+    setPreviewVideoLoading(true)
+    try {
+      let rawUrl: string | null | undefined
+      try {
+        const primary = await getDownloadLinks(projectSeq, spaceSeq, 'dubbingVideo')
+        rawUrl = primary.videoFile?.videoDownloadLink
+      } catch (err) {
+        console.warn('[Dubtube] Dubbed preview target fetch failed', err)
+      }
+      if (!rawUrl) {
+        const fallback = await getDownloadLinks(projectSeq, spaceSeq, 'all')
+        rawUrl = fallback.videoFile?.videoDownloadLink
+      }
+      if (rawUrl) {
+        setResolvedPreviewVideoUrl(rawUrl.startsWith('http') ? rawUrl : getPersoFileUrl(rawUrl))
+      }
+    } catch (err) {
+      console.warn('[Dubtube] Dubbed preview video fetch failed', err)
+    } finally {
+      setPreviewVideoLoading(false)
+    }
+  }, [previewVideoTarget, previewVideoUrl, projectSeq, spaceSeq])
 
   const loadScript = useCallback(async () => {
     if (!projectSeq) return
@@ -346,9 +370,23 @@ export function SubtitleScriptEditor({
     }
 
     setOpen(true)
+    if (!previewVideoUrl && previewVideoTarget === 'dubbingVideo' && !resolvedPreviewVideoUrl) {
+      loadPreviewVideo()
+    }
     if (allowDialogueEditing && !sentences) loadScript()
     if (!cues) loadSrt()
-  }, [open, allowDialogueEditing, sentences, cues, loadScript, loadSrt])
+  }, [
+    open,
+    previewVideoUrl,
+    previewVideoTarget,
+    resolvedPreviewVideoUrl,
+    loadPreviewVideo,
+    allowDialogueEditing,
+    sentences,
+    cues,
+    loadScript,
+    loadSrt,
+  ])
 
   const handleTabChange = useCallback((tab: EditorTab) => {
     if (tab === 'dialogue' && !allowDialogueEditing) return
@@ -427,11 +465,6 @@ export function SubtitleScriptEditor({
             : sentence,
         ) ?? null,
       )
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.subtitleScriptEditor.dialogueChangesApplied'),
-        message: t('features.dubbing.components.subtitleScriptEditor.dialogueChangesAppliedMessage', { languageName }),
-      })
     } catch (err) {
       addToast({
         type: 'error',
@@ -441,7 +474,7 @@ export function SubtitleScriptEditor({
     } finally {
       setApplyingDialogue(false)
     }
-  }, [sentences, projectSeq, addToast, t, languageName])
+  }, [sentences, projectSeq, addToast, t])
 
   const handleDiscardDialogueChanges = useCallback(() => {
     setSentences((prev) =>
@@ -456,14 +489,10 @@ export function SubtitleScriptEditor({
     setResetting(true)
     try {
       await loadSrt()
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.subtitleScriptEditor.captionsRestoredToTheGeneratedVersion'),
-      })
     } finally {
       setResetting(false)
     }
-  }, [loadSrt, addToast, t])
+  }, [loadSrt])
 
   const handleDownload = useCallback(() => {
     if (hasInvalidCaptionTiming) {
@@ -492,26 +521,6 @@ export function SubtitleScriptEditor({
       setDownloading(false)
     }
   }, [hasInvalidCaptionTiming, buildCurrentSrt, lang, langCode, addToast, t])
-
-  const handleToggleYouTubePreview = useCallback(() => {
-    const nextVisible = !showYouTubePreview
-    if (nextVisible && youtubePreviewVisibility === 'private') {
-      addToast({
-        type: 'warning',
-        title: t('features.dubbing.components.subtitleScriptEditor.youtubePreviewUnavailableForPrivateVideo'),
-        message: t('features.dubbing.components.subtitleScriptEditor.youtubePreviewPublicOrUnlistedOnly'),
-      })
-    }
-    setShowYouTubePreview(nextVisible)
-  }, [showYouTubePreview, youtubePreviewVisibility, addToast, t])
-
-  const handleYouTubePreviewError = useCallback(() => {
-    addToast({
-      type: 'warning',
-      title: t('features.dubbing.components.subtitleScriptEditor.youtubePreviewLoadFailed'),
-      message: t('features.dubbing.components.subtitleScriptEditor.youtubePreviewMayBeUnavailableForPrivateVideos'),
-    })
-  }, [addToast, t])
 
   const handlePushToYouTube = useCallback(async () => {
     if (!youtubeVideoId) return
@@ -616,7 +625,14 @@ export function SubtitleScriptEditor({
             </div>
           )}
 
-          {previewVideoUrl ? (
+          {showPreviewVideoLoading ? (
+            <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
+              <div className="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-300">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('features.dubbing.components.subtitleScriptEditor.videoPreview')}
+              </div>
+            </div>
+          ) : effectivePreviewVideoUrl ? (
             <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
               <div className="mb-3 flex min-w-0 items-start gap-2">
                 <Video className="mt-0.5 h-4 w-4 shrink-0 text-brand-600" />
@@ -625,7 +641,7 @@ export function SubtitleScriptEditor({
                 </p>
               </div>
               <div className="aspect-video w-full max-w-xl overflow-hidden rounded-lg border border-surface-200 bg-black dark:border-surface-700">
-                <video controls preload="metadata" className="h-full w-full" src={previewVideoUrl}>
+                <video controls preload="metadata" className="h-full w-full" src={effectivePreviewVideoUrl}>
                   <track kind="captions" />
                 </video>
               </div>
@@ -641,52 +657,7 @@ export function SubtitleScriptEditor({
                 </a>
               )}
             </div>
-          ) : youtubeVideoId && youtubeWatchUrl && youtubeEmbedUrl && (
-            <div className="rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-900/50">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 items-start gap-2">
-                  <Video className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-surface-900 dark:text-white">
-                      {t('features.dubbing.components.subtitleScriptEditor.youtubePreview')}
-                    </p>
-                    <p className="mt-0.5 text-xs text-surface-500 dark:text-surface-300">
-                      {t('features.dubbing.components.subtitleScriptEditor.youtubePreviewPublicOrUnlistedOnly')}
-                    </p>
-                  </div>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <a
-                    href={youtubeWatchUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border border-surface-300 bg-white px-3 text-sm font-medium text-surface-700 transition-all duration-200 hover:bg-surface-100 focus-ring dark:border-surface-700 dark:bg-transparent dark:text-surface-300 dark:hover:bg-surface-800"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                    {t('features.dubbing.components.subtitleScriptEditor.openInYouTube')}
-                  </a>
-                  <Button size="sm" variant="outline" onClick={handleToggleYouTubePreview}>
-                    {showYouTubePreview ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                    {showYouTubePreview
-                      ? t('features.dubbing.components.subtitleScriptEditor.hideYouTubePreview')
-                      : t('features.dubbing.components.subtitleScriptEditor.youtubePreview')}
-                  </Button>
-                </div>
-              </div>
-              {showYouTubePreview && (
-                <div className="mt-3 aspect-video w-full max-w-xl overflow-hidden rounded-lg border border-surface-200 bg-black dark:border-surface-700">
-                  <iframe
-                    title={t('features.dubbing.components.subtitleScriptEditor.youtubePreview')}
-                    src={youtubeEmbedUrl}
-                    className="h-full w-full"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    allowFullScreen
-                    onError={handleYouTubePreviewError}
-                  />
-                </div>
-              )}
-            </div>
-          )}
+          ) : null}
 
           {allowDialogueEditing && visibleTab === 'dialogue' && (
             <section className="space-y-3">

--- a/src/features/dubbing/components/YouTubeExtensionUpload.tsx
+++ b/src/features/dubbing/components/YouTubeExtensionUpload.tsx
@@ -164,11 +164,6 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl, a
           ...prev,
           [langCode]: { jobId: response.jobId!, status: 'running' },
         }))
-        addToast({
-          type: 'success',
-          title: t('features.dubbing.components.youTubeExtensionUpload.valueAudioTrackStarted', { getDisplayLanguageNameLangCode: getDisplayLanguageName(langCode) }),
-          message: t('features.dubbing.components.youTubeExtensionUpload.checkTheProgressInYouTubeStudio'),
-        })
       } else {
         if (response.error) {
           console.warn('[Dubtube] Extension upload request failed', response.error)
@@ -189,7 +184,7 @@ export function YouTubeExtensionUpload({ videoId, completedLangs, getAudioUrl, a
     } finally {
       setUploadingLang(null)
     }
-  }, [videoId, getAudioUrl, addToast, getDisplayLanguageName, t])
+  }, [videoId, getAudioUrl, addToast, t])
 
   // Auto-trigger: sequentially upload all languages without user clicking
   useEffect(() => {

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -274,11 +274,6 @@ export function UploadStep() {
         localizations: Object.keys(localizations).length > 0 ? localizations : undefined,
       })
       setOriginalUploadState({ status: 'done', videoId: result.videoId })
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.steps.uploadStep.originalVideoUploaded'),
-        message: t('features.dubbing.components.steps.uploadStep.youCanReviewTheVideoOnYouTube'),
-      })
       return result.videoId
     } catch (err) {
       console.warn('[Dubtube] Original video upload failed', err)
@@ -378,11 +373,6 @@ export function UploadStep() {
         throw new Error(result.status || t('features.dubbing.components.steps.uploadStep.couldNotScheduleTheYouTubeUploadPleaseTry'))
       }
 
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.components.steps.uploadStep.valueUploadScheduled', { getDisplayLanguageNameLangCode: getDisplayLanguageName(langCode) }),
-        message: t('features.dubbing.components.steps.uploadStep.theServerWillUploadItInTheBackground'),
-      })
     } catch (err) {
       console.warn('[Dubtube] YouTube upload scheduling failed', err)
       const msg = t('features.dubbing.components.steps.uploadStep.couldNotScheduleTheYouTubeUploadPleaseTry')
@@ -448,7 +438,6 @@ export function UploadStep() {
           srtContent,
         })
         setCaptionUploads((prev) => ({ ...prev, [langCode]: 'done' }))
-        addToast({ type: 'success', title: t('features.dubbing.components.steps.uploadStep.valueCaptionsUploaded', { getDisplayLanguageNameLangCode: getDisplayLanguageName(langCode) }) })
       } catch (err) {
         console.warn('[Dubtube] Caption upload failed', err)
         setCaptionUploads((prev) => ({ ...prev, [langCode]: 'error' }))
@@ -1010,7 +999,7 @@ export function UploadStep() {
                   spaceSeq={spaceSeq}
                   allowDialogueEditing={allowDialogueEditingInOutput}
                   youtubeVideoId={ytUploads[code]?.videoId ?? null}
-                  youtubePreviewVisibility={privacyStatus}
+                  previewVideoTarget={deliverableMode === 'originalWithMultiAudio' ? 'originalVideo' : 'dubbingVideo'}
                   previewVideoUrl={previewVideoUrl}
                 />
               )

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -4,9 +4,8 @@ import { useCallback, useRef } from 'react'
 import { useDubbingStore } from '../store/dubbingStore'
 import { useNotificationStore } from '@/stores/notificationStore'
 import { useAuthStore } from '@/stores/authStore'
-import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
+import { useLocaleText } from '@/hooks/useLocaleText'
 
-import type { AppLocale } from '@/lib/i18n/config'
 import {
   getSpaces,
   uploadVideoFile as persoUploadVideoFile,
@@ -31,11 +30,6 @@ const POLL_FINALIZING = 2_000     // 100%인데 COMPLETED 아직 안 온 경우 
 const DEFAULT_SOURCE_LANGUAGE = 'auto'
 const DEFAULT_SPEAKER_COUNT = 1
 type LocaleText = ReturnType<typeof useLocaleText>
-
-function countLocaleMessage(locale: AppLocale, count: number, key: string, t: LocaleText): string {
-  const unit = t(key)
-  return locale === 'ko' ? `${count}${unit}` : `${count} ${unit}`
-}
 
 function mapProgressReasonToStatus(reason: string) {
   switch (reason) {
@@ -258,7 +252,6 @@ async function cancelAllProjects(
 
 export function usePersoFlow() {
   const addToast = useNotificationStore((s) => s.addToast)
-  const locale = useAppLocale()
   const t = useLocaleText()
   const pollTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
 
@@ -282,8 +275,6 @@ export function usePersoFlow() {
     let spaceSeq = store.getState().spaceSeq
     if (!spaceSeq) spaceSeq = await initSpace()
 
-    addToast({ type: 'info', title: t('features.dubbing.hooks.usePersoFlow.uploadingVideo'), message: file.name })
-
     try {
       const result = await persoUploadVideoFile(spaceSeq!, file)
       store.getState().setMediaSeq(result.seq)
@@ -298,11 +289,6 @@ export function usePersoFlow() {
         durationMs: result.durationMs,
         channelTitle: t('features.dubbing.hooks.usePersoFlow.uploadedFile'),
       })
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.hooks.usePersoFlow.videoUploaded'),
-        message: t('features.dubbing.hooks.usePersoFlow.valueIsReadyForDubbing', { fileName: file.name }),
-      })
       return result
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : t('features.dubbing.hooks.usePersoFlow.uploadFailed')
@@ -316,13 +302,6 @@ export function usePersoFlow() {
     if (!spaceSeq) spaceSeq = await initSpace()
 
     const isYouTube = /(?:youtube\.com|youtu\.be)/.test(url)
-    addToast({
-      type: 'info',
-      title: isYouTube
-        ? t('features.dubbing.hooks.usePersoFlow.importingFromYouTube')
-        : t('features.dubbing.hooks.usePersoFlow.importingVideoURL'),
-      duration: 8000,
-    })
 
     try {
       const meta = await getExternalMetadata(spaceSeq!, url, DEFAULT_SOURCE_LANGUAGE)
@@ -339,8 +318,10 @@ export function usePersoFlow() {
 
       const result = await uploadExternalVideo(spaceSeq!, url, DEFAULT_SOURCE_LANGUAGE)
       store.getState().setMediaSeq(result.seq)
+      if (result.videoFilePath) {
+        store.getState().setOriginalVideoUrl(getPersoFileUrl(result.videoFilePath))
+      }
 
-      addToast({ type: 'success', title: t('features.dubbing.hooks.usePersoFlow.videoImported') })
       return result
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : t('features.dubbing.hooks.usePersoFlow.failedToImportVideo')
@@ -355,12 +336,6 @@ export function usePersoFlow() {
       throw new Error(t('features.dubbing.hooks.usePersoFlow.missingVideoInformationPleaseStartAgain'))
     }
     const targetLanguages = Array.from(new Set(selectedLanguages))
-
-    addToast({
-      type: 'info',
-      title: t('features.dubbing.hooks.usePersoFlow.startingDubbingJob'),
-      message: countLocaleMessage(locale, targetLanguages.length, 'features.dubbing.hooks.usePersoFlow.unitLanguages', t),
-    })
 
     try {
       try {
@@ -420,11 +395,6 @@ export function usePersoFlow() {
         },
       })
 
-      addToast({
-        type: 'success',
-        title: t('features.dubbing.hooks.usePersoFlow.dubbingStarted'),
-        message: countLocaleMessage(locale, projectIds.length, 'features.dubbing.hooks.usePersoFlow.unitLanguagesProcessing', t),
-      })
       return projectMap
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : t('features.dubbing.hooks.usePersoFlow.failedToStartDubbing')
@@ -437,7 +407,7 @@ export function usePersoFlow() {
       store.getState().setJobStatus('failed')
       throw err
     }
-  }, [addToast, locale, t])
+  }, [addToast, t])
 
   const startPolling = useCallback(() => {
     const { spaceSeq, projectMap } = store.getState()


### PR DESCRIPTION
## 변경 내용
- 더빙 플로우에서 진행/완료 상태를 중복으로 알리는 토스트를 제거
- 자막·대사 편집기의 YouTube iframe 미리보기 fallback을 제거
- 새 더빙 영상 모드에서는 Perso 더빙 영상 링크를 조회하고, 원본 자막 업로드 모드에서는 원본 영상 URL만 사용하도록 분기
- YouTube URL/채널에서 가져온 원본도 Perso 업로드 결과 URL을 저장하도록 보완

## 영향
- 사용자는 화면 상태로 이미 확인 가능한 업로드/저장/예약 알림을 덜 보게 됨
- YouTube 조회가 실패하거나 비공개 영상인 경우에도 새 더빙 영상 미리보기가 YouTube에 의존하지 않음

## 검증
- npm run typecheck
- npm run lint
- npm test