### PR TITLE
feat: YouTube 원문 메타데이터 보존 정리

### DIFF
--- a/src/app/api/youtube/metadata/route.ts
+++ b/src/app/api/youtube/metadata/route.ts
@@ -21,8 +21,12 @@ export async function GET(req: NextRequest) {
 
   return ytHandle(async () => {
     const url = new URL(req.url)
-    const { videoId } = parseQuery(url, metadataQuerySchema)
-    return withTokenRetry(req, (accessToken) => fetchVideoMetadata(accessToken, videoId))
+    const { videoId, sourceLang } = parseQuery(url, metadataQuerySchema)
+    return withTokenRetry(req, (accessToken) =>
+      sourceLang
+        ? fetchVideoMetadata(accessToken, videoId, sourceLang)
+        : fetchVideoMetadata(accessToken, videoId),
+    )
   })
 }
 

--- a/src/app/api/youtube/youtube-routes.test.ts
+++ b/src/app/api/youtube/youtube-routes.test.ts
@@ -263,6 +263,18 @@ describe('/api/youtube/metadata', () => {
     expect(fetchVideoMetadata).toHaveBeenCalledWith('mock-token', 'yt-123')
   })
 
+  it('passes requested source language when fetching metadata', async () => {
+    const { GET } = await import('./metadata/route')
+    const { fetchVideoMetadata } = await import('@/lib/youtube/server')
+    const req = new NextRequest('http://localhost/api/youtube/metadata?videoId=yt-123&sourceLang=ko')
+
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.ok).toBe(true)
+    expect(fetchVideoMetadata).toHaveBeenCalledWith('mock-token', 'yt-123', 'ko')
+  })
+
   it('updates localizations without uploading media', async () => {
     const { POST } = await import('./metadata/route')
     const { updateVideoLocalizations } = await import('@/lib/youtube/server')

--- a/src/features/dubbing/components/steps/UploadStep.tsx
+++ b/src/features/dubbing/components/steps/UploadStep.tsx
@@ -195,7 +195,8 @@ export function UploadStep() {
     existingVideoMetadataSyncRef.current.add(syncKey)
 
     try {
-      const metadata = await ytFetchVideoMetadata(targetVideoId)
+      const requestedSourceLang = toBcp47(metadataLanguage)
+      const metadata = await ytFetchVideoMetadata(targetVideoId, requestedSourceLang)
       const mergedTags = requestedTags.length === 0
         ? metadata.tags
         : Array.from(new Set([...metadata.tags, ...requestedTags]))
@@ -213,7 +214,7 @@ export function UploadStep() {
       // 원본 제목/설명은 그대로 유지 — localizations와 tags만 갱신.
       await ytUpdateVideoLocalizations({
         videoId: targetVideoId,
-        sourceLang: metadata.defaultLanguage || toBcp47(metadataLanguage),
+        sourceLang: metadata.resolvedLanguage || metadata.defaultLanguage || requestedSourceLang,
         title: metadata.title || settingsTitle?.trim() || videoMetaTitle || t('features.dubbing.components.steps.uploadStep.untitled'),
         description: metadata.description,
         tags: mergedTags,

--- a/src/features/metadata/components/MetadataLocalizationTool.tsx
+++ b/src/features/metadata/components/MetadataLocalizationTool.tsx
@@ -190,14 +190,18 @@ export function MetadataLocalizationTool() {
     if (!videoId) return
     setLoadingMetadata(true)
     try {
-      const metadata = await ytFetchVideoMetadata(videoId)
+      const requestedSourceLang = toBcp47(sourceLang || defaultLanguage)
+      const metadata = await ytFetchVideoMetadata(videoId, requestedSourceLang)
       setTitle(metadata.title)
       setDescription(metadata.description)
       // YouTube에 defaultLanguage가 명시되어 있지 않으면 빈 문자열이 옴 — 사용자 설정 기본값으로 fallback.
       const ytDefaultLang = metadata.defaultLanguage?.trim() ?? ''
-      const nextSourceLang = ytDefaultLang ? fromBcp47(ytDefaultLang) : defaultLanguage
+      const ytResolvedLang = metadata.resolvedLanguage?.trim() ?? ''
+      const nextSourceLang = ytResolvedLang
+        ? fromBcp47(ytResolvedLang)
+        : ytDefaultLang ? fromBcp47(ytDefaultLang) : defaultLanguage
       setSourceLang(nextSourceLang)
-      if (!ytDefaultLang) {
+      if (!ytDefaultLang && !ytResolvedLang) {
         addToast({
           type: 'warning',
         title: t('features.metadata.components.metadataLocalizationTool.theSourceLanguageIsNotSetOnYouTube'),

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -30,6 +30,7 @@ import {
   ytFetchVideoStats,
   ytFetchChannelStats,
   ytFetchMyVideos,
+  ytFetchVideoMetadata,
   ytUpdateVideoLocalizations,
 } from './api-client'
 
@@ -442,6 +443,15 @@ describe('ytUpdateVideoLocalizations', () => {
 })
 
 // ── uploadFileToBlob (XHR) ─────────────────────────────────
+
+describe('ytFetchVideoMetadata', () => {
+  it('passes the requested source language to the metadata API', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ videoId: 'v1' }))
+    await ytFetchVideoMetadata('v1', 'ko')
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/youtube/metadata?videoId=v1&sourceLang=ko')
+  })
+})
 
 describe('uploadFileToBlob', () => {
   let xhrInstances: Array<Record<string, unknown>>

--- a/src/lib/api-client/youtube.ts
+++ b/src/lib/api-client/youtube.ts
@@ -139,8 +139,9 @@ export async function ytFetchMyVideos(
   return json(res)
 }
 
-export async function ytFetchVideoMetadata(videoId: string): Promise<YouTubeVideoMetadata> {
+export async function ytFetchVideoMetadata(videoId: string, sourceLang?: string): Promise<YouTubeVideoMetadata> {
   const params = new URLSearchParams({ videoId })
+  if (sourceLang) params.set('sourceLang', sourceLang)
   const res = await fetch(`${YT}/metadata?${params}`, { cache: 'no-store' })
   return json(res)
 }

--- a/src/lib/validators/youtube.ts
+++ b/src/lib/validators/youtube.ts
@@ -42,6 +42,7 @@ export const videosQuerySchema = z.object({
 
 export const metadataQuerySchema = z.object({
   videoId: z.string().min(1),
+  sourceLang: z.string().min(1).optional(),
 })
 
 export const metadataUpdateBodySchema = z.object({

--- a/src/lib/youtube/metadata.test.ts
+++ b/src/lib/youtube/metadata.test.ts
@@ -7,7 +7,7 @@ describe('youtube metadata', () => {
   })
 
   it('fetches snippet and existing localizations', async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn<typeof fetch>(async () =>
       Response.json({
         items: [
           {
@@ -35,10 +35,43 @@ describe('youtube metadata', () => {
       categoryId: '22',
       tags: ['a'],
       defaultLanguage: 'ko',
+      resolvedLanguage: 'ko',
+      resolvedFrom: 'default',
       localizations: {
         en: { title: 'Title', description: 'Description' },
       },
     })
+  })
+
+  it('prefers the requested source localization when the default snippet is another language', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        items: [
+          {
+            id: 'v1',
+            snippet: {
+              title: 'English title',
+              description: 'English description',
+              categoryId: '22',
+              defaultLanguage: 'en',
+            },
+            localizations: {
+              ko: { title: 'Korean title', description: 'Korean description' },
+            },
+          },
+        ],
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchVideoMetadata('token', 'v1', 'ko')).resolves.toMatchObject({
+      title: 'Korean title',
+      description: 'Korean description',
+      defaultLanguage: 'en',
+      resolvedLanguage: 'ko',
+      resolvedFrom: 'localization',
+    })
+    expect(String(fetchMock.mock.calls[0][0])).toContain('hl=ko')
   })
 
   it('merges localizations and preserves required snippet fields on update', async () => {
@@ -109,6 +142,64 @@ describe('youtube metadata', () => {
       },
     })
     expect(result.localizations.en.title).toBe('Updated')
+  })
+
+  it('keeps the selected source language in the default snippet and omits it from localizations', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          items: [
+            {
+              id: 'v1',
+              snippet: {
+                title: 'English title',
+                description: 'English description',
+                categoryId: '22',
+                defaultLanguage: 'en',
+              },
+              localizations: {
+                ko: { title: 'Korean title', description: 'Korean description' },
+                ja: { title: 'Japanese title', description: 'Japanese description' },
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          id: 'v1',
+          snippet: {
+            title: 'Korean title',
+            description: 'Korean description',
+            categoryId: '22',
+            defaultLanguage: 'ko',
+          },
+          localizations: {
+            en: { title: 'English title', description: 'English description' },
+            ja: { title: 'Japanese title', description: 'Japanese description' },
+          },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateVideoLocalizations({
+      accessToken: 'token',
+      videoId: 'v1',
+      sourceLang: 'ko',
+      title: 'Korean title',
+      description: 'Korean description',
+      localizations: {
+        ko: { title: 'Korean title', description: 'Korean description' },
+        en: { title: 'English title', description: 'English description' },
+      },
+    })
+
+    const updateBody = JSON.parse(fetchMock.mock.calls[1][1].body as string)
+    expect(updateBody.snippet.defaultLanguage).toBe('ko')
+    expect(updateBody.snippet.title).toBe('Korean title')
+    expect(updateBody.localizations.ko).toBeUndefined()
+    expect(updateBody.localizations.en.title).toBe('English title')
   })
 
   it('updates tags when provided', async () => {

--- a/src/lib/youtube/metadata.ts
+++ b/src/lib/youtube/metadata.ts
@@ -13,8 +13,50 @@ interface YouTubeVideoResource {
     categoryId?: string
     tags?: string[]
     defaultLanguage?: string
+    localized?: YouTubeLocalization
   }
   localizations?: Record<string, YouTubeLocalization>
+}
+
+function normalizeLanguageTag(language?: string | null) {
+  return language?.trim().toLowerCase() || ''
+}
+
+function baseLanguage(language: string) {
+  return normalizeLanguageTag(language).split('-')[0] || ''
+}
+
+function isSameLanguage(left?: string | null, right?: string | null) {
+  const a = normalizeLanguageTag(left)
+  const b = normalizeLanguageTag(right)
+  if (!a || !b) return false
+  return a === b || baseLanguage(a) === baseLanguage(b)
+}
+
+function findLocalization(
+  localizations: Record<string, YouTubeLocalization>,
+  language?: string,
+) {
+  const target = normalizeLanguageTag(language)
+  if (!target) return null
+
+  const exact = Object.entries(localizations).find(([code]) => normalizeLanguageTag(code) === target)
+  if (exact) return { code: exact[0], value: exact[1] }
+
+  const targetBase = baseLanguage(target)
+  if (!targetBase) return null
+
+  const baseMatch = Object.entries(localizations).find(([code]) => baseLanguage(code) === targetBase)
+  return baseMatch ? { code: baseMatch[0], value: baseMatch[1] } : null
+}
+
+function omitLanguage(
+  localizations: Record<string, YouTubeLocalization>,
+  language: string,
+) {
+  return Object.fromEntries(
+    Object.entries(localizations).filter(([code]) => !isSameLanguage(code, language)),
+  )
 }
 
 function normalizeLocalizationMap(
@@ -37,9 +79,16 @@ function normalizeLocalizationMap(
 export async function fetchVideoMetadata(
   accessToken: string,
   videoId: string,
+  preferredLanguage?: string,
 ): Promise<YouTubeVideoMetadata> {
+  const params = new URLSearchParams({
+    part: 'snippet,localizations',
+    id: videoId,
+  })
+  if (preferredLanguage) params.set('hl', preferredLanguage)
+
   const res = await fetch(
-    `${YOUTUBE_DATA_BASE}/videos?part=snippet,localizations&id=${encodeURIComponent(videoId)}`,
+    `${YOUTUBE_DATA_BASE}/videos?${params}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   )
   if (!res.ok) {
@@ -57,16 +106,25 @@ export async function fetchVideoMetadata(
     throw new YouTubeError(404, 'YouTube video not found', 'VIDEO_NOT_FOUND')
   }
 
+  const localizations = normalizeLocalizationMap(item.localizations)
+  const defaultLanguage = item.snippet.defaultLanguage || ''
+  const preferredLocalization = !isSameLanguage(defaultLanguage, preferredLanguage)
+    ? findLocalization(localizations, preferredLanguage)
+    : null
+  const resolvedLanguage = preferredLocalization?.code || defaultLanguage
+
   return {
     videoId: item.id,
-    title: item.snippet.title || '',
-    description: item.snippet.description || '',
+    title: preferredLocalization?.value.title || item.snippet.title || '',
+    description: preferredLocalization?.value.description ?? item.snippet.description ?? '',
     categoryId: item.snippet.categoryId || '22',
     tags: item.snippet.tags || [],
     // YouTube가 defaultLanguage를 비워두면 빈 문자열로 전달 — 클라이언트에서 사용자 기본값으로 fallback.
     // 'ko' 같은 임의 값을 박으면 영문 영상의 원문 언어가 한국어로 잘못 잡혀 picker 비활성화 로직이 망가진다.
-    defaultLanguage: item.snippet.defaultLanguage || '',
-    localizations: normalizeLocalizationMap(item.localizations),
+    defaultLanguage,
+    resolvedLanguage,
+    resolvedFrom: preferredLocalization ? 'localization' : 'default',
+    localizations,
   }
 }
 
@@ -79,13 +137,13 @@ export async function updateVideoLocalizations(input: {
   tags?: string[]
   localizations: Record<string, YouTubeLocalization>
 }): Promise<YouTubeVideoMetadata> {
-  const current = await fetchVideoMetadata(input.accessToken, input.videoId)
-  const mergedLocalizations = {
+  const defaultLanguage = input.sourceLang || 'ko'
+  const current = await fetchVideoMetadata(input.accessToken, input.videoId, defaultLanguage)
+  const mergedLocalizations = omitLanguage({
     ...current.localizations,
     ...normalizeLocalizationMap(input.localizations),
-  }
+  }, defaultLanguage)
 
-  const defaultLanguage = input.sourceLang || current.defaultLanguage || 'ko'
   const body = {
     id: input.videoId,
     snippet: {
@@ -125,6 +183,8 @@ export async function updateVideoLocalizations(input: {
     categoryId: snippet.categoryId || body.snippet.categoryId,
     tags: snippet.tags || body.snippet.tags,
     defaultLanguage: snippet.defaultLanguage || defaultLanguage,
+    resolvedLanguage: snippet.defaultLanguage || defaultLanguage,
+    resolvedFrom: 'default',
     localizations: normalizeLocalizationMap(data.localizations ?? mergedLocalizations),
   }
 }

--- a/src/lib/youtube/server.test.ts
+++ b/src/lib/youtube/server.test.ts
@@ -440,6 +440,38 @@ describe('uploadVideoToYouTube', () => {
     })
   })
 
+  it('keeps source metadata in snippet and excludes the source language from localizations', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({}, 200, { Location: 'https://upload.example.com/resume' }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ id: 'yt-abc', snippet: { title: 'Korean title' }, status: { uploadStatus: 'uploaded' } }),
+      )
+
+    await uploadVideoToYouTube({
+      accessToken: 'tok',
+      videoBlob: new Blob(['video'], { type: 'video/mp4' }),
+      title: 'Korean title',
+      description: 'Korean description',
+      tags: [],
+      language: 'ko',
+      localizations: {
+        ko: { title: 'Korean title', description: 'Korean description' },
+        en: { title: 'English title', description: 'English description' },
+      },
+    })
+
+    const initBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string)
+    expect(initBody.snippet).toMatchObject({
+      title: 'Korean title',
+      description: 'Korean description',
+      defaultLanguage: 'ko',
+    })
+    expect(initBody.localizations.ko).toBeUndefined()
+    expect(initBody.localizations.en.title).toBe('English title')
+  })
+
   it('throws on init failure', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse('Bad request', 400))
     await expect(

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -20,6 +20,8 @@ export interface YouTubeVideoMetadata {
   categoryId: string
   tags: string[]
   defaultLanguage: string
+  resolvedLanguage: string
+  resolvedFrom: 'default' | 'localization'
   localizations: Record<string, YouTubeLocalization>
 }
 

--- a/src/lib/youtube/upload.ts
+++ b/src/lib/youtube/upload.ts
@@ -6,6 +6,31 @@ import { YouTubeError } from '@/lib/youtube/error'
 
 const YOUTUBE_UPLOAD_BASE = 'https://www.googleapis.com/upload/youtube/v3'
 
+function normalizeLanguageTag(language?: string | null) {
+  return language?.trim().toLowerCase() || ''
+}
+
+function baseLanguage(language: string) {
+  return normalizeLanguageTag(language).split('-')[0] || ''
+}
+
+function isSameLanguage(left?: string | null, right?: string | null) {
+  const a = normalizeLanguageTag(left)
+  const b = normalizeLanguageTag(right)
+  if (!a || !b) return false
+  return a === b || baseLanguage(a) === baseLanguage(b)
+}
+
+function omitLanguage(
+  localizations: Record<string, YouTubeLocalization> | undefined,
+  language: string,
+) {
+  if (!localizations) return undefined
+  return Object.fromEntries(
+    Object.entries(localizations).filter(([code]) => !isSameLanguage(code, language)),
+  )
+}
+
 export interface YouTubeUploadInput {
   accessToken: string
   videoBlob: Blob
@@ -68,7 +93,8 @@ export async function initYouTubeResumableUpload(
     origin,
   } = input
 
-  const hasLocalizations = !!localizations && Object.keys(localizations).length > 0
+  const filteredLocalizations = omitLanguage(localizations, language)
+  const hasLocalizations = !!filteredLocalizations && Object.keys(filteredLocalizations).length > 0
   const metadata: Record<string, unknown> = {
     snippet: {
       title,
@@ -85,7 +111,7 @@ export async function initYouTubeResumableUpload(
     },
   }
   if (hasLocalizations) {
-    metadata.localizations = localizations
+    metadata.localizations = filteredLocalizations
   }
   const parts = ['snippet', 'status', ...(hasLocalizations ? ['localizations'] : [])].join(',')
 


### PR DESCRIPTION
﻿## 변경 내용
- YouTube 메타데이터 조회 시 원문 언어를 함께 요청할 수 있도록 `sourceLang` 흐름을 추가했습니다.
- 기본 메타데이터가 다른 언어로 저장된 영상도 요청 언어의 localization이 있으면 해당 제목/설명을 우선 사용하도록 했습니다.
- 업로드/수정 시 원문 언어는 `snippet.title/description`에 보존하고, 같은 언어 localization은 제외해 중복 저장을 줄였습니다.
- 더빙 업로드/메타데이터 도구에서 원문 언어 기준으로 제목과 설명을 다시 불러오도록 연결했습니다.

## 이유
영어 번역본이 YouTube 기본 메타데이터처럼 반환되는 경우에도, 한국어 원문 localization이 남아 있으면 앱에서 원문 제목/설명을 안정적으로 복원하기 위해서입니다.

## 검증
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
