### PR TITLE
rebrand: 내부 식별자 sub2tube로 통일 (cookie/storage/domain)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -32,7 +32,7 @@
   "externally_connectable": {
     "matches": [
       "http://localhost/*",
-      "https://*.dubtube.com/*"
+      "https://*.sub2tube.com/*"
     ]
   }
 }

--- a/extension/src/background-types.ts
+++ b/extension/src/background-types.ts
@@ -11,4 +11,4 @@ export interface Job {
   createdAt: number
 }
 
-export const STORAGE_KEY = 'dubtube_jobs'
+export const STORAGE_KEY = 'sub2tube_jobs'

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -95,7 +95,7 @@ function waitForTabLoad(tabId: number, callback: () => void): void {
 
 const WEBAPP_URL_PATTERNS = [
   'http://localhost/*',
-  'https://*.dubtube.com/*',
+  'https://*.sub2tube.com/*',
 ]
 
 async function relayToWebApp(event: OutboundEvent): Promise<void> {

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -1,6 +1,6 @@
 import type { UploadMode } from './messages'
 
-const SETTINGS_KEY = 'dubtube_settings'
+const SETTINGS_KEY = 'sub2tube_settings'
 
 export interface Settings {
   uploadMode: UploadMode

--- a/src/app/[locale]/(app)/dashboard/page.tsx
+++ b/src/app/[locale]/(app)/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { verifySessionCookie } from '@/lib/auth/session-cookie'
 
 export default async function DashboardPage() {
   const cookieStore = await cookies()
-  const raw = cookieStore.get('dubtube_session')?.value
+  const raw = cookieStore.get('sub2tube_session')?.value
   const uid = raw ? await verifySessionCookie(raw) : null
 
   if (!uid) {

--- a/src/app/[locale]/(marketing)/privacy/page.tsx
+++ b/src/app/[locale]/(marketing)/privacy/page.tsx
@@ -133,11 +133,11 @@ export default async function PrivacyPolicyPage({ params }: LocaleMetadataProps)
       <Section title={t('legal.privacy.section.8.title')}>
         <p>
           {t('legal.privacy.section.8.beforeSession')}
-          <code>dubtube_session</code>
+          <code>sub2tube_session</code>
           {t('legal.privacy.section.8.session')}
-          <code>dubtube-theme</code>
+          <code>sub2tube-theme</code>
           {t('legal.privacy.section.8.theme')}
-          <code>dubtube-youtube-settings</code>
+          <code>sub2tube-youtube-settings</code>
           {t('legal.privacy.section.8.settings')}
         </p>
       </Section>

--- a/src/app/api/auth/auth-callback.test.ts
+++ b/src/app/api/auth/auth-callback.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/db/queries', () => ({
 }))
 
 vi.mock('@/lib/auth/session-cookie', () => ({
-  SESSION_COOKIE: 'dubtube_session',
+  SESSION_COOKIE: 'sub2tube_session',
   SESSION_TTL_SECONDS: 604800,
   createSessionCookie: vi.fn((uid: string) => ({
     cookie: `${uid}.fakesig`,
@@ -227,7 +227,7 @@ describe('POST /api/auth/callback', () => {
     expect(tokenRequestBody.get('redirect_uri')).toBe(CALLBACK_REDIRECT_URI)
 
     const setCookies = res.headers.getSetCookie()
-    expect(setCookies.find((c: string) => c.startsWith('dubtube_session='))).toBeDefined()
+    expect(setCookies.find((c: string) => c.startsWith('sub2tube_session='))).toBeDefined()
     expect(setCookies.find((c: string) => c.startsWith('google_access_token='))).toBeUndefined()
   })
 

--- a/src/app/api/auth/auth-signout.test.ts
+++ b/src/app/api/auth/auth-signout.test.ts
@@ -32,11 +32,11 @@ describe('POST /api/auth/signout', () => {
     expect(body).toEqual({ ok: true, data: null })
   })
 
-  it('clears dubtube_session cookie', async () => {
+  it('clears sub2tube_session cookie', async () => {
     const res = await POST(req())
     const setCookies = res.headers.getSetCookie()
     const sessionCookie = setCookies.find((c: string) =>
-      c.startsWith('dubtube_session='),
+      c.startsWith('sub2tube_session='),
     )
     expect(sessionCookie).toBeDefined()
     expect(sessionCookie).toContain('Max-Age=0')
@@ -70,7 +70,7 @@ describe('POST /api/auth/signout', () => {
       exp: 9999999999,
       legacy: false,
     })
-    const res = await POST(req('dubtube_session=signed'))
+    const res = await POST(req('sub2tube_session=signed'))
     expect(res.status).toBe(200)
     expect(revokeUserSession).toHaveBeenCalledWith('sid-1')
   })

--- a/src/app/api/auth/auth-sync.test.ts
+++ b/src/app/api/auth/auth-sync.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/db/queries', () => ({
 }))
 
 vi.mock('@/lib/auth/session-cookie', () => ({
-  SESSION_COOKIE: 'dubtube_session',
+  SESSION_COOKIE: 'sub2tube_session',
   verifySessionCookie: vi.fn(),
 }))
 
@@ -67,7 +67,7 @@ describe('POST /api/auth/sync', () => {
   it('returns 401 for an invalid session cookie', async () => {
     vi.mocked(verifySessionCookie).mockResolvedValueOnce(null)
 
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'dubtube_session=signed'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'sub2tube_session=signed'))
     expect(res.status).toBe(401)
     expect(getUser).not.toHaveBeenCalled()
   })
@@ -75,7 +75,7 @@ describe('POST /api/auth/sync', () => {
   it('returns 401 when session uid does not match the request user', async () => {
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('other-user')
 
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'dubtube_session=signed'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'sub2tube_session=signed'))
     expect(res.status).toBe(401)
     expect(getUser).not.toHaveBeenCalled()
   })
@@ -84,7 +84,7 @@ describe('POST /api/auth/sync', () => {
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('u1')
     vi.mocked(getUser).mockResolvedValueOnce(null as never)
 
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'dubtube_session=signed'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'sub2tube_session=signed'))
     expect(res.status).toBe(401)
   })
 
@@ -92,7 +92,7 @@ describe('POST /api/auth/sync', () => {
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('u1')
     vi.mocked(getUser).mockResolvedValueOnce({ id: 'u1', email: 'a@b.com' } as never)
 
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'dubtube_session=signed'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'sub2tube_session=signed'))
     expect(res.status).toBe(200)
     const data = await res.json()
     expect(data.ok).toBe(true)
@@ -104,7 +104,7 @@ describe('POST /api/auth/sync', () => {
     vi.mocked(getUser).mockResolvedValueOnce({ id: 'u1', email: 'a@b.com' } as never)
 
     const res = await POST(
-      makeReq({ uid: 'u1', email: 'a@b.com', accessToken: 'client-token' }, 'dubtube_session=signed'),
+      makeReq({ uid: 'u1', email: 'a@b.com', accessToken: 'client-token' }, 'sub2tube_session=signed'),
     )
     expect(res.status).toBe(200)
     expect(getUser).toHaveBeenCalledWith('u1')
@@ -114,7 +114,7 @@ describe('POST /api/auth/sync', () => {
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('u1')
     vi.mocked(getUser).mockRejectedValueOnce(new Error('DB down'))
 
-    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'dubtube_session=signed'))
+    const res = await POST(makeReq({ uid: 'u1', email: 'a@b.com' }, 'sub2tube_session=signed'))
     expect(res.status).toBe(500)
     const data = await res.json()
     expect(data.ok).toBe(false)

--- a/src/app/api/user/account/account-route.test.ts
+++ b/src/app/api/user/account/account-route.test.ts
@@ -48,13 +48,13 @@ describe('DELETE /api/user/account', () => {
       session: { uid: 'user-1', email: 'user@example.com' },
     })
 
-    const res = await DELETE(req('dubtube_session=signed'))
+    const res = await DELETE(req('sub2tube_session=signed'))
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toEqual({ ok: true, data: null })
     expect(mockRequestUserAccountDeletion).toHaveBeenCalledWith('user-1')
 
     const setCookies = res.headers.getSetCookie()
-    expect(setCookies.some((cookie) => cookie.startsWith('dubtube_session=') && cookie.includes('Max-Age=0'))).toBe(true)
+    expect(setCookies.some((cookie) => cookie.startsWith('sub2tube_session=') && cookie.includes('Max-Age=0'))).toBe(true)
     expect(setCookies.some((cookie) => cookie.startsWith('google_access_token=') && cookie.includes('Max-Age=0'))).toBe(true)
   })
 
@@ -65,7 +65,7 @@ describe('DELETE /api/user/account', () => {
     })
     mockRequestUserAccountDeletion.mockRejectedValueOnce(new Error('DB failed'))
 
-    const res = await DELETE(req('dubtube_session=signed'))
+    const res = await DELETE(req('sub2tube_session=signed'))
     expect(res.status).toBe(500)
     const body = await res.json()
     expect(body.ok).toBe(false)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,7 +58,7 @@ export const metadata: Metadata = {
   },
 };
 
-const themeInitScript = `try{var raw=localStorage.getItem('dubtube-theme');var state=null;var preference=null;var mode=null;if(raw){try{var parsed=JSON.parse(raw);state=parsed&&parsed.state||parsed;preference=state&&state.preference;mode=state&&state.mode||state}catch(_){mode=raw}}if(!preference&&(mode==='dark'||mode==='light'))preference=mode;var systemDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;if(preference==='dark'||((!preference||preference==='system')&&systemDark)){document.documentElement.classList.add('dark')}}catch(e){}`;
+const themeInitScript = `try{var raw=localStorage.getItem('sub2tube-theme');var state=null;var preference=null;var mode=null;if(raw){try{var parsed=JSON.parse(raw);state=parsed&&parsed.state||parsed;preference=state&&state.preference;mode=state&&state.mode||state}catch(_){mode=raw}}if(!preference&&(mode==='dark'||mode==='light'))preference=mode;var systemDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;if(preference==='dark'||((!preference||preference==='system')&&systemDark)){document.documentElement.classList.add('dark')}}catch(e){}`;
 
 export default async function RootLayout({
   children,
@@ -73,7 +73,7 @@ export default async function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         <Script
-          id="dubtube-theme-init"
+          id="sub2tube-theme-init"
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{ __html: themeInitScript }}
         />

--- a/src/lib/auth/session-cookie.test.ts
+++ b/src/lib/auth/session-cookie.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('session-cookie', () => {
   it('exports SESSION_COOKIE constant', () => {
-    expect(SESSION_COOKIE).toBe('dubtube_session')
+    expect(SESSION_COOKIE).toBe('sub2tube_session')
   })
 
   describe('signSessionCookie', () => {
@@ -78,7 +78,7 @@ describe('session-cookie', () => {
 
     it('accepts legacy uid.signature cookies used by existing Playwright helpers', async () => {
       const uid = 'legacy-user'
-      const secret = process.env.SESSION_SECRET || 'dubtube-dev-secret-do-not-use-in-prod'
+      const secret = process.env.SESSION_SECRET || 'sub2tube-dev-secret-do-not-use-in-prod'
       const sig = createHmac('sha256', secret)
         .update(uid)
         .digest('hex')

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,4 +1,4 @@
-const SESSION_COOKIE = 'dubtube_session'
+const SESSION_COOKIE = 'sub2tube_session'
 const SEPARATOR = '.'
 const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7
 const enc = new TextEncoder()
@@ -21,7 +21,7 @@ function getSecret(): string {
   if (process.env.NODE_ENV === 'production') {
     throw new Error('SESSION_SECRET env var is required in production')
   }
-  return 'dubtube-dev-secret-do-not-use-in-prod'
+  return 'sub2tube-dev-secret-do-not-use-in-prod'
 }
 
 async function importKey(secret: string): Promise<CryptoKey> {

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -42,7 +42,7 @@ describe('requireSession', () => {
   it('returns 401 when the app session cookie is invalid', async () => {
     vi.mocked(verifySessionCookiePayload).mockResolvedValueOnce(null)
 
-    const result = await requireSession(makeReq('dubtube_session=bad'))
+    const result = await requireSession(makeReq('sub2tube_session=bad'))
     expect(result.ok).toBe(false)
     if (!result.ok) {
       const body = await result.response.json()
@@ -59,7 +59,7 @@ describe('requireSession', () => {
     })
     vi.mocked(isUserSessionActive).mockResolvedValueOnce(false)
 
-    const result = await requireSession(makeReq('dubtube_session=signed'))
+    const result = await requireSession(makeReq('sub2tube_session=signed'))
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.response.status).toBe(401)
@@ -77,7 +77,7 @@ describe('requireSession', () => {
     vi.mocked(getOrRefreshAccessToken).mockResolvedValueOnce('google-token')
     vi.mocked(getUser).mockResolvedValueOnce({ email: 'test@example.com' } as never)
 
-    const result = await requireSession(makeReq('dubtube_session=signed'))
+    const result = await requireSession(makeReq('sub2tube_session=signed'))
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.session).toEqual({ uid: 'user-1', email: 'test@example.com' })
@@ -95,7 +95,7 @@ describe('requireSession', () => {
     vi.mocked(getOrRefreshAccessToken).mockResolvedValueOnce(null)
     vi.mocked(getUser).mockResolvedValueOnce({ email: 'no-token@example.com' } as never)
 
-    const result = await requireSession(makeReq('dubtube_session=signed'))
+    const result = await requireSession(makeReq('sub2tube_session=signed'))
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.session).toEqual({ uid: 'user-2', email: 'no-token@example.com' })

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -18,7 +18,7 @@ export async function requireSession(
   | { ok: true; session: Session }
   | { ok: false; response: Response }
 > {
-  const sessionCookie = req.cookies.get('dubtube_session')?.value
+  const sessionCookie = req.cookies.get('sub2tube_session')?.value
   if (sessionCookie) {
     const verified = await verifySessionCookiePayload(sessionCookie)
     if (verified) {

--- a/src/lib/auth/token-crypto.ts
+++ b/src/lib/auth/token-crypto.ts
@@ -9,7 +9,7 @@ function getEncryptionSecret() {
   if (process.env.NODE_ENV === 'production') {
     throw new Error('TOKEN_ENCRYPTION_KEY is required in production')
   }
-  return process.env.SESSION_SECRET || 'dubtube-dev-token-secret-do-not-use-in-prod'
+  return process.env.SESSION_SECRET || 'sub2tube-dev-token-secret-do-not-use-in-prod'
 }
 
 function toBase64Url(bytes: Uint8Array) {

--- a/src/lib/db/queries/users-account-deletion.test.ts
+++ b/src/lib/db/queries/users-account-deletion.test.ts
@@ -62,7 +62,7 @@ describe('user account deletion recovery queries', () => {
     expect(sql).not.toContain('DELETE FROM users')
     expect(sql).not.toContain('DELETE FROM dubbing_jobs')
     expect(mocks.tx.execute.mock.calls[0][0].args[0]).toBe('pending_deletion')
-    expect(mocks.tx.execute.mock.calls[0][0].args[3]).toMatch(/^withdrawal-requested\+[a-f0-9]{32}@withdrawal\.dubtube\.local$/)
+    expect(mocks.tx.execute.mock.calls[0][0].args[3]).toMatch(/^withdrawal-requested\+[a-f0-9]{32}@withdrawal\.sub2tube\.local$/)
     expect(mocks.tx.commit).toHaveBeenCalled()
   })
 

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -8,7 +8,7 @@ import { decryptToken, encryptToken } from '@/lib/auth/token-crypto'
 const ACCOUNT_STATUS_ACTIVE = 'active'
 const ACCOUNT_STATUS_PENDING_DELETION = 'pending_deletion'
 const ACCOUNT_DELETION_DISPLAY_NAME = '회원탈퇴 요청'
-const ACCOUNT_DELETION_EMAIL_DOMAIN = 'withdrawal.dubtube.local'
+const ACCOUNT_DELETION_EMAIL_DOMAIN = 'withdrawal.sub2tube.local'
 const ACCOUNT_DELETION_RECOVERY_DAYS = 7
 const ACCOUNT_RETENTION_REASON = 'settlement_and_legal_retention'
 const ACCOUNT_RETENTION_YEARS = 5

--- a/src/lib/i18n/config.test.ts
+++ b/src/lib/i18n/config.test.ts
@@ -45,8 +45,8 @@ describe('i18n config', () => {
   })
 
   it('reads the app locale cookie from a cookie header string', () => {
-    expect(getLocaleFromCookieString('x=1; dubtube_locale=en; y=2')).toBe('en')
-    expect(getLocaleFromCookieString('dubtube_locale=ja')).toBeNull()
+    expect(getLocaleFromCookieString('x=1; sub2tube_locale=en; y=2')).toBe('en')
+    expect(getLocaleFromCookieString('sub2tube_locale=ja')).toBeNull()
     expect(getLocaleFromCookieString(null)).toBeNull()
   })
 

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -4,8 +4,8 @@ export type AppLocale = (typeof APP_LOCALES)[number]
 
 export const DEFAULT_APP_LOCALE: AppLocale = 'ko'
 export const FALLBACK_APP_LOCALE: AppLocale = 'en'
-export const LOCALE_COOKIE = 'dubtube_locale'
-export const LOCALE_HEADER = 'x-dubtube-locale'
+export const LOCALE_COOKIE = 'sub2tube_locale'
+export const LOCALE_HEADER = 'x-sub2tube-locale'
 export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
 export const APP_LOCALE_LABELS: Record<AppLocale, { label: string; nativeLabel: string }> = {

--- a/src/lib/youtube/route-helpers.test.ts
+++ b/src/lib/youtube/route-helpers.test.ts
@@ -195,7 +195,7 @@ describe('requireAccessToken', () => {
   it('returns token from verified app session and encrypted DB token', async () => {
     vi.mocked(cookies).mockResolvedValueOnce({
       get: vi.fn((name: string) =>
-        name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+        name === 'sub2tube_session' ? { name, value: 'session-cookie' } : undefined,
       ),
     } as never)
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('user-1')
@@ -210,7 +210,7 @@ describe('requireAccessToken', () => {
   it('passes force refresh through to the token loader', async () => {
     vi.mocked(cookies).mockResolvedValueOnce({
       get: vi.fn((name: string) =>
-        name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+        name === 'sub2tube_session' ? { name, value: 'session-cookie' } : undefined,
       ),
     } as never)
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('user-1')
@@ -261,12 +261,12 @@ describe('withTokenRetry', () => {
     vi.mocked(cookies)
       .mockResolvedValueOnce({
         get: vi.fn((name: string) =>
-          name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+          name === 'sub2tube_session' ? { name, value: 'session-cookie' } : undefined,
         ),
       } as never)
       .mockResolvedValueOnce({
         get: vi.fn((name: string) =>
-          name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+          name === 'sub2tube_session' ? { name, value: 'session-cookie' } : undefined,
         ),
       } as never)
     vi.mocked(verifySessionCookie).mockResolvedValue('user-1')
@@ -294,7 +294,7 @@ describe('withTokenRetry', () => {
   it('does not retry quota errors as auth problems', async () => {
     vi.mocked(cookies).mockResolvedValueOnce({
       get: vi.fn((name: string) =>
-        name === 'dubtube_session' ? { name, value: 'session-cookie' } : undefined,
+        name === 'sub2tube_session' ? { name, value: 'session-cookie' } : undefined,
       ),
     } as never)
     vi.mocked(verifySessionCookie).mockResolvedValueOnce('user-1')

--- a/src/lib/youtube/route-helpers.ts
+++ b/src/lib/youtube/route-helpers.ts
@@ -139,7 +139,7 @@ export async function requireAccessToken(
   opts: { forceRefresh?: boolean } = {},
 ): Promise<string> {
   const cookieStore = await cookies()
-  const sessionCookie = cookieStore.get('dubtube_session')?.value
+  const sessionCookie = cookieStore.get('sub2tube_session')?.value
 
   if (sessionCookie) {
     const uid = await verifySessionCookie(sessionCookie)

--- a/src/stores/i18nStore.ts
+++ b/src/stores/i18nStore.ts
@@ -34,7 +34,7 @@ export const useI18nStore = create<I18nState>()(
       }),
     }),
     {
-      name: 'dubtube-i18n',
+      name: 'sub2tube-i18n',
       partialize: (state) => ({
         appLocale: state.appLocale,
         metadataTargetPreset: state.metadataTargetPreset,

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -86,7 +86,7 @@ describe('themeStore', () => {
 
   it('onRehydrateStorage applies explicit dark class for legacy dark mode', async () => {
     document.documentElement.classList.remove('dark')
-    localStorage.setItem('dubtube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
+    localStorage.setItem('sub2tube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
     await useThemeStore.persist.rehydrate()
     expect(useThemeStore.getState().preference).toBe('dark')
     expect(document.documentElement.classList.contains('dark')).toBe(true)
@@ -95,7 +95,7 @@ describe('themeStore', () => {
   it('onRehydrateStorage resolves system preference from matchMedia', async () => {
     mockSystemTheme(true)
     document.documentElement.classList.remove('dark')
-    localStorage.setItem('dubtube-theme', JSON.stringify({ state: { preference: 'system', mode: 'light' }, version: 1 }))
+    localStorage.setItem('sub2tube-theme', JSON.stringify({ state: { preference: 'system', mode: 'light' }, version: 1 }))
     await useThemeStore.persist.rehydrate()
     expect(useThemeStore.getState().preference).toBe('system')
     expect(useThemeStore.getState().mode).toBe('dark')

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -68,7 +68,7 @@ export const useThemeStore = create<ThemeState>()(
       },
     }),
     {
-      name: 'dubtube-theme',
+      name: 'sub2tube-theme',
       version: 1,
       skipHydration: true,
       migrate: (persistedState) => {

--- a/tests/console-errors.spec.ts
+++ b/tests/console-errors.spec.ts
@@ -17,7 +17,7 @@ const ROUTES = [
 
 async function injectMockAuth(page: Page) {
   await page.context().addCookies([
-    { name: 'dubtube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'sub2tube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
   ])
   await page.addInitScript(() => {
     try {
@@ -38,7 +38,7 @@ async function injectMockAuth(page: Page) {
 
 async function setKoreanLocale(page: Page) {
   await page.context().addCookies([
-    { name: 'dubtube_locale', value: 'ko', domain: 'localhost', path: '/' },
+    { name: 'sub2tube_locale', value: 'ko', domain: 'localhost', path: '/' },
   ])
 }
 

--- a/tests/dark-mode-fouc.spec.ts
+++ b/tests/dark-mode-fouc.spec.ts
@@ -13,7 +13,7 @@ import { signTestSessionCookie } from './helpers/signed-cookie'
 
 test('dark mode has no FOUC on landing', async ({ page }) => {
   await page.addInitScript(() => {
-    localStorage.setItem('dubtube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
+    localStorage.setItem('sub2tube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
   })
 
   await page.goto('http://localhost:3000/', { waitUntil: 'domcontentloaded' })
@@ -27,10 +27,10 @@ test('dark mode has no FOUC on landing', async ({ page }) => {
 
 test('dark mode has no FOUC on dashboard', async ({ page }) => {
   await page.context().addCookies([
-    { name: 'dubtube_session', value: signTestSessionCookie('x'), domain: 'localhost', path: '/' },
+    { name: 'sub2tube_session', value: signTestSessionCookie('x'), domain: 'localhost', path: '/' },
   ])
   await page.addInitScript(() => {
-    localStorage.setItem('dubtube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
+    localStorage.setItem('sub2tube-theme', JSON.stringify({ state: { mode: 'dark' }, version: 0 }))
     localStorage.setItem(
       'google_user',
       JSON.stringify({ uid: 'x', email: 'x@x.x', displayName: 'X', photoURL: null })

--- a/tests/e2e-dubbing.spec.ts
+++ b/tests/e2e-dubbing.spec.ts
@@ -79,8 +79,8 @@ test('dubbing page renders and captures network sequence', async ({ page }) => {
   const consoleErrors: string[] = []
 
   await page.context().addCookies([
-    { name: 'dubtube_locale', value: 'ko', domain: 'localhost', path: '/' },
-    { name: 'dubtube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'sub2tube_locale', value: 'ko', domain: 'localhost', path: '/' },
+    { name: 'sub2tube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
   ])
   await page.addInitScript(() => {
     localStorage.setItem(

--- a/tests/helpers/signed-cookie.ts
+++ b/tests/helpers/signed-cookie.ts
@@ -2,7 +2,7 @@ import { createHmac } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const DEV_SECRET = 'dubtube-dev-secret-do-not-use-in-prod'
+const DEV_SECRET = 'sub2tube-dev-secret-do-not-use-in-prod'
 
 function readEnvLocalSessionSecret(): string | null {
   const envPath = resolve(process.cwd(), '.env.local')

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from '@playwright/test'
 test.describe('smoke', () => {
   test('next landing responds', async ({ page }) => {
     await page.context().addCookies([
-      { name: 'dubtube_locale', value: 'ko', domain: 'localhost', path: '/' },
+      { name: 'sub2tube_locale', value: 'ko', domain: 'localhost', path: '/' },
     ])
     const res = await page.goto('http://localhost:3000/', { waitUntil: 'domcontentloaded' })
     expect(res?.status()).toBeLessThan(400)

--- a/tests/visual-regression.spec.ts
+++ b/tests/visual-regression.spec.ts
@@ -24,7 +24,7 @@ const PAGES: Array<{ route: string; name: string; needsAuth: boolean }> = [
 ]
 
 // Port 5173 is occupied by another project (VoiceAlarm) on this dev machine.
-// Dubtube's Vite dev server moved to 5174.
+// sub2tube's Vite dev server moved to 5174.
 const VITE_BASE = process.env.VITE_BASE_URL ?? 'http://localhost:5174'
 const NEXT_BASE = process.env.NEXT_BASE_URL ?? 'http://localhost:3000'
 
@@ -33,7 +33,7 @@ fs.mkdirSync(SNAPSHOT_DIR, { recursive: true })
 
 async function injectMockAuth(page: Page) {
   await page.context().addCookies([
-    { name: 'dubtube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
+    { name: 'sub2tube_session', value: signTestSessionCookie('test'), domain: 'localhost', path: '/' },
   ])
   await page.addInitScript(() => {
     try {


### PR DESCRIPTION
Closes #350

## Summary
- 사용자 노출 텍스트(#349)와 별도로, 내부 식별자만 한꺼번에 sub2tube로 변경
- 영역별로 7개 작은 커밋으로 분리 (auth / i18n locale / stores / db anonymization / extension / privacy 표기 / e2e fixture)

## 변경 항목
- `dubtube_session` → `sub2tube_session` (세션 쿠키)
- `dubtube_locale` / `x-dubtube-locale` → `sub2tube_*`
- `dubtube-theme` / `dubtube-i18n` / `dubtube-youtube-settings` localStorage 키
- `dubtube_jobs` / `dubtube_settings` (chrome.storage)
- `withdrawal.dubtube.local` → `withdrawal.sub2tube.local` (탈퇴 이메일 anonymization)
- `dubtube-dev-secret-...` / `dubtube-dev-token-secret-...` (개발용 fallback)
- `*.dubtube.com` → `*.sub2tube.com` (Chrome 확장 externally_connectable)
- 개인정보처리방침의 `<code>` 코드블록 표기

## ⚠️ 배포 시 영향
- **모든 활성 사용자가 강제 로그아웃** → 다음 접속 시 Google 재로그인 필요
- **저장된 테마/언어/YouTube 설정 초기화** → localStorage 키 변경
- **확장 사용자의 진행 중인 업로드 큐 1회 초기화**
- 기존 탈퇴 row의 이메일 도메인은 그대로 유지 (정산·법적 보존 기록 보호)

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm run test` — 51 files / 583 tests 모두 통과
- [ ] 머지 후 develop 배포에서 실제 로그인 흐름 (Google → callback → 쿠키 부여) 1회 검증
- [ ] 다크모드 깜빡임 없는지 확인 (테마 직주입 스크립트 정상 동작)
- [ ] 운영팀에 사용자 강제 로그아웃 일정 공유

🤖 Generated with [Claude Code](https://claude.com/claude-code)