### PR TITLE
feat: YouTube 업로드 설정 스냅샷 도입

### DIFF
--- a/migrations/0008_youtube_upload_snapshots.sql
+++ b/migrations/0008_youtube_upload_snapshots.sql
@@ -1,0 +1,9 @@
+ALTER TABLE dubbing_jobs ADD COLUMN youtube_upload_snapshot_json TEXT;
+ALTER TABLE job_languages ADD COLUMN youtube_upload_snapshot_json TEXT;
+
+ALTER TABLE upload_queue ADD COLUMN upload_kind TEXT NOT NULL DEFAULT 'new_video_dubbed_video';
+ALTER TABLE upload_queue ADD COLUMN metadata_json TEXT;
+ALTER TABLE upload_queue ADD COLUMN localizations_json TEXT;
+
+ALTER TABLE youtube_uploads ADD COLUMN upload_kind TEXT NOT NULL DEFAULT 'new_video_dubbed_video';
+ALTER TABLE youtube_uploads ADD COLUMN metadata_json TEXT;

--- a/src/app/[locale]/(app)/uploads/page.tsx
+++ b/src/app/[locale]/(app)/uploads/page.tsx
@@ -10,13 +10,25 @@ import { formatDuration } from '@/utils/formatters'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/authStore'
 import { useNotificationStore } from '@/stores/notificationStore'
-import { ytUploadVideo, ytUploadCaption, getDownloadLinks, getPersoFileUrl } from '@/lib/api-client'
+import {
+  ytUploadVideo,
+  ytUploadCaption,
+  ytUpdateVideoLocalizations,
+  getDownloadLinks,
+  getPersoFileUrl,
+} from '@/lib/api-client'
 import { dbMutation } from '@/lib/api/dbMutation'
-import { getLanguageByCode } from '@/utils/languages'
+import { getLanguageByCode, toBcp47 } from '@/utils/languages'
+import { extractVideoId } from '@/utils/validators'
 import { useAppLocale, useLocaleText } from '@/hooks/useLocaleText'
 import type { CompletedJobLanguage } from '@/lib/db/queries/dashboard'
 import type { MessageKey } from '@/lib/i18n/clientMessages'
 import { resolveCaptionTrackName } from '@/lib/youtube/captions'
+import {
+  parseYouTubeUploadSnapshot,
+  snapshotMetadataJson,
+  type YouTubeUploadSnapshot,
+} from '@/lib/youtube/upload-snapshot'
 
 type UploadState = 'idle' | 'fetching' | 'uploading' | 'done' | 'error'
 type PrivacyStatus = 'public' | 'unlisted' | 'private'
@@ -46,15 +58,93 @@ async function fetchCompletedLanguages(uid: string, t: LocaleText): Promise<Comp
   return json.data
 }
 
-function buildDefaultSettings(item: CompletedJobLanguage, langName: string, t: LocaleText): UploadSettings {
+function buildFallbackSnapshot(item: CompletedJobLanguage, langName: string, t: LocaleText): YouTubeUploadSnapshot {
+  const targetAssetKind = item.deliverable_mode === 'originalWithMultiAudio' ? 'original_video' : 'dubbed_video'
+  const sourceKind = item.original_youtube_url ? 'my_youtube_video' : 'new_video'
+  const title = `[${langName}] ${item.video_title}`
+  const description = t('app.app.uploads.page.valueDubtubeAIDubbingInValue', { itemVideo_title: item.video_title, langName: langName })
+  const tags = [t('app.app.uploads.page.dubtubeAIDubbingValue', { langName: langName })]
+  const originalYouTubeVideoId = item.original_youtube_url ? extractVideoId(item.original_youtube_url) : null
   return {
-    title: `[${langName}] ${item.video_title}`,
-    description: t('app.app.uploads.page.valueDubtubeAIDubbingInValue', { itemVideo_title: item.video_title, langName: langName }),
-    tags: t('app.app.uploads.page.dubtubeAIDubbingValue', { langName: langName }),
-    privacyStatus: 'private',
-    uploadCaptions: true,
-    selfDeclaredMadeForKids: false,
-    containsSyntheticMedia: true,
+    version: 1,
+    uploadKind: sourceKind === 'my_youtube_video'
+      ? targetAssetKind === 'original_video' ? 'my_video_original_captions' : 'my_video_dubbed_video'
+      : targetAssetKind === 'original_video' ? 'new_video_original_captions' : 'new_video_dubbed_video',
+    sourceKind,
+    targetAssetKind,
+    sourceLanguage: item.language_code,
+    targetLanguage: item.language_code,
+    selectedLanguages: [item.language_code],
+    settings: {
+      title,
+      description,
+      tags,
+      privacyStatus: 'private',
+      uploadCaptions: true,
+      selfDeclaredMadeForKids: false,
+      containsSyntheticMedia: targetAssetKind === 'dubbed_video',
+      attachOriginalLink: true,
+    },
+    metadata: {
+      source: {
+        title: item.video_title,
+        description,
+        finalDescription: description,
+      },
+      translated: {
+        [item.language_code]: {
+          title,
+          description,
+          finalDescription: description,
+          containsSyntheticMedia: targetAssetKind === 'dubbed_video',
+        },
+      },
+      localizations: {},
+    },
+    assets: {
+      originalVideoUrl: item.original_video_url,
+      originalYouTubeVideoId,
+      originalYouTubeUrl: item.original_youtube_url,
+      dubbedVideoUrl: item.dubbed_video_url,
+      audioUrl: item.audio_url,
+      srtUrl: item.srt_url,
+    },
+  }
+}
+
+function resolveSnapshot(item: CompletedJobLanguage, langName: string, t: LocaleText): YouTubeUploadSnapshot {
+  const parsed = parseYouTubeUploadSnapshot(item.youtube_upload_snapshot_json)
+  const fallback = buildFallbackSnapshot(item, langName, t)
+  const snapshot = parsed ?? fallback
+  return {
+    ...snapshot,
+    assets: {
+      originalVideoUrl: snapshot.assets.originalVideoUrl ?? item.original_video_url,
+      originalYouTubeVideoId: snapshot.assets.originalYouTubeVideoId ?? fallback.assets.originalYouTubeVideoId,
+      originalYouTubeUrl: snapshot.assets.originalYouTubeUrl ?? item.original_youtube_url,
+      dubbedVideoUrl: snapshot.assets.dubbedVideoUrl ?? item.dubbed_video_url,
+      audioUrl: snapshot.assets.audioUrl ?? item.audio_url,
+      srtUrl: snapshot.assets.srtUrl ?? item.srt_url,
+    },
+  }
+}
+
+function buildSettingsFromSnapshot(snapshot: YouTubeUploadSnapshot): UploadSettings {
+  const metadata = snapshot.metadata.translated[snapshot.targetLanguage]
+  const title = snapshot.targetAssetKind === 'dubbed_video'
+    ? metadata?.title || snapshot.settings.title
+    : snapshot.metadata.source.title || snapshot.settings.title
+  const description = snapshot.targetAssetKind === 'dubbed_video'
+    ? metadata?.finalDescription || metadata?.description || snapshot.settings.description
+    : snapshot.metadata.source.finalDescription || snapshot.metadata.source.description || snapshot.settings.description
+  return {
+    title,
+    description,
+    tags: snapshot.settings.tags.join(', '),
+    privacyStatus: snapshot.settings.privacyStatus,
+    uploadCaptions: snapshot.settings.uploadCaptions,
+    selfDeclaredMadeForKids: snapshot.settings.selfDeclaredMadeForKids,
+    containsSyntheticMedia: snapshot.settings.containsSyntheticMedia,
   }
 }
 
@@ -77,8 +167,9 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
         <Input
           label={t('app.app.uploads.page.title')}
           value={settings.title}
-          onChange={(e) => onChange({ ...settings, title: e.target.value })}
+          readOnly
           placeholder={t('app.app.uploads.page.videoTitle')}
+          className="bg-surface-50 dark:bg-surface-800"
         />
 
         <div className="w-full">
@@ -89,17 +180,18 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
             id="yt-description"
             rows={4}
             value={settings.description}
-            onChange={(e) => onChange({ ...settings, description: e.target.value })}
+            readOnly
             placeholder={t('app.app.uploads.page.videoDescription')}
-            className="w-full resize-none rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm text-surface-900 placeholder:text-surface-500 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 dark:placeholder:text-surface-400"
+            className="w-full resize-none rounded-lg border border-surface-300 bg-surface-50 px-3 py-2 text-sm text-surface-900 placeholder:text-surface-500 transition-colors focus-ring dark:border-surface-700 dark:bg-surface-800 dark:text-surface-100 dark:placeholder:text-surface-400"
           />
         </div>
 
         <Input
           label={t('app.app.uploads.page.tags')}
           value={settings.tags}
-          onChange={(e) => onChange({ ...settings, tags: e.target.value })}
+          readOnly
           placeholder={t('app.app.uploads.page.separateTagsWithCommas')}
+          className="bg-surface-50 dark:bg-surface-800"
         />
 
         <Select
@@ -137,7 +229,8 @@ function UploadSettingsModal({ open, onClose, settings, onChange, onConfirm, isL
             type="checkbox"
             className="mt-0.5 h-4 w-4 rounded border-surface-300 text-brand-600 focus:ring-brand-500"
             checked={settings.containsSyntheticMedia}
-            onChange={(e) => onChange({ ...settings, containsSyntheticMedia: e.target.checked })}
+            disabled
+            readOnly
           />
           <span>{t('app.app.uploads.page.discloseAIVoiceUse')}</span>
         </label>
@@ -183,13 +276,15 @@ function UploadRow({ item, userId }: UploadRowProps) {
   const [videoId, setVideoId] = useState<string | null>(item.youtube_video_id)
   const lang = getLanguageByCode(item.language_code)
   const langName = (locale === 'ko' ? lang?.nativeName : lang?.name) || lang?.name || item.language_code
-  const captionTrackName = resolveCaptionTrackName(item.language_code, lang?.name)
+  const snapshot = resolveSnapshot(item, langName, t)
+  const captionLanguage = toBcp47(snapshot.targetLanguage || item.language_code)
+  const captionTrackName = resolveCaptionTrackName(captionLanguage, lang?.name)
 
   const [modalOpen, setModalOpen] = useState(false)
-  const [settings, setSettings] = useState<UploadSettings>(() => buildDefaultSettings(item, langName, t))
+  const [settings, setSettings] = useState<UploadSettings>(() => buildSettingsFromSnapshot(snapshot))
 
   const handleOpenModal = useCallback(() => {
-    setSettings(buildDefaultSettings(item, langName, t))
+    setSettings(buildSettingsFromSnapshot(resolveSnapshot(item, langName, t)))
     setModalOpen(true)
   }, [item, langName, t])
 
@@ -216,67 +311,122 @@ function UploadRow({ item, userId }: UploadRowProps) {
         return { video: toAbs(raw), srt: toAbs(rawSrt) }
       }
 
-      // Start from DB URL (normalized). Refetch if missing or later if fetch fails (expired CDN link).
-      let videoUrl = toAbs(item.dubbed_video_url)
-      let srtUrl = toAbs(item.srt_url)
-
-      if (!videoUrl) {
-        const fresh = await refetchFromPerso()
-        videoUrl = fresh.video
-        srtUrl = srtUrl ?? fresh.srt
+      const resolveSrtContent = async (): Promise<string | null> => {
+        let srtUrl = toAbs(snapshot.assets.srtUrl ?? item.srt_url)
+        if (!srtUrl) {
+          const fresh = await refetchFromPerso()
+          srtUrl = fresh.srt
+        }
+        if (!srtUrl) return null
+        const srtRes = await fetch(srtUrl)
+        return srtRes.ok ? await srtRes.text() : null
       }
-      if (!videoUrl) throw new Error(t('app.app.uploads.page.couldNotFindTheDubbedVideoDownloadLink'))
+
+      const effectiveSnapshot: YouTubeUploadSnapshot = {
+        ...snapshot,
+        settings: {
+          ...snapshot.settings,
+          privacyStatus: settings.privacyStatus,
+          uploadCaptions: settings.uploadCaptions,
+          selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
+        },
+      }
+      const targetMetadata = snapshot.metadata.translated[snapshot.targetLanguage] ?? {
+        title: settings.title,
+        description: settings.description,
+        finalDescription: settings.description,
+        containsSyntheticMedia: settings.containsSyntheticMedia,
+      }
+      const metadataJson = snapshotMetadataJson(effectiveSnapshot)
 
       setState('uploading')
-      const baseTags = settings.tags.split(',').map((t) => t.trim()).filter(Boolean)
+      const baseTags = snapshot.settings.tags
+      let targetVideoId = snapshot.targetAssetKind === 'original_video'
+        ? snapshot.assets.originalYouTubeVideoId
+        : null
+      let uploadTitle = settings.title
+      let shouldPersistOriginalYouTubeUrl = false
 
-      const doUpload = (url: string) =>
-        ytUploadVideo({
-          videoUrl: url,
-          title: settings.title,
-          description: settings.description,
-          tags: baseTags,
-          privacyStatus: settings.privacyStatus,
-          selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
-          containsSyntheticMedia: settings.containsSyntheticMedia,
-          language: item.language_code,
-        })
+      if (!targetVideoId) {
+        let videoUrl = snapshot.targetAssetKind === 'original_video'
+          ? toAbs(snapshot.assets.originalVideoUrl ?? item.original_video_url)
+          : toAbs(snapshot.assets.dubbedVideoUrl ?? item.dubbed_video_url)
 
-      const uploadOnce = async () => {
+        if (!videoUrl && snapshot.targetAssetKind === 'dubbed_video') {
+          const fresh = await refetchFromPerso()
+          videoUrl = fresh.video
+        }
+        if (!videoUrl) throw new Error(t('app.app.uploads.page.couldNotFindTheDubbedVideoDownloadLink'))
+
+        const isOriginalVideoUpload = snapshot.targetAssetKind === 'original_video'
+        uploadTitle = isOriginalVideoUpload
+          ? snapshot.metadata.source.title || settings.title
+          : targetMetadata.title || settings.title
+        const uploadDescription = isOriginalVideoUpload
+          ? snapshot.metadata.source.finalDescription || snapshot.metadata.source.description || settings.description
+          : targetMetadata.finalDescription || targetMetadata.description || settings.description
+
+        const doUpload = (url: string) =>
+          ytUploadVideo({
+            videoUrl: url,
+            title: uploadTitle,
+            description: uploadDescription,
+            tags: baseTags,
+            privacyStatus: settings.privacyStatus,
+            selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
+            containsSyntheticMedia: isOriginalVideoUpload ? false : settings.containsSyntheticMedia,
+            language: isOriginalVideoUpload ? toBcp47(snapshot.sourceLanguage) : toBcp47(snapshot.targetLanguage),
+            localizations: isOriginalVideoUpload ? snapshot.metadata.localizations : undefined,
+          })
+
         try {
-          return await doUpload(videoUrl!)
+          const result = await doUpload(videoUrl)
+          targetVideoId = result.videoId
+          shouldPersistOriginalYouTubeUrl = isOriginalVideoUpload
         } catch (err) {
           const msg = err instanceof Error ? err.message : ''
           const isFetchFailure = /VIDEO_FETCH_FAILED|fetch/i.test(msg)
-          if (!isFetchFailure || !item.project_seq || !item.space_seq) throw err
+          if (!isFetchFailure || !item.project_seq || !item.space_seq || isOriginalVideoUpload) throw err
           setState('fetching')
           const fresh = await refetchFromPerso()
           if (!fresh.video) throw err
-          videoUrl = fresh.video
-          srtUrl = srtUrl ?? fresh.srt
           setState('uploading')
-          return await doUpload(videoUrl)
+          const result = await doUpload(fresh.video)
+          targetVideoId = result.videoId
+          shouldPersistOriginalYouTubeUrl = isOriginalVideoUpload
         }
       }
 
-      const result = await uploadOnce()
+      if (!targetVideoId) throw new Error(t('app.app.uploads.page.couldNotFindTheDubbedVideoDownloadLink'))
 
-      if (settings.uploadCaptions && srtUrl) {
-        try {
-          const srtRes = await fetch(srtUrl)
-          const srtText = await srtRes.text()
+      if (
+        snapshot.targetAssetKind === 'original_video' &&
+        snapshot.assets.originalYouTubeVideoId &&
+        Object.keys(snapshot.metadata.localizations).length > 0
+      ) {
+        await ytUpdateVideoLocalizations({
+          videoId: targetVideoId,
+          sourceLang: toBcp47(snapshot.sourceLanguage),
+          title: snapshot.metadata.source.title || item.video_title,
+          description: snapshot.metadata.source.finalDescription || snapshot.metadata.source.description,
+          tags: baseTags,
+          localizations: snapshot.metadata.localizations,
+        })
+      }
+
+      if (settings.uploadCaptions) {
+        const srtText = await resolveSrtContent()
+        if (srtText?.trim()) {
           await ytUploadCaption({
-            videoId: result.videoId,
-            language: item.language_code,
+            videoId: targetVideoId,
+            language: captionLanguage,
             name: captionTrackName,
             srtContent: srtText,
           })
-        } catch {
-          // SRT optional
         }
       }
 
-      setVideoId(result.videoId)
+      setVideoId(targetVideoId)
       setState('done')
 
       const privacyLabelKey = PRIVACY_OPTIONS.find((o) => o.value === settings.privacyStatus)?.labelKey
@@ -286,16 +436,18 @@ function UploadRow({ item, userId }: UploadRowProps) {
         message: privacyLabelKey ? t(privacyLabelKey) : settings.privacyStatus,
       })
 
-      await Promise.all([
+      const dbWrites = [
         dbMutation({
           type: 'createYouTubeUpload',
           payload: {
             userId,
-            youtubeVideoId: result.videoId,
-            title: settings.title,
+            youtubeVideoId: targetVideoId,
+            title: uploadTitle,
             languageCode: item.language_code,
             privacyStatus: settings.privacyStatus,
             isShort: false,
+            uploadKind: snapshot.uploadKind,
+            metadataJson,
           },
         }),
         dbMutation({
@@ -303,10 +455,22 @@ function UploadRow({ item, userId }: UploadRowProps) {
           payload: {
             jobId: item.job_id,
             langCode: item.language_code,
-            youtubeVideoId: result.videoId,
+            youtubeVideoId: targetVideoId,
           },
         }),
-      ])
+      ]
+      if (shouldPersistOriginalYouTubeUrl) {
+        dbWrites.push(
+          dbMutation({
+            type: 'updateDubbingJobOriginalYouTubeUrl',
+            payload: {
+              jobId: item.job_id,
+              originalYouTubeUrl: `https://www.youtube.com/watch?v=${targetVideoId}`,
+            },
+          }),
+        )
+      }
+      await Promise.all(dbWrites)
       queryClient.invalidateQueries({ queryKey: ['completed-languages'] })
     } catch (err) {
       setState('error')
@@ -316,7 +480,7 @@ function UploadRow({ item, userId }: UploadRowProps) {
         message: err instanceof Error ? err.message : t('app.app.uploads.page.anUnknownErrorOccurred'),
       })
     }
-  }, [item, langName, captionTrackName, settings, userId, addToast, queryClient, t])
+  }, [item, langName, snapshot, captionLanguage, captionTrackName, settings, userId, addToast, queryClient, t])
 
   const isLoading = state === 'fetching' || state === 'uploading'
   const loadingLabel = state === 'fetching'

--- a/src/app/api/dashboard/dashboard-routes.test.ts
+++ b/src/app/api/dashboard/dashboard-routes.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/db/queries', () => ({
   updateJobLanguageProgress: vi.fn(),
   updateJobLanguageCompleted: vi.fn(),
   updateJobStatus: vi.fn(),
+  updateDubbingJobOriginalYouTubeUrl: vi.fn(),
   createYouTubeUpload: vi.fn(async () => 10),
   updateJobLanguageYouTube: vi.fn(),
   startJobLanguageYouTubeUpload: vi.fn(async () => ({ status: 'reserved' })),
@@ -588,6 +589,27 @@ describe('/api/dashboard/mutations', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data.jobId).toBe(1)
+  })
+
+  it('returns 200 for updateDubbingJobOriginalYouTubeUrl', async () => {
+    mockAuth('user1')
+    const req = new NextRequest('http://localhost/api/dashboard/mutations', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'updateDubbingJobOriginalYouTubeUrl',
+        payload: {
+          jobId: 1,
+          originalYouTubeUrl: 'https://www.youtube.com/watch?v=abc123',
+        },
+      }),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual({
+      jobId: 1,
+      originalYouTubeUrl: 'https://www.youtube.com/watch?v=abc123',
+    })
   })
 
   it('returns 200 for createYouTubeUpload with matching uid', async () => {

--- a/src/app/api/dashboard/mutations/route.ts
+++ b/src/app/api/dashboard/mutations/route.ts
@@ -6,6 +6,7 @@ import {
   updateJobLanguageProgress,
   updateJobLanguageCompleted,
   updateJobStatus,
+  updateDubbingJobOriginalYouTubeUrl,
   updateJobLanguageProjects,
   createYouTubeUpload,
   updateJobLanguageYouTube,
@@ -158,6 +159,11 @@ export async function POST(req: NextRequest) {
           })
         }
         return apiOk({ jobId })
+      }
+      case 'updateDubbingJobOriginalYouTubeUrl': {
+        const { jobId, originalYouTubeUrl } = action.payload
+        await updateDubbingJobOriginalYouTubeUrl(jobId, originalYouTubeUrl)
+        return apiOk({ jobId, originalYouTubeUrl })
       }
       case 'createYouTubeUpload': {
         const id = await createYouTubeUpload(action.payload)

--- a/src/features/dubbing/hooks/usePersoFlow.ts
+++ b/src/features/dubbing/hooks/usePersoFlow.ts
@@ -18,6 +18,8 @@ import {
   getDownloadLinks,
   getPersoFileUrl,
   cancelProject,
+  translateMetadata,
+  type MetadataTranslation,
 } from '@/lib/api-client'
 import type { DownloadTarget, PersoTtsModel } from '@/lib/perso/types'
 import {
@@ -28,6 +30,17 @@ import {
 import type { LanguageProgress } from '../types/dubbing.types'
 import { dbMutation, dbMutationStrict } from '@/lib/api/dbMutation'
 import { extractVideoId } from '@/utils/validators'
+import { toBcp47 } from '@/utils/languages'
+import {
+  appendAiDisclosureFooter,
+  appendTextFooter,
+  stripAiDisclosureFooter,
+} from '@/features/dubbing/utils/aiDisclosure'
+import {
+  resolveYouTubeUploadKind,
+  serializeYouTubeUploadSnapshot,
+  type YouTubeUploadSnapshot,
+} from '@/lib/youtube/upload-snapshot'
 
 const POLL_INTERVAL_MIN = 8_000   // 첫 폴링: 8초
 const POLL_INTERVAL_MAX = 30_000  // 최대 간격: 30초
@@ -104,15 +117,18 @@ async function saveJobToDb(
   lipSyncEnabled: boolean,
   sourceLanguage: string,
   t: LocaleText,
+  youtubeUploadSnapshotByLanguage: Record<string, string | null> = {},
 ): Promise<number> {
   const userId = useAuthStore.getState().user?.uid
   const videoMeta = store.getState().videoMeta
   const isShort = store.getState().isShort
   const state = store.getState()
   const originalYouTubeId =
-    state.videoSource?.type === 'url' && state.videoSource.url
-      ? extractVideoId(state.videoSource.url)
-      : null
+    state.videoSource?.type === 'channel'
+      ? state.videoSource.videoId ?? null
+      : state.videoSource?.type === 'url' && state.videoSource.url
+        ? extractVideoId(state.videoSource.url)
+        : null
   if (!userId) {
     throw new Error(t('features.dubbing.hooks.usePersoFlow.pleaseSignInFirst'))
   }
@@ -135,11 +151,133 @@ async function saveJobToDb(
         originalVideoUrl: state.originalVideoUrl,
         originalYouTubeUrl: originalYouTubeId ? `https://www.youtube.com/watch?v=${originalYouTubeId}` : null,
       },
-      languages: selectedLanguages.map((code) => ({ code, projectSeq: projectMap[code] || 0 })),
+      languages: selectedLanguages.map((code) => ({
+        code,
+        projectSeq: projectMap[code] || 0,
+        youtubeUploadSnapshotJson: youtubeUploadSnapshotByLanguage[code] ?? null,
+      })),
     },
   })
   store.getState().setDbJobId(result.jobId)
   return result.jobId
+}
+
+async function buildYouTubeUploadSnapshotByLanguage(
+  targetLanguages: string[],
+): Promise<Record<string, string | null>> {
+  const state = store.getState()
+  const settings = state.uploadSettings
+  const baseTitle = settings.title.trim() || state.videoMeta?.title?.trim() || 'Dubtube video'
+  const baseDescription = stripAiDisclosureFooter(settings.description || '')
+  const sourceLanguage = settings.metadataLanguage || 'ko'
+  const sourceType = state.videoSource?.type
+  const targetAssetKind = state.deliverableMode === 'originalWithMultiAudio'
+    ? 'original_video'
+    : 'dubbed_video'
+  const sourceKind = sourceType === 'channel' ? 'my_youtube_video' : 'new_video'
+  const originalYouTubeVideoId = sourceType === 'channel'
+    ? state.videoSource?.videoId ?? null
+    : sourceType === 'url' && state.videoSource?.url
+      ? extractVideoId(state.videoSource.url)
+      : null
+  const originalYouTubeUrl = originalYouTubeVideoId
+    ? `https://www.youtube.com/watch?v=${originalYouTubeVideoId}`
+    : null
+  const shouldApplyAiDisclosure =
+    targetAssetKind === 'dubbed_video' && settings.containsSyntheticMedia
+
+  let translations: Record<string, MetadataTranslation> = {}
+  if (targetLanguages.length > 0) {
+    try {
+      translations = await translateMetadata({
+        title: baseTitle,
+        description: baseDescription,
+        sourceLang: sourceLanguage,
+        targetLangs: targetLanguages,
+      })
+    } catch (err) {
+      console.warn('[Dubtube] metadata snapshot translation failed; using source metadata fallback', err)
+      translations = Object.fromEntries(
+        targetLanguages.map((code) => [code, { title: baseTitle, description: baseDescription }]),
+      )
+    }
+  }
+
+  const finalDescriptionFor = (description: string, languageCode: string) => {
+    let next = stripAiDisclosureFooter(description)
+    if (targetAssetKind === 'dubbed_video' && settings.attachOriginalLink && originalYouTubeUrl) {
+      next = appendTextFooter(next, `Original video: ${originalYouTubeUrl}`)
+    }
+    return appendAiDisclosureFooter(next, languageCode, shouldApplyAiDisclosure)
+  }
+
+  const translated = Object.fromEntries(
+    targetLanguages.map((code) => {
+      const value = translations[code] ?? { title: baseTitle, description: baseDescription }
+      return [code, {
+        title: value.title,
+        description: value.description,
+        finalDescription: targetAssetKind === 'dubbed_video'
+          ? finalDescriptionFor(value.description, code)
+          : stripAiDisclosureFooter(value.description),
+        containsSyntheticMedia: shouldApplyAiDisclosure,
+      }]
+    }),
+  )
+
+  const localizations = targetAssetKind === 'original_video'
+    ? Object.fromEntries(
+      targetLanguages.map((code) => {
+        const value = translations[code] ?? { title: baseTitle, description: baseDescription }
+        return [toBcp47(code), {
+          title: value.title,
+          description: stripAiDisclosureFooter(value.description),
+        }]
+      }),
+    )
+    : {}
+
+  return Object.fromEntries(
+    targetLanguages.map((code) => {
+      const snapshot: YouTubeUploadSnapshot = {
+        version: 1,
+        uploadKind: resolveYouTubeUploadKind(sourceType, state.deliverableMode),
+        sourceKind,
+        targetAssetKind,
+        sourceLanguage,
+        targetLanguage: code,
+        selectedLanguages: targetLanguages,
+        settings: {
+          title: baseTitle,
+          description: baseDescription,
+          tags: settings.tags,
+          privacyStatus: settings.privacyStatus,
+          uploadCaptions: settings.uploadCaptions,
+          selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
+          containsSyntheticMedia: shouldApplyAiDisclosure,
+          attachOriginalLink: settings.attachOriginalLink,
+        },
+        metadata: {
+          source: {
+            title: baseTitle,
+            description: baseDescription,
+            finalDescription: stripAiDisclosureFooter(baseDescription),
+          },
+          translated,
+          localizations,
+        },
+        assets: {
+          originalVideoUrl: state.originalVideoUrl,
+          originalYouTubeVideoId,
+          originalYouTubeUrl,
+          dubbedVideoUrl: null,
+          audioUrl: null,
+          srtUrl: null,
+        },
+      }
+      return [code, serializeYouTubeUploadSnapshot(snapshot)]
+    }),
+  )
 }
 
 async function pollLanguage(
@@ -378,6 +516,7 @@ export function usePersoFlow() {
       }
 
       const pendingProjectMap = Object.fromEntries(targetLanguages.map((lang) => [lang, 0]))
+      const youtubeUploadSnapshotByLanguage = await buildYouTubeUploadSnapshotByLanguage(targetLanguages)
       const dbJobId = await saveJobToDb(
         mediaSeq,
         spaceSeq,
@@ -386,6 +525,7 @@ export function usePersoFlow() {
         lipSyncEnabled,
         DEFAULT_SOURCE_LANGUAGE,
         t,
+        youtubeUploadSnapshotByLanguage,
       )
       await dbMutationStrict({ type: 'reserveJobCredits', payload: { jobId: dbJobId } })
 

--- a/src/lib/db/queries/dashboard.ts
+++ b/src/lib/db/queries/dashboard.ts
@@ -113,6 +113,11 @@ export interface CompletedJobLanguage {
   audio_url: string | null
   srt_url: string | null
   youtube_video_id: string | null
+  youtube_upload_status: string | null
+  youtube_upload_snapshot_json: string | null
+  deliverable_mode: string
+  original_video_url: string | null
+  original_youtube_url: string | null
   created_at: string
 }
 
@@ -120,8 +125,10 @@ export async function getCompletedJobLanguages(userId: string): Promise<Complete
   const db = getDb()
   const result = await db.execute({
     sql: `SELECT dj.id as job_id, dj.video_title, dj.video_thumbnail, dj.video_duration_ms,
-          dj.space_seq, jl.language_code, jl.project_seq,
+          dj.space_seq, dj.deliverable_mode, dj.original_video_url, dj.original_youtube_url,
+          jl.language_code, jl.project_seq,
           jl.dubbed_video_url, jl.audio_url, jl.srt_url, jl.youtube_video_id,
+          jl.youtube_upload_status, jl.youtube_upload_snapshot_json,
           dj.created_at
           FROM dubbing_jobs dj
           JOIN job_languages jl ON jl.job_id = dj.id

--- a/src/lib/db/queries/index.ts
+++ b/src/lib/db/queries/index.ts
@@ -36,6 +36,7 @@ export {
   updateJobLanguageProgress,
   updateJobLanguageCompleted,
   updateJobStatus,
+  updateDubbingJobOriginalYouTubeUrl,
   getDubbingJobLanguageWorkItem,
   getDubbingJobLanguageWorkItems,
   getJobLanguageTerminalSummary,

--- a/src/lib/db/queries/jobs.test.ts
+++ b/src/lib/db/queries/jobs.test.ts
@@ -40,6 +40,12 @@ describe('job queries', () => {
           { name: 'deliverable_mode' },
           { name: 'original_video_url' },
           { name: 'original_youtube_url' },
+          { name: 'youtube_upload_snapshot_json' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { name: 'youtube_upload_snapshot_json' },
         ],
       })
       .mockResolvedValueOnce({ lastInsertRowid: 35 })
@@ -52,8 +58,8 @@ describe('job queries', () => {
 
     expect(jobId).toBe(35)
     expect(mockBatch).toHaveBeenCalledWith([
-      expect.objectContaining({ args: [35, 'en', 0] }),
-      expect.objectContaining({ args: [35, 'ja', 0] }),
+      expect.objectContaining({ args: [35, 'en', 0, null] }),
+      expect.objectContaining({ args: [35, 'ja', 0, null] }),
     ])
     const languageSql = mockBatch.mock.calls[0][0].map((q: { sql: string }) => q.sql).join('\n')
     expect(languageSql).not.toContain('last_insert_rowid')
@@ -72,12 +78,12 @@ describe('job queries', () => {
     ])
 
     expect(mockExecute).toHaveBeenNthCalledWith(2, {
-      sql: 'UPDATE job_languages SET project_seq = ? WHERE id = ?',
-      args: [347162, 10],
+      sql: expect.stringContaining('youtube_upload_snapshot_json = COALESCE'),
+      args: [347162, null, 10],
     })
     expect(mockExecute).toHaveBeenNthCalledWith(4, {
       sql: expect.stringContaining('INSERT INTO job_languages'),
-      args: [35, 'ja', 347163],
+      args: [35, 'ja', 347163, null],
     })
   })
 })

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -7,6 +7,11 @@ import {
   type PersistedDeliverableMode,
   type PersistedJobUploadSettings,
 } from '@/lib/dubbing/job-upload-settings'
+import {
+  parseYouTubeUploadSnapshot,
+  serializeYouTubeUploadSnapshot,
+  type YouTubeUploadSnapshot,
+} from '@/lib/youtube/upload-snapshot'
 
 export interface DubbingJobUploadSettingsInput {
   deliverableMode?: PersistedDeliverableMode
@@ -34,6 +39,7 @@ export interface DubbingJobLanguageWorkItem {
   srtUrl: string | null
   youtubeVideoId: string | null
   youtubeUploadStatus: string | null
+  youtubeUploadSnapshot: YouTubeUploadSnapshot | null
 }
 
 let durableWorkerColumnsEnsured = false
@@ -41,16 +47,24 @@ let durableWorkerColumnsEnsured = false
 async function ensureDurableWorkerColumns() {
   if (durableWorkerColumnsEnsured) return
   const db = getDb()
-  const result = await db.execute({ sql: 'PRAGMA table_info(dubbing_jobs)', args: [] })
-  const existing = new Set(result.rows.map((row) => String(row.name)))
-  const addColumn = async (name: string, definition: string) => {
-    if (existing.has(name)) return
-    await db.execute({ sql: `ALTER TABLE dubbing_jobs ADD COLUMN ${name} ${definition}`, args: [] })
+  const ensureColumns = async (table: string, columns: Array<[name: string, definition: string]>) => {
+    const result = await db.execute({ sql: `PRAGMA table_info(${table})`, args: [] })
+    const existing = new Set((result.rows ?? []).map((row) => String(row.name)))
+    for (const [name, definition] of columns) {
+      if (existing.has(name)) continue
+      await db.execute({ sql: `ALTER TABLE ${table} ADD COLUMN ${name} ${definition}`, args: [] })
+    }
   }
-  await addColumn('upload_settings_json', 'TEXT')
-  await addColumn('deliverable_mode', "TEXT NOT NULL DEFAULT 'newDubbedVideos'")
-  await addColumn('original_video_url', 'TEXT')
-  await addColumn('original_youtube_url', 'TEXT')
+  await ensureColumns('dubbing_jobs', [
+    ['upload_settings_json', 'TEXT'],
+    ['deliverable_mode', "TEXT NOT NULL DEFAULT 'newDubbedVideos'"],
+    ['original_video_url', 'TEXT'],
+    ['original_youtube_url', 'TEXT'],
+    ['youtube_upload_snapshot_json', 'TEXT'],
+  ])
+  await ensureColumns('job_languages', [
+    ['youtube_upload_snapshot_json', 'TEXT'],
+  ])
   durableWorkerColumnsEnsured = true
 }
 
@@ -104,20 +118,22 @@ export async function createDubbingJob(job: {
 
 export async function createJobLanguages(
   jobId: number,
-  languages: { code: string; projectSeq: number }[],
+  languages: { code: string; projectSeq: number; youtubeUploadSnapshotJson?: string | null }[],
 ) {
+  await ensureDurableWorkerColumns()
   const db = getDb()
   await db.batch(
     languages.map((lang) => ({
-      sql: 'INSERT INTO job_languages (job_id, language_code, project_seq) VALUES (?, ?, ?)',
-      args: [jobId, lang.code, lang.projectSeq],
+      sql: `INSERT INTO job_languages (job_id, language_code, project_seq, youtube_upload_snapshot_json)
+            VALUES (?, ?, ?, ?)`,
+      args: [jobId, lang.code, lang.projectSeq, lang.youtubeUploadSnapshotJson ?? null],
     })),
   )
 }
 
 export async function createDubbingJobWithLanguages(
   job: Parameters<typeof createDubbingJob>[0],
-  languages: { code: string; projectSeq: number }[],
+  languages: { code: string; projectSeq: number; youtubeUploadSnapshotJson?: string | null }[],
 ): Promise<number> {
   await ensureDurableWorkerColumns()
   const db = getDb()
@@ -151,7 +167,7 @@ export async function createDubbingJobWithLanguages(
 
 export async function updateJobLanguageProjects(
   jobId: number,
-  languages: { code: string; projectSeq: number }[],
+  languages: { code: string; projectSeq: number; youtubeUploadSnapshotJson?: string | null }[],
 ) {
   if (languages.length === 0) return
   const db = getDb()
@@ -163,14 +179,17 @@ export async function updateJobLanguageProjects(
     const id = existing.rows[0]?.id
     if (id !== undefined && id !== null) {
       await db.execute({
-        sql: 'UPDATE job_languages SET project_seq = ? WHERE id = ?',
-        args: [lang.projectSeq, id],
+        sql: `UPDATE job_languages
+              SET project_seq = ?,
+                  youtube_upload_snapshot_json = COALESCE(?, youtube_upload_snapshot_json)
+              WHERE id = ?`,
+        args: [lang.projectSeq, lang.youtubeUploadSnapshotJson ?? null, id],
       })
     } else {
       await db.execute({
-        sql: `INSERT INTO job_languages (job_id, language_code, project_seq, status, progress_reason)
-              VALUES (?, ?, ?, 'pending', 'PENDING')`,
-        args: [jobId, lang.code, lang.projectSeq],
+        sql: `INSERT INTO job_languages (job_id, language_code, project_seq, status, progress_reason, youtube_upload_snapshot_json)
+              VALUES (?, ?, ?, 'pending', 'PENDING', ?)`,
+        args: [jobId, lang.code, lang.projectSeq, lang.youtubeUploadSnapshotJson ?? null],
       })
     }
   }
@@ -198,15 +217,41 @@ export async function updateJobLanguageCompleted(
   urls: { dubbedVideoUrl?: string; audioUrl?: string; srtUrl?: string },
 ) {
   const db = getDb()
+  const existing = await db.execute({
+    sql: `SELECT youtube_upload_snapshot_json
+          FROM job_languages
+          WHERE job_id = ? AND language_code = ?
+          LIMIT 1`,
+    args: [jobId, langCode],
+  })
+  const snapshot = parseYouTubeUploadSnapshot(
+    existing.rows[0]?.youtube_upload_snapshot_json
+      ? String(existing.rows[0].youtube_upload_snapshot_json)
+      : null,
+  )
+  const nextSnapshotJson = snapshot
+    ? serializeYouTubeUploadSnapshot({
+      ...snapshot,
+      assets: {
+        ...snapshot.assets,
+        dubbedVideoUrl: urls.dubbedVideoUrl || snapshot.assets.dubbedVideoUrl,
+        audioUrl: urls.audioUrl || snapshot.assets.audioUrl,
+        srtUrl: urls.srtUrl || snapshot.assets.srtUrl,
+      },
+    })
+    : null
   await db.execute({
     sql: `UPDATE job_languages SET status = 'completed', progress = 100,
           progress_reason = 'COMPLETED',
-          dubbed_video_url = ?, audio_url = ?, srt_url = ?, updated_at = datetime('now')
+          dubbed_video_url = ?, audio_url = ?, srt_url = ?,
+          youtube_upload_snapshot_json = COALESCE(?, youtube_upload_snapshot_json),
+          updated_at = datetime('now')
           WHERE job_id = ? AND language_code = ?`,
     args: [
       urls.dubbedVideoUrl || null,
       urls.audioUrl || null,
       urls.srtUrl || null,
+      nextSnapshotJson,
       jobId,
       langCode,
     ],
@@ -218,6 +263,17 @@ export async function updateJobStatus(jobId: number, status: string) {
   await db.execute({
     sql: `UPDATE dubbing_jobs SET status = ?, updated_at = datetime('now') WHERE id = ?`,
     args: [status, jobId],
+  })
+}
+
+export async function updateDubbingJobOriginalYouTubeUrl(jobId: number, originalYouTubeUrl: string) {
+  await ensureDurableWorkerColumns()
+  const db = getDb()
+  await db.execute({
+    sql: `UPDATE dubbing_jobs
+          SET original_youtube_url = ?, updated_at = datetime('now')
+          WHERE id = ?`,
+    args: [originalYouTubeUrl, jobId],
   })
 }
 
@@ -254,6 +310,9 @@ function rowToDubbingJobLanguageWorkItem(row: DubbingJobLanguageWorkItemRow): Du
     srtUrl: row.srt_url ? String(row.srt_url) : null,
     youtubeVideoId: row.youtube_video_id ? String(row.youtube_video_id) : null,
     youtubeUploadStatus: row.youtube_upload_status ? String(row.youtube_upload_status) : null,
+    youtubeUploadSnapshot: parseYouTubeUploadSnapshot(
+      row.youtube_upload_snapshot_json ? String(row.youtube_upload_snapshot_json) : null,
+    ),
   }
 }
 
@@ -281,7 +340,8 @@ export async function getDubbingJobLanguageWorkItems(limit = 50): Promise<Dubbin
             jl.audio_url,
             jl.srt_url,
             jl.youtube_video_id,
-            jl.youtube_upload_status
+            jl.youtube_upload_status,
+            jl.youtube_upload_snapshot_json
           FROM job_languages jl
           JOIN dubbing_jobs dj ON dj.id = jl.job_id
           WHERE COALESCE(jl.project_seq, 0) > 0
@@ -329,7 +389,8 @@ export async function getDubbingJobLanguageWorkItem(
             jl.audio_url,
             jl.srt_url,
             jl.youtube_video_id,
-            jl.youtube_upload_status
+            jl.youtube_upload_status,
+            jl.youtube_upload_snapshot_json
           FROM job_languages jl
           JOIN dubbing_jobs dj ON dj.id = jl.job_id
           WHERE jl.job_id = ? AND jl.language_code = ?

--- a/src/lib/db/queries/upload-queue.ts
+++ b/src/lib/db/queries/upload-queue.ts
@@ -23,6 +23,9 @@ export interface UploadQueueItem {
   srtContent: string | null
   selfDeclaredMadeForKids: boolean
   containsSyntheticMedia: boolean
+  uploadKind: string
+  metadataJson: string | null
+  localizationsJson: string | null
   status: QueueStatus
   retries: number
   error: string | null
@@ -72,7 +75,7 @@ async function ensureTable() {
     sql: 'PRAGMA table_info(upload_queue)',
     args: [],
   })
-  const existing = new Set(columns.rows.map((row) => String(row.name)))
+  const existing = new Set((columns.rows ?? []).map((row) => String(row.name)))
   const addColumn = async (name: string, definition: string) => {
     if (existing.has(name)) return
     await db.execute({
@@ -86,6 +89,9 @@ async function ensureTable() {
   await addColumn('srt_content', 'TEXT')
   await addColumn('self_declared_made_for_kids', 'INTEGER NOT NULL DEFAULT 0')
   await addColumn('contains_synthetic_media', 'INTEGER NOT NULL DEFAULT 0')
+  await addColumn('upload_kind', "TEXT NOT NULL DEFAULT 'new_video_dubbed_video'")
+  await addColumn('metadata_json', 'TEXT')
+  await addColumn('localizations_json', 'TEXT')
   tableEnsured = true
 }
 
@@ -106,6 +112,9 @@ export async function createUploadQueueItem(item: {
   srtContent?: string | null
   selfDeclaredMadeForKids?: boolean
   containsSyntheticMedia?: boolean
+  uploadKind?: string
+  metadataJson?: string | null
+  localizationsJson?: string | null
   resetFailed?: boolean
 }): Promise<number> {
   await ensureTable()
@@ -141,6 +150,9 @@ export async function createUploadQueueItem(item: {
                 srt_content = ?,
                 self_declared_made_for_kids = ?,
                 contains_synthetic_media = ?,
+                upload_kind = ?,
+                metadata_json = ?,
+                localizations_json = ?,
                 status = 'pending',
                 retries = 0,
                 error = NULL,
@@ -162,6 +174,9 @@ export async function createUploadQueueItem(item: {
         item.srtContent ?? null,
         item.selfDeclaredMadeForKids ? 1 : 0,
         item.containsSyntheticMedia ? 1 : 0,
+        item.uploadKind ?? 'new_video_dubbed_video',
+        item.metadataJson ?? null,
+        item.localizationsJson ?? null,
         id,
       ],
     })
@@ -171,9 +186,10 @@ export async function createUploadQueueItem(item: {
     sql: `INSERT INTO upload_queue (
             user_id, job_id, lang_code, video_url, title, description, tags,
             privacy_status, language, is_short, upload_captions, caption_language,
-            caption_name, srt_content, self_declared_made_for_kids, contains_synthetic_media
+            caption_name, srt_content, self_declared_made_for_kids, contains_synthetic_media,
+            upload_kind, metadata_json, localizations_json
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       item.userId,
       item.jobId,
@@ -191,6 +207,9 @@ export async function createUploadQueueItem(item: {
       item.srtContent ?? null,
       item.selfDeclaredMadeForKids ? 1 : 0,
       item.containsSyntheticMedia ? 1 : 0,
+      item.uploadKind ?? 'new_video_dubbed_video',
+      item.metadataJson ?? null,
+      item.localizationsJson ?? null,
     ],
   })
   return Number(result.lastInsertRowid)
@@ -292,6 +311,10 @@ export async function failQueueItem(id: number, error: string): Promise<boolean>
   return Boolean(row)
 }
 
+function dbBoolean(value: unknown) {
+  return value === true || value === 1 || value === '1'
+}
+
 function rowToItem(row: Record<string, unknown>): UploadQueueItem {
   return {
     id: Number(row.id),
@@ -304,13 +327,16 @@ function rowToItem(row: Record<string, unknown>): UploadQueueItem {
     tags: String(row.tags),
     privacyStatus: String(row.privacy_status),
     language: String(row.language),
-    isShort: Boolean(row.is_short),
-    uploadCaptions: Boolean(row.upload_captions),
+    isShort: dbBoolean(row.is_short),
+    uploadCaptions: dbBoolean(row.upload_captions),
     captionLanguage: row.caption_language ? String(row.caption_language) : null,
     captionName: row.caption_name ? String(row.caption_name) : null,
     srtContent: row.srt_content ? String(row.srt_content) : null,
-    selfDeclaredMadeForKids: Boolean(row.self_declared_made_for_kids),
-    containsSyntheticMedia: Boolean(row.contains_synthetic_media),
+    selfDeclaredMadeForKids: dbBoolean(row.self_declared_made_for_kids),
+    containsSyntheticMedia: dbBoolean(row.contains_synthetic_media),
+    uploadKind: row.upload_kind ? String(row.upload_kind) : 'new_video_dubbed_video',
+    metadataJson: row.metadata_json ? String(row.metadata_json) : null,
+    localizationsJson: row.localizations_json ? String(row.localizations_json) : null,
     status: String(row.status) as QueueStatus,
     retries: Number(row.retries),
     error: row.error ? String(row.error) : null,

--- a/src/lib/db/queries/youtube.ts
+++ b/src/lib/db/queries/youtube.ts
@@ -7,6 +7,22 @@ export interface JobLanguageYouTubeUploadReservation {
   youtubeVideoId?: string | null
 }
 
+let youtubeUploadColumnsEnsured = false
+
+async function ensureYouTubeUploadColumns() {
+  if (youtubeUploadColumnsEnsured) return
+  const db = getDb()
+  const result = await db.execute({ sql: 'PRAGMA table_info(youtube_uploads)', args: [] })
+  const existing = new Set((result.rows ?? []).map((row) => String(row.name)))
+  const addColumn = async (name: string, definition: string) => {
+    if (existing.has(name)) return
+    await db.execute({ sql: `ALTER TABLE youtube_uploads ADD COLUMN ${name} ${definition}`, args: [] })
+  }
+  await addColumn('upload_kind', "TEXT NOT NULL DEFAULT 'new_video_dubbed_video'")
+  await addColumn('metadata_json', 'TEXT')
+  youtubeUploadColumnsEnsured = true
+}
+
 export async function createYouTubeUpload(upload: {
   userId: string
   jobLanguageId?: number
@@ -15,11 +31,17 @@ export async function createYouTubeUpload(upload: {
   languageCode: string
   privacyStatus: string
   isShort: boolean
+  uploadKind?: string
+  metadataJson?: string | null
 }): Promise<number> {
+  await ensureYouTubeUploadColumns()
   const db = getDb()
   const result = await db.execute({
-    sql: `INSERT INTO youtube_uploads (user_id, job_language_id, youtube_video_id, title, language_code, privacy_status, is_short)
-          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO youtube_uploads (
+            user_id, job_language_id, youtube_video_id, title, language_code,
+            privacy_status, is_short, upload_kind, metadata_json
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       upload.userId,
       upload.jobLanguageId || null,
@@ -28,6 +50,8 @@ export async function createYouTubeUpload(upload: {
       upload.languageCode,
       upload.privacyStatus,
       upload.isShort ? 1 : 0,
+      upload.uploadKind ?? 'new_video_dubbed_video',
+      upload.metadataJson ?? null,
     ],
   })
   return Number(result.lastInsertRowid)

--- a/src/lib/dubbing/process.test.ts
+++ b/src/lib/dubbing/process.test.ts
@@ -76,6 +76,7 @@ const workItem = {
   srtUrl: null,
   youtubeVideoId: null,
   youtubeUploadStatus: null,
+  youtubeUploadSnapshot: null,
 }
 
 beforeEach(() => {

--- a/src/lib/dubbing/process.ts
+++ b/src/lib/dubbing/process.ts
@@ -20,6 +20,10 @@ import { recordOperationalEventSafe } from '@/lib/ops/observability'
 import { getLanguageByCode, toBcp47 } from '@/utils/languages'
 import { resolveCaptionTrackName } from '@/lib/youtube/captions'
 import { appendAiDisclosureFooter, appendTextFooter, stripAiDisclosureFooter } from '@/features/dubbing/utils/aiDisclosure'
+import {
+  snapshotLocalizationsJson,
+  snapshotMetadataJson,
+} from '@/lib/youtube/upload-snapshot'
 
 export interface ProcessDubbingJobsOptions {
   limit?: number
@@ -200,25 +204,31 @@ async function enqueueCompletedLanguage(
   if (!videoUrl) return { status: 'missing_video_url' }
 
   const metadata = await buildMetadata(item)
-  const srtContent = settings.uploadCaptions ? await fetchTranslatedSrt(item).catch(() => null) : null
+  const snapshot = item.youtubeUploadSnapshot
+  const snapshotMetadata = snapshot?.metadata.translated[item.languageCode]
+  const uploadCaptions = snapshot?.settings.uploadCaptions ?? settings.uploadCaptions
+  const srtContent = uploadCaptions ? await fetchTranslatedSrt(item).catch(() => null) : null
 
   return enqueueYouTubeUpload({
     userId: item.userId,
     jobId: item.jobId,
     langCode: item.languageCode,
     videoUrl,
-    title: metadata.title,
-    description: metadata.description,
-    tags: metadata.tags,
-    privacyStatus: settings.privacyStatus,
+    title: snapshotMetadata?.title || metadata.title,
+    description: snapshotMetadata?.finalDescription || metadata.description,
+    tags: snapshot?.settings.tags?.length ? snapshot.settings.tags : metadata.tags,
+    privacyStatus: snapshot?.settings.privacyStatus || settings.privacyStatus,
     language: item.languageCode,
     isShort: item.isShort,
-    uploadCaptions: settings.uploadCaptions,
+    uploadCaptions,
     captionLanguage: toBcp47(item.languageCode),
     captionName: metadata.captionName,
     srtContent,
-    selfDeclaredMadeForKids: settings.selfDeclaredMadeForKids,
-    containsSyntheticMedia: item.deliverableMode === 'newDubbedVideos' && settings.containsSyntheticMedia,
+    selfDeclaredMadeForKids: snapshot?.settings.selfDeclaredMadeForKids ?? settings.selfDeclaredMadeForKids,
+    containsSyntheticMedia: snapshot?.settings.containsSyntheticMedia ?? (item.deliverableMode === 'newDubbedVideos' && settings.containsSyntheticMedia),
+    uploadKind: snapshot?.uploadKind,
+    metadataJson: snapshot ? snapshotMetadataJson(snapshot) : null,
+    localizationsJson: snapshot ? snapshotLocalizationsJson(snapshot) : null,
     resetFailed: Boolean(options.force),
   })
 }

--- a/src/lib/upload-queue/enqueue.ts
+++ b/src/lib/upload-queue/enqueue.ts
@@ -20,6 +20,9 @@ export interface EnqueueYouTubeUploadInput {
   srtContent?: string | null
   selfDeclaredMadeForKids?: boolean
   containsSyntheticMedia?: boolean
+  uploadKind?: string
+  metadataJson?: string | null
+  localizationsJson?: string | null
   resetFailed?: boolean
 }
 

--- a/src/lib/upload-queue/process.test.ts
+++ b/src/lib/upload-queue/process.test.ts
@@ -54,6 +54,9 @@ const queueItem = {
   srtContent: '1\n00:00:00,000 --> 00:00:01,000\nHello',
   selfDeclaredMadeForKids: false,
   containsSyntheticMedia: true,
+  uploadKind: 'new_video_dubbed_video',
+  metadataJson: JSON.stringify({ translated: { en: { title: 'Translated title' } } }),
+  localizationsJson: JSON.stringify({ en: { title: 'Translated title', description: 'Translated description' } }),
   status: 'processing' as const,
   retries: 0,
   error: null,
@@ -105,6 +108,7 @@ describe('processUploadQueue', () => {
         tags: ['dubtube', 'english'],
         selfDeclaredMadeForKids: false,
         containsSyntheticMedia: true,
+        localizations: { en: { title: 'Translated title', description: 'Translated description' } },
       }),
     )
     expect(uploadCaptionToYouTube).toHaveBeenCalledWith({
@@ -116,7 +120,12 @@ describe('processUploadQueue', () => {
     })
     expect(completeQueueItem).toHaveBeenCalledWith(10, 'yt-123')
     expect(createYouTubeUpload).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'user-1', youtubeVideoId: 'yt-123' }),
+      expect.objectContaining({
+        userId: 'user-1',
+        youtubeVideoId: 'yt-123',
+        uploadKind: 'new_video_dubbed_video',
+        metadataJson: queueItem.metadataJson,
+      }),
     )
     expect(updateJobLanguageYouTube).toHaveBeenCalledWith(20, 'en', 'yt-123')
   })

--- a/src/lib/upload-queue/process.ts
+++ b/src/lib/upload-queue/process.ts
@@ -9,12 +9,23 @@ import { createYouTubeUpload, updateJobLanguageYouTube } from '@/lib/db/queries'
 import { getOrRefreshAccessToken } from '@/lib/auth/token-refresh'
 import { uploadCaptionToYouTube, uploadVideoToYouTube } from '@/lib/youtube/upload'
 import { resolveCaptionTrackName } from '@/lib/youtube/captions'
+import type { YouTubeLocalization } from '@/lib/youtube/types'
 import { logger } from '@/lib/logger'
 
 export interface ProcessUploadQueueOptions {
   limit?: number
   userId?: string
   queueId?: number
+}
+
+function parseLocalizationsJson(json: string | null): Record<string, YouTubeLocalization> | undefined {
+  if (!json) return undefined
+  try {
+    const parsed = JSON.parse(json) as Record<string, YouTubeLocalization>
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
 }
 
 export async function processUploadQueue(options: ProcessUploadQueueOptions = {}) {
@@ -62,6 +73,7 @@ export async function processUploadQueue(options: ProcessUploadQueueOptions = {}
         selfDeclaredMadeForKids: item.selfDeclaredMadeForKids,
         containsSyntheticMedia: item.containsSyntheticMedia,
         language: item.language || undefined,
+        localizations: parseLocalizationsJson(item.localizationsJson),
       })
 
       if (item.uploadCaptions && item.srtContent?.trim()) {
@@ -91,6 +103,8 @@ export async function processUploadQueue(options: ProcessUploadQueueOptions = {}
           languageCode: item.langCode,
           privacyStatus: item.privacyStatus,
           isShort: item.isShort,
+          uploadKind: item.uploadKind,
+          metadataJson: item.metadataJson,
         })
         await updateJobLanguageYouTube(item.jobId, item.langCode, result.videoId)
       } catch {

--- a/src/lib/validators/dashboard.ts
+++ b/src/lib/validators/dashboard.ts
@@ -52,7 +52,11 @@ const createJobLanguagesSchema = z.object({
   type: z.literal('createJobLanguages'),
   payload: z.object({
     jobId: z.number().int(),
-    languages: z.array(z.object({ code: z.string().min(1), projectSeq: z.number().int() })).min(1),
+    languages: z.array(z.object({
+      code: z.string().min(1),
+      projectSeq: z.number().int(),
+      youtubeUploadSnapshotJson: z.string().nullable().optional(),
+    })).min(1),
   }),
 })
 
@@ -88,6 +92,14 @@ const updateJobStatusSchema = z.object({
   }),
 })
 
+const updateDubbingJobOriginalYouTubeUrlSchema = z.object({
+  type: z.literal('updateDubbingJobOriginalYouTubeUrl'),
+  payload: z.object({
+    jobId: z.number().int(),
+    originalYouTubeUrl: z.string().url(),
+  }),
+})
+
 const createYouTubeUploadSchema = z.object({
   type: z.literal('createYouTubeUpload'),
   payload: z.object({
@@ -98,6 +110,8 @@ const createYouTubeUploadSchema = z.object({
     languageCode: z.string().min(1),
     privacyStatus: z.string().min(1),
     isShort: z.boolean(),
+    uploadKind: z.string().optional(),
+    metadataJson: z.string().nullable().optional(),
   }),
 })
 
@@ -161,7 +175,11 @@ const updateJobLanguageProjectsSchema = z.object({
   type: z.literal('updateJobLanguageProjects'),
   payload: z.object({
     jobId: z.number().int(),
-    languages: z.array(z.object({ code: z.string().min(1), projectSeq: z.number().int() })).min(1),
+    languages: z.array(z.object({
+      code: z.string().min(1),
+      projectSeq: z.number().int(),
+      youtubeUploadSnapshotJson: z.string().nullable().optional(),
+    })).min(1),
   }),
 })
 
@@ -169,7 +187,11 @@ const createDubbingJobWithLanguagesSchema = z.object({
   type: z.literal('createDubbingJobWithLanguages'),
   payload: z.object({
     job: createDubbingJobSchema.shape.payload,
-    languages: z.array(z.object({ code: z.string().min(1), projectSeq: z.number().int() })).min(1),
+    languages: z.array(z.object({
+      code: z.string().min(1),
+      projectSeq: z.number().int(),
+      youtubeUploadSnapshotJson: z.string().nullable().optional(),
+    })).min(1),
   }),
 })
 
@@ -199,6 +221,9 @@ const queueYouTubeUploadSchema = z.object({
     srtContent: z.string().nullable().optional(),
     selfDeclaredMadeForKids: z.boolean().optional(),
     containsSyntheticMedia: z.boolean().optional(),
+    uploadKind: z.string().optional(),
+    metadataJson: z.string().nullable().optional(),
+    localizationsJson: z.string().nullable().optional(),
     resetFailed: z.boolean().optional(),
     processNow: z.boolean().optional(),
   }),
@@ -220,6 +245,7 @@ export const mutationActionSchema = z.discriminatedUnion('type', [
   updateJobLanguageProgressSchema,
   updateJobLanguageCompletedSchema,
   updateJobStatusSchema,
+  updateDubbingJobOriginalYouTubeUrlSchema,
   createYouTubeUploadSchema,
   updateJobLanguageYouTubeSchema,
   startJobLanguageYouTubeUploadSchema,
@@ -268,6 +294,8 @@ export function getJobIdFromAction(action: MutationAction): number | null {
     case 'updateJobLanguageCompleted':
       return action.payload.jobId
     case 'updateJobStatus':
+      return action.payload.jobId
+    case 'updateDubbingJobOriginalYouTubeUrl':
       return action.payload.jobId
     case 'updateJobLanguageYouTube':
       return action.payload.jobId

--- a/src/lib/youtube/upload-snapshot.ts
+++ b/src/lib/youtube/upload-snapshot.ts
@@ -1,0 +1,198 @@
+import type { DeliverableMode, PrivacyStatus, VideoSourceType } from '@/features/dubbing/types/dubbing.types'
+import type { YouTubeLocalization } from '@/lib/youtube/types'
+
+export type YouTubeUploadKind =
+  | 'new_video_dubbed_video'
+  | 'new_video_original_captions'
+  | 'my_video_dubbed_video'
+  | 'my_video_original_captions'
+
+export type YouTubeUploadSourceKind = 'new_video' | 'my_youtube_video'
+export type YouTubeUploadTargetAssetKind = 'dubbed_video' | 'original_video'
+
+export interface YouTubeUploadSnapshot {
+  version: 1
+  uploadKind: YouTubeUploadKind
+  sourceKind: YouTubeUploadSourceKind
+  targetAssetKind: YouTubeUploadTargetAssetKind
+  sourceLanguage: string
+  targetLanguage: string
+  selectedLanguages: string[]
+  settings: {
+    title: string
+    description: string
+    tags: string[]
+    privacyStatus: PrivacyStatus
+    uploadCaptions: boolean
+    selfDeclaredMadeForKids: boolean
+    containsSyntheticMedia: boolean
+    attachOriginalLink: boolean
+  }
+  metadata: {
+    source: {
+      title: string
+      description: string
+      finalDescription: string
+    }
+    translated: Record<string, {
+      title: string
+      description: string
+      finalDescription: string
+      containsSyntheticMedia: boolean
+    }>
+    localizations: Record<string, YouTubeLocalization>
+  }
+  assets: {
+    originalVideoUrl: string | null
+    originalYouTubeVideoId: string | null
+    originalYouTubeUrl: string | null
+    dubbedVideoUrl: string | null
+    audioUrl: string | null
+    srtUrl: string | null
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function asString(value: unknown, fallback = '') {
+  return typeof value === 'string' ? value : fallback
+}
+
+function asNullableString(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function asBoolean(value: unknown, fallback: boolean) {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+    : []
+}
+
+function asPrivacy(value: unknown): PrivacyStatus {
+  return value === 'public' || value === 'unlisted' || value === 'private' ? value : 'private'
+}
+
+function asUploadKind(value: unknown): YouTubeUploadKind {
+  return value === 'new_video_original_captions' ||
+    value === 'my_video_dubbed_video' ||
+    value === 'my_video_original_captions'
+    ? value
+    : 'new_video_dubbed_video'
+}
+
+function asSourceKind(value: unknown): YouTubeUploadSourceKind {
+  return value === 'my_youtube_video' ? 'my_youtube_video' : 'new_video'
+}
+
+function asTargetAssetKind(value: unknown): YouTubeUploadTargetAssetKind {
+  return value === 'original_video' ? 'original_video' : 'dubbed_video'
+}
+
+function normalizeLocalizationMap(value: unknown): Record<string, YouTubeLocalization> {
+  const root = asObject(value)
+  const entries = Object.entries(root)
+    .map(([code, localization]) => {
+      const item = asObject(localization)
+      const title = asString(item.title).trim()
+      if (!title) return null
+      return [code, { title, description: asString(item.description) }] as const
+    })
+    .filter((entry): entry is readonly [string, YouTubeLocalization] => entry !== null)
+  return Object.fromEntries(entries)
+}
+
+function normalizeTranslatedMap(value: unknown): YouTubeUploadSnapshot['metadata']['translated'] {
+  const root = asObject(value)
+  const entries = Object.entries(root)
+    .map(([code, metadata]) => {
+      const item = asObject(metadata)
+      const title = asString(item.title).trim()
+      if (!title) return null
+      return [code, {
+        title,
+        description: asString(item.description),
+        finalDescription: asString(item.finalDescription, asString(item.description)),
+        containsSyntheticMedia: asBoolean(item.containsSyntheticMedia, false),
+      }] as const
+    })
+    .filter((entry): entry is readonly [string, YouTubeUploadSnapshot['metadata']['translated'][string]] => entry !== null)
+  return Object.fromEntries(entries)
+}
+
+export function resolveYouTubeUploadKind(
+  sourceType: VideoSourceType | undefined,
+  deliverableMode: DeliverableMode,
+): YouTubeUploadKind {
+  const sourcePrefix = sourceType === 'channel' ? 'my_video' : 'new_video'
+  const suffix = deliverableMode === 'originalWithMultiAudio' ? 'original_captions' : 'dubbed_video'
+  return `${sourcePrefix}_${suffix}` as YouTubeUploadKind
+}
+
+export function parseYouTubeUploadSnapshot(json: string | null | undefined): YouTubeUploadSnapshot | null {
+  if (!json) return null
+  try {
+    const root = asObject(JSON.parse(json))
+    const settings = asObject(root.settings)
+    const metadata = asObject(root.metadata)
+    const source = asObject(metadata.source)
+    const assets = asObject(root.assets)
+    return {
+      version: 1,
+      uploadKind: asUploadKind(root.uploadKind),
+      sourceKind: asSourceKind(root.sourceKind),
+      targetAssetKind: asTargetAssetKind(root.targetAssetKind),
+      sourceLanguage: asString(root.sourceLanguage, 'ko'),
+      targetLanguage: asString(root.targetLanguage),
+      selectedLanguages: asStringArray(root.selectedLanguages),
+      settings: {
+        title: asString(settings.title),
+        description: asString(settings.description),
+        tags: asStringArray(settings.tags),
+        privacyStatus: asPrivacy(settings.privacyStatus),
+        uploadCaptions: asBoolean(settings.uploadCaptions, true),
+        selfDeclaredMadeForKids: asBoolean(settings.selfDeclaredMadeForKids, false),
+        containsSyntheticMedia: asBoolean(settings.containsSyntheticMedia, false),
+        attachOriginalLink: asBoolean(settings.attachOriginalLink, true),
+      },
+      metadata: {
+        source: {
+          title: asString(source.title),
+          description: asString(source.description),
+          finalDescription: asString(source.finalDescription, asString(source.description)),
+        },
+        translated: normalizeTranslatedMap(metadata.translated),
+        localizations: normalizeLocalizationMap(metadata.localizations),
+      },
+      assets: {
+        originalVideoUrl: asNullableString(assets.originalVideoUrl),
+        originalYouTubeVideoId: asNullableString(assets.originalYouTubeVideoId),
+        originalYouTubeUrl: asNullableString(assets.originalYouTubeUrl),
+        dubbedVideoUrl: asNullableString(assets.dubbedVideoUrl),
+        audioUrl: asNullableString(assets.audioUrl),
+        srtUrl: asNullableString(assets.srtUrl),
+      },
+    }
+  } catch {
+    return null
+  }
+}
+
+export function serializeYouTubeUploadSnapshot(snapshot: YouTubeUploadSnapshot): string {
+  return JSON.stringify(snapshot)
+}
+
+export function snapshotMetadataJson(snapshot: YouTubeUploadSnapshot): string {
+  return JSON.stringify(snapshot.metadata)
+}
+
+export function snapshotLocalizationsJson(snapshot: YouTubeUploadSnapshot): string {
+  return JSON.stringify(snapshot.metadata.localizations)
+}


### PR DESCRIPTION
﻿## 요약
- 더빙 작업 생성 시 YouTube 업로드 설정과 번역 메타데이터를 스냅샷 JSON으로 저장
- 완료된 작업 페이지에서 더빙 영상 업로드와 원본 영상 자막 업로드의 대상 영상을 구분
- 업로드 큐와 YouTube 업로드 이력에 업로드 종류, 메타데이터, localizations JSON 저장 경로 추가

## 변경 내용
- `job_languages`, `upload_queue`, `youtube_uploads`에 업로드 스냅샷/메타데이터 저장 컬럼 추가
- 제목, 설명, 태그, 공개범위, 아동용 여부, AI 음성 고지 여부, 번역 메타데이터를 완료 후 업로드 시 재사용
- 완료된 작업 페이지 업로드 모달에서 제목/설명/태그/AI 음성 여부는 읽기 전용 처리하고 SRT, 공개범위, 아동용 여부만 변경 가능
- 원본 영상 자막 업로드 흐름은 원본 YouTube 영상 또는 업로드된 원본 영상을 사용하고, 더빙 영상 업로드 흐름은 더빙 결과 영상을 사용

## 검증
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
