### PR TITLE
fix: 더빙 음성 모델 호환성 정리

### DIFF
--- a/src/app/api/perso/translate/route.ts
+++ b/src/app/api/perso/translate/route.ts
@@ -7,6 +7,7 @@ import { translateBodySchema } from '@/lib/validators/perso'
 import type { TranslateResponse } from '@/lib/perso/types'
 import { assertPersoMediaOwner } from '@/lib/perso/ownership'
 import { logger } from '@/lib/logger'
+import { DEFAULT_TTS_MODEL } from '@/lib/perso/tts-model'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -43,7 +44,7 @@ export async function POST(req: NextRequest) {
       numberOfSpeakers: body.numberOfSpeakers,
       withLipSync: body.withLipSync ?? false,
       preferredSpeedType: body.preferredSpeedType,
-      ttsModel: body.ttsModel ?? 'ELEVEN_V2',
+      ttsModel: body.ttsModel ?? DEFAULT_TTS_MODEL,
       title,
       ...(customDictionaryBlobPath ? { customDictionaryBlobPath } : {}),
       ...(srtBlobPath ? { srtBlobPath } : {}),

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -8,6 +8,7 @@ import { useLocaleText } from '@/hooks/useLocaleText'
 
 import {
   getSpaces,
+  getLanguages,
   uploadVideoFile as persoUploadVideoFile,
   getExternalMetadata,
   uploadExternalVideo,
@@ -18,7 +19,12 @@ import {
   getPersoFileUrl,
   cancelProject,
 } from '@/lib/api-client'
-import type { DownloadTarget } from '@/lib/perso/types'
+import type { DownloadTarget, PersoTtsModel } from '@/lib/perso/types'
+import {
+  BROADEST_TTS_MODEL,
+  DEFAULT_TTS_MODEL,
+  resolveTtsModelForTargetLanguages,
+} from '@/lib/perso/tts-model'
 import type { LanguageProgress } from '../types/dubbing.types'
 import { dbMutation, dbMutationStrict } from '@/lib/api/dbMutation'
 import { extractVideoId } from '@/utils/validators'
@@ -64,6 +70,31 @@ function mapProgressReasonToStatus(reason: string) {
 }
 
 const store = useDubbingStore
+
+async function resolveSubmitTtsModel(
+  targetLanguages: string[],
+  t: LocaleText,
+): Promise<PersoTtsModel> {
+  const unsupportedMessage = t('features.dubbing.hooks.usePersoFlow.unsupportedTtsModelPair')
+  try {
+    const languages = await getLanguages()
+    const model = resolveTtsModelForTargetLanguages(
+      languages,
+      targetLanguages,
+      DEFAULT_TTS_MODEL,
+    )
+    if (!model) {
+      throw new Error(unsupportedMessage)
+    }
+    return model
+  } catch (err) {
+    if (err instanceof Error && err.message === unsupportedMessage) {
+      throw err
+    }
+    console.warn('[Dubtube] TTS model compatibility lookup failed; using broadest model', err)
+    return BROADEST_TTS_MODEL
+  }
+}
 
 async function saveJobToDb(
   mediaSeq: number,
@@ -338,6 +369,8 @@ export function usePersoFlow() {
     const targetLanguages = Array.from(new Set(selectedLanguages))
 
     try {
+      const ttsModel = await resolveSubmitTtsModel(targetLanguages, t)
+
       try {
         await initializeQueue(spaceSeq)
       } catch {
@@ -364,7 +397,7 @@ export function usePersoFlow() {
         numberOfSpeakers: DEFAULT_SPEAKER_COUNT,
         withLipSync: lipSyncEnabled,
         preferredSpeedType: 'GREEN',
-        ttsModel: 'ELEVEN_V2',
+        ttsModel,
         title: videoMeta?.title?.trim() || `Dubtube project ${mediaSeq}`,
       })
 

--- a/src/lib/i18n/client-messages/dubbing.ts
+++ b/src/lib/i18n/client-messages/dubbing.ts
@@ -372,6 +372,7 @@ export const dubbingMessages = {
   "features.dubbing.hooks.usePersoFlow.startingDubbingJob": { ko: "더빙 작업을 시작하는 중...", en: "Starting dubbing job..." },
   "features.dubbing.hooks.usePersoFlow.unitLanguages": { ko: "개 언어", en: "languages" },
   "features.dubbing.hooks.usePersoFlow.unitLanguagesProcessing": { ko: "개 언어 처리 중", en: "languages processing" },
+  "features.dubbing.hooks.usePersoFlow.unsupportedTtsModelPair": { ko: "선택한 언어 조합에서 사용할 수 있는 음성 모델이 없습니다. 언어 선택을 줄이거나 다시 시도해 주세요.", en: "No voice model is available for the selected language combination. Choose fewer languages or try again." },
   "features.dubbing.hooks.usePersoFlow.uploadedFile": { ko: "직접 업로드한 파일", en: "Uploaded file" },
   "features.dubbing.hooks.usePersoFlow.uploadFailed": { ko: "업로드하지 못했습니다.", en: "Upload failed." },
   "features.dubbing.hooks.usePersoFlow.uploadFailed2": { ko: "업로드 실패", en: "Upload failed" },

--- a/src/lib/i18n/generatedMessages.ts
+++ b/src/lib/i18n/generatedMessages.ts
@@ -558,6 +558,7 @@ export const generatedMessages = {
   "features.dubbing.hooks.usePersoFlow.failedToImportVideo": { ko: "영상을 가져오지 못했습니다.", en: "Failed to import video." },
   "features.dubbing.hooks.usePersoFlow.failedToLoadWorkspace": { ko: "작업 공간을 불러오지 못했습니다.", en: "Failed to load workspace." },
   "features.dubbing.hooks.usePersoFlow.failedToStartDubbing": { ko: "더빙 작업을 시작하지 못했습니다.", en: "Failed to start dubbing." },
+  "features.dubbing.hooks.usePersoFlow.unsupportedTtsModelPair": { ko: "선택한 언어 조합에서 사용할 수 있는 음성 모델이 없습니다. 언어 선택을 줄이거나 다시 시도해 주세요.", en: "No voice model is available for the selected language combination. Choose fewer languages or try again." },
   "features.dubbing.hooks.usePersoFlow.importFailed": { ko: "영상 가져오기 실패", en: "Import failed" },
   "features.dubbing.hooks.usePersoFlow.importingFromYouTube": { ko: "YouTube에서 영상을 가져오는 중...", en: "Importing from YouTube..." },
   "features.dubbing.hooks.usePersoFlow.importingVideoURL": { ko: "영상 URL을 가져오는 중...", en: "Importing video URL..." },

--- a/src/lib/perso/errors.ts
+++ b/src/lib/perso/errors.ts
@@ -36,6 +36,9 @@ export const ERROR_MAP: Record<string, { status: number; message: string }> = {
   VT4043: { status: 404, message: '지원하지 않는 원본 언어입니다.' },
   VT4044: { status: 404, message: '지원하지 않는 대상 언어입니다.' },
 
+  VT4009: { status: 400, message: '선택한 언어와 음성 모델 조합이 지원되지 않습니다. 언어 선택을 줄이거나 다시 시도해 주세요.' },
+  UNSUPPORTED_TTS_MODEL_PAIR: { status: 400, message: '선택한 언어와 음성 모델 조합이 지원되지 않습니다. 언어 선택을 줄이거나 다시 시도해 주세요.' },
+
   // Queue / temporary
   VT5034: { status: 503, message: '잠시 후 다시 시도해 주세요. 현재 작업량이 많습니다.' },
   TIMEOUT: { status: 504, message: '외부 처리 서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.' },

--- a/src/lib/perso/tts-model.test.ts
+++ b/src/lib/perso/tts-model.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTtsModelForTargetLanguages } from './tts-model'
+import type { PersoLanguage } from './types'
+
+const languages: PersoLanguage[] = [
+  { code: 'en', name: 'English', experiment: false, supportedTtsModels: ['ELEVEN_V3', 'ELEVEN_V2'] },
+  { code: 'ko', name: 'Korean', experiment: true, supportedTtsModels: ['ELEVEN_V3', 'ELEVEN_V2'] },
+  { code: 'ja', name: 'Japanese', experiment: false, supportedTtsModels: ['ELEVEN_V3'] },
+  { code: 'auto', name: 'Auto', experiment: false, supportedTtsModels: [] },
+]
+
+describe('resolveTtsModelForTargetLanguages', () => {
+  it('keeps ELEVEN_V2 when every target language supports it', () => {
+    expect(resolveTtsModelForTargetLanguages(languages, ['en', 'ko'])).toBe('ELEVEN_V2')
+  })
+
+  it('uses ELEVEN_V3 when at least one target language is V3-only', () => {
+    expect(resolveTtsModelForTargetLanguages(languages, ['en', 'ko', 'ja'])).toBe('ELEVEN_V3')
+  })
+
+  it('returns null when no common model is supported', () => {
+    expect(resolveTtsModelForTargetLanguages(languages, ['auto'])).toBeNull()
+  })
+
+  it('does not reject older language responses that omit supportedTtsModels', () => {
+    expect(resolveTtsModelForTargetLanguages([{ code: 'en', name: 'English', experiment: false }], ['en'])).toBe('ELEVEN_V2')
+  })
+})

--- a/src/lib/perso/tts-model.ts
+++ b/src/lib/perso/tts-model.ts
@@ -1,0 +1,34 @@
+import type { PersoLanguage, PersoTtsModel } from '@/lib/perso/types'
+
+export const DEFAULT_TTS_MODEL: PersoTtsModel = 'ELEVEN_V2'
+export const BROADEST_TTS_MODEL: PersoTtsModel = 'ELEVEN_V3'
+
+const PREFERRED_TTS_MODELS: readonly PersoTtsModel[] = [
+  DEFAULT_TTS_MODEL,
+  BROADEST_TTS_MODEL,
+]
+
+function uniqueModels(preferred: PersoTtsModel): PersoTtsModel[] {
+  return [preferred, ...PREFERRED_TTS_MODELS.filter((model) => model !== preferred)]
+}
+
+function isModelSupported(language: PersoLanguage | undefined, model: PersoTtsModel): boolean {
+  if (!language) return false
+  if (!Array.isArray(language.supportedTtsModels)) return true
+  if (language.supportedTtsModels.length === 0) return false
+  return language.supportedTtsModels.includes(model)
+}
+
+export function resolveTtsModelForTargetLanguages(
+  languages: PersoLanguage[],
+  targetLanguageCodes: string[],
+  preferred: PersoTtsModel = DEFAULT_TTS_MODEL,
+): PersoTtsModel | null {
+  const targets = Array.from(new Set(targetLanguageCodes.map((code) => code.trim()).filter(Boolean)))
+  if (targets.length === 0) return preferred
+
+  const languagesByCode = new Map(languages.map((language) => [language.code, language]))
+  return uniqueModels(preferred).find((model) =>
+    targets.every((code) => isModelSupported(languagesByCode.get(code), model)),
+  ) ?? null
+}

--- a/src/lib/perso/types.ts
+++ b/src/lib/perso/types.ts
@@ -54,6 +54,8 @@ export interface MediaValidateRequest {
   thumbnailFilePath?: string | null
 }
 
+export type PersoTtsModel = 'ELEVEN_V2' | 'ELEVEN_V3'
+
 export interface TranslateRequest {
   mediaSeq: number
   isVideoProject: boolean
@@ -64,7 +66,7 @@ export interface TranslateRequest {
   preferredSpeedType: 'GREEN' | 'RED'
   customDictionaryBlobPath?: string
   srtBlobPath?: string
-  ttsModel?: 'ELEVEN_V2' | 'ELEVEN_V3'
+  ttsModel?: PersoTtsModel
   title?: string
 }
 
@@ -183,4 +185,5 @@ export interface PersoLanguage {
   code: string
   name: string
   experiment: boolean
+  supportedTtsModels?: PersoTtsModel[]
 }


### PR DESCRIPTION
## 변경 내용
- Perso 언어 목록의 supportedTtsModels 기준으로 더빙 요청 TTS 모델을 자동 선택
- 모든 대상 언어가 ELEVEN_V2를 지원하면 기존처럼 ELEVEN_V2 사용
- 일본어처럼 ELEVEN_V3만 지원하는 언어가 포함되면 ELEVEN_V3로 전환
- VT4009와 내부 호환성 오류 메시지를 명확한 사용자 안내로 매핑
- TTS 모델 선택 유틸과 테스트 추가

## 원인
Perso가 일본어 대상 언어와 ELEVEN_V2 조합을 지원하지 않아 `VT4009 Target language and TTS model pair is not supported`를 반환했지만, 앱은 ELEVEN_V2를 고정으로 보내고 있었습니다.

## 검증
- npm run typecheck
- npm run lint
- npm test