### PR TITLE
fix: 완료 작업 최신순 정리

### DIFF
--- a/src/app/[locale]/(app)/uploads/page.tsx
+++ b/src/app/[locale]/(app)/uploads/page.tsx
@@ -32,6 +32,13 @@ import {
 
 type UploadState = 'idle' | 'fetching' | 'uploading' | 'done' | 'error'
 type PrivacyStatus = 'public' | 'unlisted' | 'private'
+type CompletedJobGroup = {
+  id: number
+  title: string
+  durationMs: number
+  createdAt: string
+  langs: CompletedJobLanguage[]
+}
 
 interface UploadSettings {
   title: string
@@ -556,18 +563,21 @@ export default function UploadsPage() {
     staleTime: 60_000,
   })
 
-  const jobs = items.reduce<Record<number, { title: string; durationMs: number; createdAt: string; langs: CompletedJobLanguage[] }>>((acc, item) => {
-    if (!acc[item.job_id]) {
-      acc[item.job_id] = {
+  const jobs = Array.from(items.reduce<Map<number, CompletedJobGroup>>((acc, item) => {
+    const existing = acc.get(item.job_id)
+    if (!existing) {
+      acc.set(item.job_id, {
+        id: item.job_id,
         title: item.video_title,
         durationMs: item.video_duration_ms,
         createdAt: item.created_at,
-        langs: [],
-      }
+        langs: [item],
+      })
+      return acc
     }
-    acc[item.job_id].langs.push(item)
+    existing.langs.push(item)
     return acc
-  }, {})
+  }, new Map()).values())
 
   return (
     <div className="space-y-6">
@@ -589,8 +599,8 @@ export default function UploadsPage() {
         />
       ) : (
         <div className="space-y-4">
-          {Object.entries(jobs).map(([jobId, job]) => (
-            <Card key={jobId}>
+          {jobs.map((job) => (
+            <Card key={job.id}>
               <div className="mb-3 flex items-center justify-between">
                 <div>
                   <CardTitle className="text-base">{job.title}</CardTitle>


### PR DESCRIPTION
﻿## 요약
- 완료된 작업/YouTube 업로드 목록에서 최신 작업이 위에 보이도록 정렬 유지 방식을 수정
- API가 내려주는 최신순 결과가 숫자 job id 객체 key 정렬 때문에 뒤집히지 않도록 `Map` 기반 그룹으로 변경

## DB 정리
- 현재 실행 DB에서 영상 작업 산출물만 1회성 초기화 완료
- 유지: 사용자, 세션, 결제, 크레딧 잔액/거래, 설정
- 정리: dubbing_jobs, job_languages, upload_queue, youtube_uploads, perso_media_resources, analytics_cache, develop_test 전용 STT 산출물 테이블

## 검증
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
